### PR TITLE
Fixed issue with missing reload call for didReceiveEntity for heaters…

### DIFF
--- a/IntelliNest/Navigation/NavigatorExtension.swift
+++ b/IntelliNest/Navigation/NavigatorExtension.swift
@@ -18,6 +18,10 @@ extension Navigator: WebSocketServiceDelegate {
             homeViewModel.reload(entityID: entityID, state: state, lastChanged: lastChanged)
         }
 
+        if heatersViewModel.entityIDs.contains(entityID) {
+            heatersViewModel.reload(entityID: entityID, state: state)
+        }
+
         if roborockViewModel.entityIDs.contains(entityID) {
             roborockViewModel.reload(entityID: entityID, state: state)
         }

--- a/IntelliNest/ViewModel/HeatersViewModel.swift
+++ b/IntelliNest/ViewModel/HeatersViewModel.swift
@@ -67,7 +67,7 @@ class HeatersViewModel: HassAPIViewModelProtocol {
     func toggleCorridorTimerMode() {
         let action: Action = heaterCorridorTimerMode.isActive ? .turnOff : .turnOn
         toggleHeaterTimerMode(heaterEntityID: heaterCorridor.entityId,
-                              heaterTimerModeEntityID: .heaterCorridorTimerMode,
+                              heaterTimerModeEntityID: heaterCorridorTimerMode.entityId,
                               dateEntity: resetCorridorHeaterTime,
                               action: action)
     }
@@ -75,7 +75,7 @@ class HeatersViewModel: HassAPIViewModelProtocol {
     func togglePlayroomTimerMode() {
         let action: Action = heaterPlayroomTimerMode.isActive ? .turnOff : .turnOn
         toggleHeaterTimerMode(heaterEntityID: heaterPlayroom.entityId,
-                              heaterTimerModeEntityID: .heaterPlayroomTimerMode,
+                              heaterTimerModeEntityID: heaterPlayroomTimerMode.entityId,
                               dateEntity: resetPlayroomHeaterTime,
                               action: action)
     }

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ With chatGPT I think this would be doable even if you are not a iOS developer bu
 ## Code statistics
 | Indicators                          | Now  | Desired |
 |-------------------------------------|------|---------|
-| Total LOC                           | 9090 | N/A |
+| Total LOC                           | 9094 | N/A |
 | Swift file count                    | 138 | N/A |
 | Average LOC per file                | 65 | <100 |
 | TODO comment count                  | 0 | 0 |
 | FIX comment count                   | 0 | 0 |
 | unowned reference count             | 0 | 0 |
-| Commit count in main                | 30 | N/A |
-| Total deleted lines                 | 2062 | N/A |
-| Total added lines                   | 14111 | N/A |
+| Commit count in main                | 31 | N/A |
+| Total deleted lines                 | 2048 | N/A |
+| Total added lines                   | 14107 | N/A |
 
 Last Updated: 2023-11-19
 ## Supported features


### PR DESCRIPTION
…ViewModel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced navigation logic to reload `heatersViewModel` with specific `entityID` and `state` when applicable.

- **Refactor**
  - Updated `HeatersViewModel` to use `entityId` properties for timer mode functions, improving the referencing mechanism for timer modes.

- **Documentation**
  - Updated project statistics in the README, reflecting the latest codebase changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->