### PR TITLE
Added CLAUDE.md with architecture, build commands and commit guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+**Run all tests (local):**
+```bash
+xcodebuild test \
+  -project IntelliNest.xcodeproj \
+  -scheme "IntelliNest-github" \
+  -testPlan "IntelliNest-github" \
+  -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
+  -configuration "Github actions" \
+  CODE_SIGNING_ALLOWED=NO | xcbeautify
+```
+
+**Run a single test class:**
+```bash
+xcodebuild test \
+  -project IntelliNest.xcodeproj \
+  -scheme "IntelliNest-github" \
+  -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
+  -configuration "Github actions" \
+  -only-testing:IntelliNestTests/HomeViewModelTests \
+  CODE_SIGNING_ALLOWED=NO | xcbeautify
+```
+
+Install `xcbeautify` with `brew install xcbeautify` if not present.
+
+**Local development** requires `IntelliNest-Info.xcconfig` (not committed). Copy `Github-Info.xcconfig` and fill in real secrets.
+
+## Architecture
+
+### MVVM + Navigator
+
+The app uses MVVM with SwiftUI. `Navigator` (in `Navigation/`) is the central coordinator — a `@StateObject` owned by `AppMain`. It:
+- Lazily initializes all ViewModels
+- Owns the `NavigationPath` for the SwiftUI `NavigationStack`
+- Runs a continuous reload loop (every 5 seconds) to keep entity state current
+- Manages the error banner state shown across all views
+- Triggers geofence-driven lock/unlock actions
+
+`AppMain.swift` detects test mode via environment variables and skips full initialization when running tests.
+
+### ViewModels
+
+All ViewModels are `@MainActor ObservableObject` classes. Key ones:
+- `HomeViewModel` — controls locks, lights, appliances, Yale API integration
+- `ElectricityViewModel` — power consumption, NordPool pricing, solar/grid data
+- `HeatersViewModel` — thermostat mode/fan/temperature
+- `LynkViewModel` — EV car climate and charging
+- `RoborockViewModel` — vacuum control and room targeting
+
+ViewModels receive `RestAPIService`, `YaleApiService`, and `URLCreator` via constructor injection. Navigation is decoupled via closure callbacks passed at init.
+
+### Service Layer
+
+- **`RestAPIService`** — HTTP calls to Home Assistant REST API (`/api/states/{entityId}`, `/api/services/{domain}/{action}`). Inherits from `URLRequestBuilder`.
+- **`YaleApiService`** — Yale lock API with Keychain-stored JWT tokens, auto-refresh logic.
+- **`URLCreator`** — Checks the current SSID against the configured home SSID to decide between internal URL (local LAN) and external URL (DuckDNS). Updates `RestAPIService.internalUrl`/`externalUrl` dynamically.
+
+Most real-time entity updates use WebSocket (`HAWebSocketService`) rather than REST polling.
+
+### Models
+
+`EntityProtocol` is the base for all Home Assistant entities. It carries `state`, `entityId`, and timestamps. Concrete types (`LightEntity`, `LockEntity`, `HeaterEntity`, etc.) add domain-specific decoded properties.
+
+All entity IDs are declared in the `EntityId` enum; all HA domains in `Domain`; all service actions in `Action`. Always add new IDs there rather than using raw strings.
+
+### Configuration
+
+Secrets are injected via xcconfig variables at build time (accessed as `Bundle.main.infoDictionary` values). `Github-Info.xcconfig` contains placeholder values safe to commit. Never commit `IntelliNest-Info.xcconfig`.
+
+## Pre-commit: SwiftFormat & SwiftLint
+
+Run both tools on changed Swift files before every commit, matching what Xcode does in its build phases.
+
+**SwiftFormat** (bundled binary, same flags as the Xcode build phase):
+```bash
+BuildTools/SwiftFormat/swiftformat . --indent 4
+```
+
+**SwiftLint** (Homebrew install, same config as the Xcode build phase):
+```bash
+swiftlint --config .swiftlint
+```
+
+Fix all SwiftLint errors before committing. Warnings are acceptable but errors are not. The config (`.swiftlint`) sets a warning threshold at 140 chars and an error threshold at 160 chars per line.
+
+## Commit Messages
+
+Based on the project history, follow this style:
+
+- **Past tense**, capitalised first word, no trailing period — e.g. `Added garden waste to upcoming events`, `Fixed spot prices`, `Improved websocket handling by unsubscribing`
+- **Short and specific** — describe what changed, not why. One line is the norm; no body needed.
+- Common leading verbs: `Added`, `Fixed`, `Improved`, `Removed`, `Updated`, `Renamed`, `Refactored`, `Increased`
+- PR numbers (`(#104)`) are appended automatically by GitHub on merge — do not add them manually.
+
+Examples from history:
+```
+Added storage lock
+Fixed ui issues on electricity
+Improved handling of geofence tracking
+Removed websocket
+Refactored all files using swiftformat swift version 5.10
+```
+
+### Testing
+
+Tests live in `IntelliNestTests/`. The pattern:
+1. `URLProtocolStub` intercepts URLSession requests and returns pre-configured mock responses.
+2. `TestHelpers.swift` provides factory helpers for common stub setups.
+3. ViewModels are instantiated with a stubbed `URLSession` passed through `RestAPIService`.
+
+Tests validate both initial state and post-`reload()` state. Use `await Task.yield()` or short `Task.sleep` calls only when async work must settle — check existing tests for the established pattern before adding new ones.

--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -1327,7 +1327,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "IntelliNest/Supporting Files/IntelliNest.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_ASSET_PATHS = "\"IntelliNest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1349,7 +1349,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.02.26;
+				MARKETING_VERSION = 2026.03.04;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1368,7 +1368,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "IntelliNest/Supporting Files/IntelliNest.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_ASSET_PATHS = "\"IntelliNest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1390,7 +1390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.02.26;
+				MARKETING_VERSION = 2026.03.04;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1408,7 +1408,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1416,7 +1416,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.02.26;
+				MARKETING_VERSION = 2026.03.04;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1433,7 +1433,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1441,7 +1441,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.02.26;
+				MARKETING_VERSION = 2026.03.04;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1459,7 +1459,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = IntelliWidget/IntelliWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1473,7 +1473,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2026.02.26;
+				MARKETING_VERSION = 2026.03.04;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest.IntelliWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1492,7 +1492,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = IntelliWidget/IntelliWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1506,7 +1506,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2026.02.26;
+				MARKETING_VERSION = 2026.03.04;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest.IntelliWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1524,7 +1524,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = IntelliWidget/IntelliWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1538,7 +1538,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2026.02.26;
+				MARKETING_VERSION = 2026.03.04;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest.IntelliWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1618,7 +1618,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "IntelliNest/Supporting Files/IntelliNest.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_ASSET_PATHS = "\"IntelliNest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1640,7 +1640,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.02.26;
+				MARKETING_VERSION = 2026.03.04;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1658,7 +1658,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1666,7 +1666,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.02.26;
+				MARKETING_VERSION = 2026.03.04;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/IntelliNest/ViewModels/HomeViewModel.swift
+++ b/IntelliNest/ViewModels/HomeViewModel.swift
@@ -271,5 +271,4 @@ class HomeViewModel: ObservableObject {
             return .unknown
         }
     }
-
 }

--- a/IntelliNestTests/TestHelpers.swift
+++ b/IntelliNestTests/TestHelpers.swift
@@ -1,5 +1,5 @@
-@testable import IntelliNest
 import Foundation
+@testable import IntelliNest
 
 func makeEntityJSON(entityId: String, state: String) -> Data {
     Data("""

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ IntelliNest is a native iOS application that leverages the power of the popular 
 ## Code statistics
 | Indicators                          | Now  | Desired |
 |-------------------------------------|------|---------|
-| Total LOC                           | 10350 | N/A |
-| Swift file count                    | 147 | N/A |
-| Average LOC per file                | 70 | <100 |
+| Total LOC                           | 11035 | N/A |
+| Swift file count                    | 150 | N/A |
+| Average LOC per file                | 73 | <100 |
 | TODO comment count                  | 0 | 0 |
 | FIX comment count                   | 0 | 0 |
 | unowned reference count             | 0 | 0 |
-| Commit count in main                | 116 | N/A |
-| Total deleted lines                 | 12663 | N/A |
-| Total added lines                   | 26230 | N/A |
+| Commit count in main                | 120 | N/A |
+| Total deleted lines                 | 12741 | N/A |
+| Total added lines                   | 27034 | N/A |
 
-Last Updated: 2026-02-26
+Last Updated: 2026-03-04
 ## Supported features
 ### Rest API and Websocket support
 Most views now use WebSocket instead of REST API for improved real-time updates.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` to guide Claude Code when working in this repo
- Documents build & test commands, high-level MVVM architecture, and service layer patterns
- Includes pre-commit instructions for SwiftFormat and SwiftLint matching the Xcode build phases
- Adds commit message style guidelines derived from the project history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump: updated from 2.0.26 to 2.0.3.04
  * Added development documentation and guidelines
  * Updated project statistics and metrics
  * Code cleanup and internal organization improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->