### PR TITLE
Add unit tests for HomeViewModel and ElectricityViewModel

### DIFF
--- a/IntelliNestTests/ElectricityViewModelTests.swift
+++ b/IntelliNestTests/ElectricityViewModelTests.swift
@@ -30,17 +30,6 @@ class ElectricityViewModelTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeEntityJSON(entityId: String, state: String) -> Data {
-        Data("""
-        {
-            "entity_id": "\(entityId)",
-            "state": "\(state)",
-            "last_changed": "2023-06-17T13:30:00.215607+00:00",
-            "last_updated": "2023-06-17T13:30:00.215607+00:00"
-        }
-        """.utf8)
-    }
-
     private func makeNordPoolJSON(state: String, today: [Int], tomorrow: [Int], tomorrowValid: Bool) -> Data {
         let todayJSON = today.map(String.init).joined(separator: ", ")
         let tomorrowJSON = tomorrow.map(String.init).joined(separator: ", ")
@@ -55,14 +44,6 @@ class ElectricityViewModelTests: XCTestCase {
             }
         }
         """.utf8)
-    }
-
-    private func stubEntityURL(entityID: EntityId, data: Data) {
-        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
-        components.path = "/api/states/\(entityID.rawValue)"
-        let url = components.url!
-        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        URLProtocolStub.setStub(for: url, data: data, response: response, error: nil)
     }
 
     // MARK: - Initial State
@@ -244,8 +225,7 @@ class ElectricityViewModelTests: XCTestCase {
             .solarPower: "1000"
         ]
         for (entityID, state) in entityStates {
-            let data = makeEntityJSON(entityId: entityID.rawValue, state: state)
-            stubEntityURL(entityID: entityID, data: data)
+            stubEntityURL(entityID: entityID, state: state)
         }
         // Stub NordPool with valid JSON so reload() doesn't fail for it
         let nordPoolData = makeNordPoolJSON(
@@ -279,8 +259,7 @@ class ElectricityViewModelTests: XCTestCase {
         stubEntityURL(entityID: .nordPool, data: nordPoolData)
         // Stub remaining entities so the reload loop doesn't stall on them
         for entityID in viewModel.entityIDs where entityID != .nordPool {
-            let data = makeEntityJSON(entityId: entityID.rawValue, state: "0")
-            stubEntityURL(entityID: entityID, data: data)
+            stubEntityURL(entityID: entityID, state: "0")
         }
 
         // When
@@ -312,13 +291,11 @@ class ElectricityViewModelTests: XCTestCase {
             }
         }
         for entityID in viewModel.entityIDs {
-            let data: Data
             if entityID == .nordPool {
-                data = self.makeNordPoolJSON(state: "100", today: [100], tomorrow: [], tomorrowValid: false)
+                stubEntityURL(entityID: entityID, data: makeNordPoolJSON(state: "100", today: [100], tomorrow: [], tomorrowValid: false))
             } else {
-                data = self.makeEntityJSON(entityId: entityID.rawValue, state: "0")
+                stubEntityURL(entityID: entityID, state: "0")
             }
-            stubEntityURL(entityID: entityID, data: data)
         }
 
         // When

--- a/IntelliNestTests/ElectricityViewModelTests.swift
+++ b/IntelliNestTests/ElectricityViewModelTests.swift
@@ -1,0 +1,333 @@
+@testable import IntelliNest
+import XCTest
+
+@MainActor
+class ElectricityViewModelTests: XCTestCase {
+    var viewModel: ElectricityViewModel!
+    var restAPIService: RestAPIService!
+    var urlCreator: URLCreator!
+
+    override func setUp() async throws {
+        URLProtocolStub.startInterceptingRequests()
+        let stubbedSession = URLProtocolStub.createStubbedURLSession()
+        urlCreator = URLCreator(session: stubbedSession)
+        urlCreator.connectionState = .local
+        restAPIService = RestAPIService(
+            urlCreator: urlCreator,
+            session: stubbedSession,
+            setErrorBannerText: { _, _ in },
+            repeatReloadAction: { _ in }
+        )
+        viewModel = ElectricityViewModel(restAPIService: restAPIService)
+    }
+
+    override func tearDown() async throws {
+        URLProtocolStub.stopInterceptingRequests()
+        viewModel = nil
+        restAPIService = nil
+        urlCreator = nil
+    }
+
+    // MARK: - Helpers
+
+    private func makeEntityJSON(entityId: String, state: String) -> Data {
+        Data("""
+        {
+            "entity_id": "\(entityId)",
+            "state": "\(state)",
+            "last_changed": "2023-06-17T13:30:00.215607+00:00",
+            "last_updated": "2023-06-17T13:30:00.215607+00:00"
+        }
+        """.utf8)
+    }
+
+    private func makeNordPoolJSON(state: String, today: [Int], tomorrow: [Int], tomorrowValid: Bool) -> Data {
+        let todayJSON = today.map(String.init).joined(separator: ", ")
+        let tomorrowJSON = tomorrow.map(String.init).joined(separator: ", ")
+        return Data("""
+        {
+            "entity_id": "\(EntityId.nordPool.rawValue)",
+            "state": "\(state)",
+            "attributes": {
+                "today": [\(todayJSON)],
+                "tomorrow": [\(tomorrowJSON)],
+                "tomorrow_valid": \(tomorrowValid)
+            }
+        }
+        """.utf8)
+    }
+
+    private func stubEntityURL(entityID: EntityId, data: Data) {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/states/\(entityID.rawValue)"
+        let url = components.url!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: data, response: response, error: nil)
+    }
+
+    // MARK: - Initial State
+
+    func testInitialState() {
+        XCTAssertEqual(viewModel.nordPool.state, "Loading")
+        XCTAssertEqual(viewModel.tibberCostToday.state, "Loading")
+        XCTAssertEqual(viewModel.pulseConsumptionToday.state, "Loading")
+        XCTAssertEqual(viewModel.housePower, 0)
+        XCTAssertEqual(viewModel.solarPower, 0)
+    }
+
+    // MARK: - reload(entityID:state:) Dispatch
+
+    func testReloadEntityIDUpdatesPulsePower() {
+        // Given / When
+        viewModel.reload(entityID: .pulsePower, state: "2500")
+        // Then
+        XCTAssertEqual(viewModel.housePower, 2500)
+    }
+
+    func testReloadEntityIDUpdatesTibberCostToday() {
+        // Given / When
+        viewModel.reload(entityID: .tibberCostToday, state: "42.5")
+        // Then
+        XCTAssertEqual(viewModel.tibberCostToday.state, "42.5")
+    }
+
+    func testReloadEntityIDUpdatesPulseConsumptionToday() {
+        // Given / When
+        viewModel.reload(entityID: .pulseConsumptionToday, state: "18.3")
+        // Then
+        XCTAssertEqual(viewModel.pulseConsumptionToday.state, "18.3")
+    }
+
+    func testReloadEntityIDUpdatesSolarPower() {
+        // Given / When
+        viewModel.reload(entityID: .solarPower, state: "3000")
+        // Then
+        XCTAssertEqual(viewModel.solarPower, 3000)
+    }
+
+    // MARK: - Computed Property: solarPower
+
+    func testSolarPower_whenStateIsNumeric() {
+        // Given / When
+        viewModel.reload(entityID: .solarPower, state: "4500")
+        // Then
+        XCTAssertEqual(viewModel.solarPower, 4500)
+    }
+
+    func testSolarPower_whenStateIsNonNumeric() {
+        // Given / When
+        viewModel.reload(entityID: .solarPower, state: "unavailable")
+        // Then
+        XCTAssertEqual(viewModel.solarPower, 0)
+    }
+
+    // MARK: - Computed Property: housePower
+
+    func testHousePower_whenStateIsNumeric() {
+        // Given / When
+        viewModel.reload(entityID: .pulsePower, state: "1800")
+        // Then
+        XCTAssertEqual(viewModel.housePower, 1800)
+    }
+
+    func testHousePower_whenStateIsNonNumeric() {
+        // Given / When
+        viewModel.reload(entityID: .pulsePower, state: "unavailable")
+        // Then
+        XCTAssertEqual(viewModel.housePower, 0)
+    }
+
+    // MARK: - Computed Property: gridPower
+
+    func testGridPower_isHousePowerMinusSolarPower() {
+        // Given / When
+        viewModel.reload(entityID: .pulsePower, state: "3000")
+        viewModel.reload(entityID: .solarPower, state: "1000")
+        // Then
+        XCTAssertEqual(viewModel.gridPower, 2000)
+    }
+
+    func testGridPower_isNegativeWhenSolarExceedsConsumption() {
+        // Given / When
+        viewModel.reload(entityID: .pulsePower, state: "1000")
+        viewModel.reload(entityID: .solarPower, state: "4000")
+        // Then
+        XCTAssertEqual(viewModel.gridPower, -3000)
+    }
+
+    // MARK: - Computed Property: isSolarToGrid
+
+    func testIsSolarToGrid_whenSolarExceedsHouseConsumption() {
+        // Given: solar produces 5 kW, house consumes 1 kW → exporting 4 kW to grid
+        viewModel.reload(entityID: .solarPower, state: "5000")
+        viewModel.reload(entityID: .pulsePower, state: "1000")
+        // Then
+        XCTAssertTrue(viewModel.isSolarToGrid)
+    }
+
+    func testIsSolarToGrid_whenSolarIsBelowHouseConsumption() {
+        // Given: solar produces 1 kW, house consumes 3 kW → drawing 2 kW from grid
+        viewModel.reload(entityID: .solarPower, state: "1000")
+        viewModel.reload(entityID: .pulsePower, state: "3000")
+        // Then
+        XCTAssertFalse(viewModel.isSolarToGrid)
+    }
+
+    func testIsSolarToGrid_whenNoSolarProduction() {
+        // Given: no solar production
+        viewModel.reload(entityID: .solarPower, state: "0")
+        viewModel.reload(entityID: .pulsePower, state: "2000")
+        // Then
+        XCTAssertFalse(viewModel.isSolarToGrid)
+    }
+
+    // MARK: - Computed Property: isSolarToHouse
+
+    func testIsSolarToHouse_whenSolarPartiallyCoversConsumption() {
+        // Given: solar covers 1.5 kW of a 3 kW load
+        viewModel.reload(entityID: .solarPower, state: "1500")
+        viewModel.reload(entityID: .pulsePower, state: "3000")
+        // Then
+        XCTAssertTrue(viewModel.isSolarToHouse)
+    }
+
+    func testIsSolarToHouse_whenSolarFullyCoversPlusExports() {
+        // Given: solar exceeds house consumption and exports to grid
+        viewModel.reload(entityID: .solarPower, state: "5000")
+        viewModel.reload(entityID: .pulsePower, state: "1000")
+        // Then
+        XCTAssertTrue(viewModel.isSolarToHouse)
+    }
+
+    func testIsSolarToHouse_whenNoSolarProduction() {
+        // Given: no solar production
+        viewModel.reload(entityID: .solarPower, state: "0")
+        viewModel.reload(entityID: .pulsePower, state: "2000")
+        // Then
+        XCTAssertFalse(viewModel.isSolarToHouse)
+    }
+
+    // MARK: - Computed Property: isGridToHouse
+
+    func testIsGridToHouse_whenDrawingFromGrid() {
+        // Given: house draws 2 kW from grid (no solar)
+        viewModel.reload(entityID: .solarPower, state: "0")
+        viewModel.reload(entityID: .pulsePower, state: "2000")
+        // Then
+        XCTAssertTrue(viewModel.isGridToHouse)
+    }
+
+    func testIsGridToHouse_whenSolarCoversAllConsumption() {
+        // Given: solar covers all house consumption and exports surplus
+        viewModel.reload(entityID: .solarPower, state: "5000")
+        viewModel.reload(entityID: .pulsePower, state: "1000")
+        // Then
+        XCTAssertFalse(viewModel.isGridToHouse)
+    }
+
+    func testIsGridToHouse_whenSolarPartiallyCoversConsumption() {
+        // Given: solar covers 1 kW but house needs 3 kW → drawing 2 kW from grid
+        viewModel.reload(entityID: .solarPower, state: "1000")
+        viewModel.reload(entityID: .pulsePower, state: "3000")
+        // Then
+        XCTAssertTrue(viewModel.isGridToHouse)
+    }
+
+    // MARK: - Network Reload
+
+    func testReloadFetchesRegularEntitiesFromNetwork() async {
+        // Given: stub all non-NordPool entity URLs
+        let entityStates: [EntityId: String] = [
+            .pulsePower: "2000",
+            .tibberCostToday: "55.0",
+            .pulseConsumptionToday: "20.5",
+            .solarPower: "1000"
+        ]
+        for (entityID, state) in entityStates {
+            let data = makeEntityJSON(entityId: entityID.rawValue, state: state)
+            stubEntityURL(entityID: entityID, data: data)
+        }
+        // Stub NordPool with valid JSON so reload() doesn't fail for it
+        let nordPoolData = makeNordPoolJSON(
+            state: "120",
+            today: [80, 90, 100, 110],
+            tomorrow: [],
+            tomorrowValid: false
+        )
+        stubEntityURL(entityID: .nordPool, data: nordPoolData)
+
+        // When
+        await viewModel.reload()
+
+        // Then
+        XCTAssertEqual(viewModel.housePower, 2000)
+        XCTAssertEqual(viewModel.solarPower, 1000)
+        XCTAssertEqual(viewModel.tibberCostToday.state, "55.0")
+        XCTAssertEqual(viewModel.pulseConsumptionToday.state, "20.5")
+    }
+
+    func testReloadFetchesNordPoolEntityFromNetwork() async {
+        // Given: stub NordPool URL with price data
+        let today = Array(1 ... 96).map { $0 * 10 }
+        let tomorrow = Array(1 ... 96).map { $0 * 12 }
+        let nordPoolData = makeNordPoolJSON(
+            state: "250",
+            today: today,
+            tomorrow: tomorrow,
+            tomorrowValid: true
+        )
+        stubEntityURL(entityID: .nordPool, data: nordPoolData)
+        // Stub remaining entities so the reload loop doesn't stall on them
+        for entityID in viewModel.entityIDs where entityID != .nordPool {
+            let data = makeEntityJSON(entityId: entityID.rawValue, state: "0")
+            stubEntityURL(entityID: entityID, data: data)
+        }
+
+        // When
+        await viewModel.reload()
+
+        // Then
+        XCTAssertEqual(viewModel.nordPool.state, "250")
+        XCTAssertFalse(viewModel.nordPool.today.isEmpty)
+        XCTAssertFalse(viewModel.nordPool.tomorrow.isEmpty)
+        XCTAssertTrue(viewModel.nordPool.tomorrowValid)
+    }
+
+    func testReloadSilentlyHandlesNetworkFailure() async {
+        // Given: no stubs registered – all requests will fail
+        // When
+        await viewModel.reload()
+        // Then: entities remain in their initial Loading state
+        XCTAssertEqual(viewModel.nordPool.state, "Loading")
+        XCTAssertEqual(viewModel.tibberCostToday.state, "Loading")
+        XCTAssertEqual(viewModel.pulseConsumptionToday.state, "Loading")
+    }
+
+    func testReloadObservesCorrectURLs() async {
+        // Given
+        var observedPaths: [String] = []
+        URLProtocolStub.observerRequests { request in
+            if let path = request.url?.path {
+                observedPaths.append(path)
+            }
+        }
+        for entityID in viewModel.entityIDs {
+            let data: Data
+            if entityID == .nordPool {
+                data = self.makeNordPoolJSON(state: "100", today: [100], tomorrow: [], tomorrowValid: false)
+            } else {
+                data = self.makeEntityJSON(entityId: entityID.rawValue, state: "0")
+            }
+            stubEntityURL(entityID: entityID, data: data)
+        }
+
+        // When
+        await viewModel.reload()
+
+        // Then: a request was made for every entity in entityIDs
+        let expectedPaths = viewModel.entityIDs.map { "/api/states/\($0.rawValue)" }
+        for path in expectedPaths {
+            XCTAssertTrue(observedPaths.contains(path), "Expected request for path \(path)")
+        }
+    }
+}

--- a/IntelliNestTests/HomeViewModelTests.swift
+++ b/IntelliNestTests/HomeViewModelTests.swift
@@ -41,28 +41,6 @@ class HomeViewModelTests: XCTestCase {
         urlCreator = nil
     }
 
-    // MARK: - Helpers
-
-    private func makeEntityJSON(entityId: String, state: String) -> Data {
-        Data("""
-        {
-            "entity_id": "\(entityId)",
-            "state": "\(state)",
-            "last_changed": "2023-06-17T13:30:00.215607+00:00",
-            "last_updated": "2023-06-17T13:30:00.215607+00:00"
-        }
-        """.utf8)
-    }
-
-    private func stubEntityURL(entityID: EntityId, state: String) {
-        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
-        components.path = "/api/states/\(entityID.rawValue)"
-        let url = components.url!
-        let data = makeEntityJSON(entityId: entityID.rawValue, state: state)
-        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        URLProtocolStub.setStub(for: url, data: data, response: response, error: nil)
-    }
-
     // MARK: - Initial State
 
     func testInitialState() {

--- a/IntelliNestTests/HomeViewModelTests.swift
+++ b/IntelliNestTests/HomeViewModelTests.swift
@@ -1,0 +1,413 @@
+@testable import IntelliNest
+import XCTest
+
+@MainActor
+class HomeViewModelTests: XCTestCase {
+    var viewModel: HomeViewModel!
+    var restAPIService: RestAPIService!
+    var yaleAPIService: YaleApiService!
+    var urlCreator: URLCreator!
+
+    override func setUp() async throws {
+        URLProtocolStub.startInterceptingRequests()
+        let stubbedSession = URLProtocolStub.createStubbedURLSession()
+        urlCreator = URLCreator(session: stubbedSession)
+        urlCreator.connectionState = .local
+        restAPIService = RestAPIService(
+            urlCreator: urlCreator,
+            session: stubbedSession,
+            setErrorBannerText: { _, _ in },
+            repeatReloadAction: { _ in }
+        )
+        yaleAPIService = YaleApiService(hassAPIService: restAPIService, session: stubbedSession)
+        viewModel = HomeViewModel(
+            restAPIService: restAPIService,
+            yaleApiService: yaleAPIService,
+            urlCreator: urlCreator,
+            showHeatersAction: {},
+            showLynkAction: {},
+            showRoborockAction: {},
+            showPowerGridAction: {},
+            showLightsAction: {},
+            toolbarReloadAction: {}
+        )
+    }
+
+    override func tearDown() async throws {
+        URLProtocolStub.stopInterceptingRequests()
+        viewModel = nil
+        restAPIService = nil
+        yaleAPIService = nil
+        urlCreator = nil
+    }
+
+    // MARK: - Helpers
+
+    private func makeEntityJSON(entityId: String, state: String) -> Data {
+        Data("""
+        {
+            "entity_id": "\(entityId)",
+            "state": "\(state)",
+            "last_changed": "2023-06-17T13:30:00.215607+00:00",
+            "last_updated": "2023-06-17T13:30:00.215607+00:00"
+        }
+        """.utf8)
+    }
+
+    private func stubEntityURL(entityID: EntityId, state: String) {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/states/\(entityID.rawValue)"
+        let url = components.url!
+        let data = makeEntityJSON(entityId: entityID.rawValue, state: state)
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: data, response: response, error: nil)
+    }
+
+    // MARK: - Initial State
+
+    func testInitialState() {
+        XCTAssertEqual(viewModel.coffeeMachine.state, "Loading")
+        XCTAssertEqual(viewModel.pulsePower.state, "Loading")
+        XCTAssertEqual(viewModel.tibberPrice.state, "Loading")
+        XCTAssertEqual(viewModel.pulseConsumptionToday.state, "Loading")
+        XCTAssertEqual(viewModel.washerState.state, "Loading")
+        XCTAssertEqual(viewModel.dryerState.state, "Loading")
+        XCTAssertEqual(viewModel.easeeStatus.state, "Loading")
+        XCTAssertEqual(viewModel.allLights.state, "Loading")
+        XCTAssertEqual(viewModel.storageLock.state, "Loading")
+        XCTAssertFalse(viewModel.noLocationAccess)
+    }
+
+    // MARK: - reload(entityID:state:) Dispatch
+
+    func testReloadEntityIDUpdatesAllLights() {
+        // Given / When
+        viewModel.reload(entityID: .allLights, state: "on")
+        // Then
+        XCTAssertEqual(viewModel.allLights.state, "on")
+        XCTAssertTrue(viewModel.allLights.isActive)
+    }
+
+    func testReloadEntityIDUpdatesCoffeeMachine() {
+        // Given / When
+        viewModel.reload(entityID: .coffeeMachine, state: "on")
+        // Then
+        XCTAssertEqual(viewModel.coffeeMachine.state, "on")
+        XCTAssertTrue(viewModel.coffeeMachine.isActive)
+    }
+
+    func testReloadEntityIDUpdatesCoffeeMachineLastChanged() {
+        // Given
+        let lastChanged = Date(timeIntervalSinceReferenceDate: 700_000_000)
+        // When
+        viewModel.reload(entityID: .coffeeMachine, state: "on", lastChanged: lastChanged)
+        // Then
+        XCTAssertEqual(viewModel.coffeeMachine.lastChanged, lastChanged)
+    }
+
+    func testReloadEntityIDDoesNotOverwriteCoffeeMachineLastChangedWhenNil() {
+        // Given
+        let originalLastChanged = viewModel.coffeeMachine.lastChanged
+        // When
+        viewModel.reload(entityID: .coffeeMachine, state: "off", lastChanged: nil)
+        // Then
+        XCTAssertEqual(viewModel.coffeeMachine.lastChanged, originalLastChanged)
+    }
+
+    func testReloadEntityIDUpdatesStorageLock() {
+        // Given / When
+        viewModel.reload(entityID: .storageLock, state: "locked")
+        // Then
+        XCTAssertEqual(viewModel.storageLock.state, "locked")
+        XCTAssertEqual(viewModel.storageLock.lockState, .locked)
+    }
+
+    func testReloadEntityIDUpdatesSarahsIphone() {
+        // Given / When
+        viewModel.reload(entityID: .hittaSarahsIphone, state: "on")
+        // Then
+        XCTAssertEqual(viewModel.sarahsIphone.state, "on")
+        XCTAssertTrue(viewModel.sarahsIphone.isActive)
+    }
+
+    func testReloadEntityIDUpdatesCoffeeMachineStartTime() {
+        // Given / When
+        viewModel.reload(entityID: .coffeeMachineStartTime, state: "07:30:00")
+        // Then
+        XCTAssertEqual(viewModel.coffeeMachineStartTime.state, "07:30:00")
+    }
+
+    func testReloadEntityIDUpdatesCoffeeMachineStartTimeEnabled() {
+        // Given / When
+        viewModel.reload(entityID: .coffeeMachineStartTimeEnabled, state: "on")
+        // Then
+        XCTAssertEqual(viewModel.coffeeMachineStartTimeEnabled.state, "on")
+        XCTAssertTrue(viewModel.coffeeMachineStartTimeEnabled.isActive)
+    }
+
+    func testReloadEntityIDUpdatesPulsePower() {
+        // Given / When
+        viewModel.reload(entityID: .pulsePower, state: "1234")
+        // Then
+        XCTAssertEqual(viewModel.pulsePower.state, "1234")
+    }
+
+    func testReloadEntityIDUpdatesTibberPrice() {
+        // Given / When
+        viewModel.reload(entityID: .tibberPrice, state: "0.85")
+        // Then
+        XCTAssertEqual(viewModel.tibberPrice.state, "0.85")
+    }
+
+    func testReloadEntityIDUpdatesPulseConsumptionToday() {
+        // Given / When
+        viewModel.reload(entityID: .pulseConsumptionToday, state: "15.3")
+        // Then
+        XCTAssertEqual(viewModel.pulseConsumptionToday.state, "15.3")
+    }
+
+    func testReloadEntityIDUpdatesSolarProductionToday() {
+        // Given / When
+        viewModel.reload(entityID: .solarProducdtionToday, state: "8.7")
+        // Then
+        XCTAssertEqual(viewModel.solarProducdtionToday.state, "8.7")
+    }
+
+    func testReloadEntityIDUpdatesWasherCompletionTime() {
+        // Given / When
+        viewModel.reload(entityID: .washerCompletionTime, state: "2023-06-17 15:30:00")
+        // Then
+        XCTAssertEqual(viewModel.washerCompletionTime.state, "2023-06-17 15:30:00")
+    }
+
+    func testReloadEntityIDUpdatesWasherState() {
+        // Given / When
+        viewModel.reload(entityID: .washerState, state: "run")
+        // Then
+        XCTAssertEqual(viewModel.washerState.state, "run")
+    }
+
+    func testReloadEntityIDUpdatesDryerCompletionTime() {
+        // Given / When
+        viewModel.reload(entityID: .dryerCompletionTime, state: "2023-06-17 17:30:00")
+        // Then
+        XCTAssertEqual(viewModel.dryerCompletionTime.state, "2023-06-17 17:30:00")
+    }
+
+    func testReloadEntityIDUpdatesDryerState() {
+        // Given / When
+        viewModel.reload(entityID: .dryerState, state: "drying")
+        // Then
+        XCTAssertEqual(viewModel.dryerState.state, "drying")
+    }
+
+    func testReloadEntityIDUpdatesEaseePower() {
+        // Given / When
+        viewModel.reload(entityID: .easeePower, state: "7200")
+        // Then
+        XCTAssertEqual(viewModel.easeePower.state, "7200")
+    }
+
+    func testReloadEntityIDUpdatesEaseeNoCurrentReason() {
+        // Given / When
+        viewModel.reload(entityID: .easeeNoCurrentReason, state: "pending_schedule")
+        // Then
+        XCTAssertEqual(viewModel.easeeNoCurrentReason.state, "pending_schedule")
+    }
+
+    func testReloadEntityIDUpdatesEaseeStatus() {
+        // Given / When
+        viewModel.reload(entityID: .easeeStatus, state: "charging")
+        // Then
+        XCTAssertEqual(viewModel.easeeStatus.state, "charging")
+    }
+
+    func testReloadEntityIDUpdatesGeneralWasteDate() {
+        // Given / When
+        viewModel.reload(entityID: .generalWasteDate, state: "2023-06-20")
+        // Then
+        XCTAssertEqual(viewModel.generalWasteDate.state, "2023-06-20")
+    }
+
+    func testReloadEntityIDUpdatesPlasticWasteDate() {
+        // Given / When
+        viewModel.reload(entityID: .plasticWasteDate, state: "2023-06-27")
+        // Then
+        XCTAssertEqual(viewModel.plasticWasteDate.state, "2023-06-27")
+    }
+
+    func testReloadEntityIDUpdatesGardenWasteDate() {
+        // Given / When
+        viewModel.reload(entityID: .gardenWasteDate, state: "2023-07-04")
+        // Then
+        XCTAssertEqual(viewModel.gardenWasteDate.state, "2023-07-04")
+    }
+
+    // MARK: - Computed Properties
+
+    func testIsEaseeCharging_whenStatusIsCharging() {
+        // Given / When
+        viewModel.reload(entityID: .easeeStatus, state: "charging")
+        // Then
+        XCTAssertTrue(viewModel.isEaseeCharging)
+    }
+
+    func testIsEaseeCharging_whenStatusIsNotCharging() {
+        // Given / When
+        viewModel.reload(entityID: .easeeStatus, state: "awaiting_start")
+        // Then
+        XCTAssertFalse(viewModel.isEaseeCharging)
+    }
+
+    func testIsEaseeCharging_isCaseInsensitive() {
+        // Given / When
+        viewModel.reload(entityID: .easeeStatus, state: "Charging")
+        // Then
+        XCTAssertTrue(viewModel.isEaseeCharging)
+    }
+
+    func testIsEaseeAwaitingSchedule_whenNoCurrentReasonIsPendingSchedule() {
+        // Given / When
+        viewModel.reload(entityID: .easeeNoCurrentReason, state: "pending_schedule")
+        // Then
+        XCTAssertTrue(viewModel.isEaseeAwaitingSchedule)
+    }
+
+    func testIsEaseeAwaitingSchedule_whenStatusIsAwaitingStart() {
+        // Given / When
+        viewModel.reload(entityID: .easeeStatus, state: "awaiting_start")
+        // Then
+        XCTAssertTrue(viewModel.isEaseeAwaitingSchedule)
+    }
+
+    func testIsEaseeAwaitingSchedule_whenNeither() {
+        // Given / When
+        viewModel.reload(entityID: .easeeNoCurrentReason, state: "idle")
+        viewModel.reload(entityID: .easeeStatus, state: "charging")
+        // Then
+        XCTAssertFalse(viewModel.isEaseeAwaitingSchedule)
+    }
+
+    // MARK: - Lock State
+
+    func testResetExpectedLockStates() {
+        // Given
+        viewModel.storageLock.expectedState = .locked
+        viewModel.frontDoor.expectedState = .locked
+        viewModel.sideDoor.expectedState = .locked
+        // When
+        viewModel.resetExpectedLockStates()
+        // Then
+        XCTAssertEqual(viewModel.storageLock.expectedState, .unknown)
+        XCTAssertEqual(viewModel.frontDoor.expectedState, .unknown)
+        XCTAssertEqual(viewModel.sideDoor.expectedState, .unknown)
+    }
+
+    func testToggleStateForStorageLock_setsExpectedStateLocked() {
+        // Given
+        viewModel.reload(entityID: .storageLock, state: "unlocked")
+        // When
+        viewModel.toggleStateForStorageLock()
+        // Then
+        XCTAssertEqual(viewModel.storageLock.expectedState, .locked)
+    }
+
+    func testToggleStateForStorageLock_setsExpectedStateUnlocked() {
+        // Given
+        viewModel.reload(entityID: .storageLock, state: "locked")
+        // When
+        viewModel.toggleStateForStorageLock()
+        // Then
+        XCTAssertEqual(viewModel.storageLock.expectedState, .unlocked)
+    }
+
+    func testLockStorage_setsExpectedStateLocked() {
+        // Given / When
+        viewModel.lockStorage()
+        // Then
+        XCTAssertEqual(viewModel.storageLock.expectedState, .locked)
+    }
+
+    func testUnlockStorage_setsExpectedStateUnlocked() {
+        // Given / When
+        viewModel.unlockStorage()
+        // Then
+        XCTAssertEqual(viewModel.storageLock.expectedState, .unlocked)
+    }
+
+    // MARK: - Network Reload
+
+    func testReloadFetchesAllEntitiesFromNetwork() async {
+        // Given: stub all entity URLs with mock responses
+        let entityStates: [EntityId: String] = [
+            .hittaSarahsIphone: "off",
+            .coffeeMachine: "on",
+            .storageLock: "locked",
+            .coffeeMachineStartTime: "07:30:00",
+            .coffeeMachineStartTimeEnabled: "on",
+            .pulsePower: "1500",
+            .tibberPrice: "1.23",
+            .pulseConsumptionToday: "12.5",
+            .washerCompletionTime: "2023-06-17 15:30:00",
+            .solarProducdtionToday: "5.2",
+            .dryerCompletionTime: "2023-06-17 17:00:00",
+            .washerState: "run",
+            .dryerState: "cooling",
+            .easeePower: "7200",
+            .easeeNoCurrentReason: "idle",
+            .easeeStatus: "charging",
+            .generalWasteDate: "2023-06-20",
+            .plasticWasteDate: "2023-06-27",
+            .gardenWasteDate: "2023-07-04",
+            .allLights: "off"
+        ]
+        for (entityID, state) in entityStates {
+            stubEntityURL(entityID: entityID, state: state)
+        }
+
+        // When
+        await viewModel.reload()
+
+        // Then
+        XCTAssertEqual(viewModel.coffeeMachine.state, "on")
+        XCTAssertEqual(viewModel.pulsePower.state, "1500")
+        XCTAssertEqual(viewModel.easeeStatus.state, "charging")
+        XCTAssertEqual(viewModel.storageLock.state, "locked")
+        XCTAssertEqual(viewModel.allLights.state, "off")
+        XCTAssertEqual(viewModel.washerState.state, "run")
+        XCTAssertEqual(viewModel.dryerState.state, "cooling")
+        XCTAssertEqual(viewModel.generalWasteDate.state, "2023-06-20")
+    }
+
+    func testReloadSilentlyHandlesNetworkFailure() async {
+        // Given: no stubs registered – all requests will fail
+        // When
+        await viewModel.reload()
+        // Then: entities remain in their initial Loading state
+        XCTAssertEqual(viewModel.coffeeMachine.state, "Loading")
+        XCTAssertEqual(viewModel.pulsePower.state, "Loading")
+        XCTAssertEqual(viewModel.easeeStatus.state, "Loading")
+    }
+
+    func testReloadObservesCorrectURLs() async {
+        // Given
+        var observedPaths: [String] = []
+        URLProtocolStub.observerRequests { request in
+            if let path = request.url?.path {
+                observedPaths.append(path)
+            }
+        }
+        for entityID in viewModel.entityIDs {
+            stubEntityURL(entityID: entityID, state: "off")
+        }
+
+        // When
+        await viewModel.reload()
+
+        // Then: a request was made for every entity in entityIDs
+        let expectedPaths = viewModel.entityIDs.map { "/api/states/\($0.rawValue)" }
+        for path in expectedPaths {
+            XCTAssertTrue(observedPaths.contains(path), "Expected request for path \(path)")
+        }
+    }
+}

--- a/IntelliNestTests/TestHelpers.swift
+++ b/IntelliNestTests/TestHelpers.swift
@@ -1,0 +1,32 @@
+@testable import IntelliNest
+import Foundation
+
+func makeEntityJSON(entityId: String, state: String) -> Data {
+    Data("""
+    {
+        "entity_id": "\(entityId)",
+        "state": "\(state)",
+        "last_changed": "2023-06-17T13:30:00.215607+00:00",
+        "last_updated": "2023-06-17T13:30:00.215607+00:00"
+    }
+    """.utf8)
+}
+
+func stubEntityURL(entityID: EntityId, state: String) {
+    let url = entityStateURL(for: entityID)
+    let data = makeEntityJSON(entityId: entityID.rawValue, state: state)
+    let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    URLProtocolStub.setStub(for: url, data: data, response: response, error: nil)
+}
+
+func stubEntityURL(entityID: EntityId, data: Data) {
+    let url = entityStateURL(for: entityID)
+    let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    URLProtocolStub.setStub(for: url, data: data, response: response, error: nil)
+}
+
+private func entityStateURL(for entityID: EntityId) -> URL {
+    var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+    components.path = "/api/states/\(entityID.rawValue)"
+    return components.url!
+}


### PR DESCRIPTION
Tests use URLProtocolStub to intercept all network requests, ensuring no real HTTP calls are made during testing.

HomeViewModelTests covers: initial state, all reload(entityID:) dispatch branches, computed properties (isEaseeCharging, isEaseeAwaitingSchedule), lock state mutations, and async end-to-end reload with stubbed responses.

ElectricityViewModelTests covers: initial state, all reload(entityID:) dispatch branches, computed properties (solarPower, housePower, gridPower, isSolarToGrid, isSolarToHouse, isGridToHouse), and async end-to-end reload including the NordPool entity's attributes decoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for electricity and home view models covering initial states, reload/update flows, computed property logic (power, grid/solar routing, charging/lock statuses), last-changed handling, and resilience to network failures. Tests also verify correct API request observation.
* **Test Helpers**
  * Added utilities to generate mock entity responses and stub network endpoints for deterministic HTTP testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->