### PR TITLE
Improved fetch retry logic to fall back to external URL on GET failures

### DIFF
--- a/IntelliNest/Services/RestAPIService.swift
+++ b/IntelliNest/Services/RestAPIService.swift
@@ -51,23 +51,37 @@ class RestAPIService: URLRequestBuilder {
     }
 
     func reloadState(entityID: EntityId) async throws -> Entity {
-        guard let request = createURLRequest(path: "/api/states/\(entityID.rawValue)", method: .get) else {
+        let path = "/api/states/\(entityID.rawValue)"
+        guard let request = createURLRequest(path: path, method: .get) else {
             throw EntityError.badRequest
         }
 
-        let (data, response) = try await session.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EntityError.badResponse
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw EntityError.badResponse
+            }
+            guard httpResponse.statusCode == 200 else {
+                throw EntityError.httpRequestFailure
+            }
+            return try JSONDecoder().decode(Entity.self, from: data)
+        } catch {
+            let url = request.url?.absoluteString ?? ""
+            guard !url.contains(GlobalConstants.baseExternalUrlString) else {
+                throw error
+            }
+            guard let externalRequest = createURLRequest(shouldForceExternalURL: true, path: path, method: .get) else {
+                throw EntityError.badRequest
+            }
+            let (externalData, externalResponse) = try await session.data(for: externalRequest)
+            guard let httpResponse = externalResponse as? HTTPURLResponse else {
+                throw EntityError.badResponse
+            }
+            guard httpResponse.statusCode == 200 else {
+                throw EntityError.httpRequestFailure
+            }
+            return try JSONDecoder().decode(Entity.self, from: externalData)
         }
-
-        guard httpResponse.statusCode == 200 else {
-            throw EntityError.httpRequestFailure
-        }
-
-        let decoder = JSONDecoder()
-        let entity = try decoder.decode(Entity.self, from: data)
-        return entity
     }
 
     func reload<T: EntityProtocol>(hassEntity: T, entityType: T.Type) async -> T {
@@ -94,31 +108,37 @@ class RestAPIService: URLRequestBuilder {
 
     @MainActor
     func get<T: EntityProtocol>(entityId: EntityId, entityType: T.Type) async throws -> T {
-        guard let request = createURLRequest(path: "/api/states/\(entityId.rawValue)",
-                                             method: .get) else {
+        let path = "/api/states/\(entityId.rawValue)"
+        guard let request = createURLRequest(path: path, method: .get) else {
             throw EntityError.badRequest
         }
 
-        let (data, response) = try await session.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EntityError.badResponse
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw EntityError.badResponse
+            }
+            guard httpResponse.statusCode == 200 else {
+                throw EntityError.httpRequestFailure
+            }
+            return try JSONDecoder().decode(entityType.self, from: data)
+        } catch {
+            let url = request.url?.absoluteString ?? ""
+            guard !url.contains(GlobalConstants.baseExternalUrlString) else {
+                throw error
+            }
+            guard let externalRequest = createURLRequest(shouldForceExternalURL: true, path: path, method: .get) else {
+                throw EntityError.badRequest
+            }
+            let (externalData, externalResponse) = try await session.data(for: externalRequest)
+            guard let httpResponse = externalResponse as? HTTPURLResponse else {
+                throw EntityError.badResponse
+            }
+            guard httpResponse.statusCode == 200 else {
+                throw EntityError.httpRequestFailure
+            }
+            return try JSONDecoder().decode(entityType.self, from: externalData)
         }
-
-        /* Testing purposes
-         if entityId == .roborockMapImage {
-             if let string = String(data: data, encoding: .utf8) {
-                 print("TLA91: string = \(string)")
-             }
-         }
-          */
-
-        guard httpResponse.statusCode == 200 else {
-            throw EntityError.httpRequestFailure
-        }
-
-        let decoder = JSONDecoder()
-        return try decoder.decode(entityType.self, from: data)
     }
 
     // MARK: Post requests

--- a/IntelliNest/Services/URLCreator.swift
+++ b/IntelliNest/Services/URLCreator.swift
@@ -47,6 +47,7 @@ class URLCreator: ObservableObject, URLRequestBuilder {
             let ssid = await SSIDUtil.getCurrentSSID()
             if ssid == GlobalConstants.localSSID {
                 connectionState = .local
+                shouldRetryOnFailure = true
             } else {
                 retryWithExternalURL()
             }
@@ -75,6 +76,7 @@ class URLCreator: ObservableObject, URLRequestBuilder {
                 do {
                     _ = try await session.data(for: remoteRequest)
                     connectionState = .internet
+                    shouldRetryOnFailure = true
                 } catch {
                     connectionState = .disconnected
                     if shouldRetryOnFailure {
@@ -104,6 +106,7 @@ class URLCreator: ObservableObject, URLRequestBuilder {
             do {
                 _ = try await session.data(for: request)
                 connectionState = .local
+                shouldRetryOnFailure = true
             } catch {
                 retryWithExternalURL()
             }

--- a/IntelliNestTests/RestAPIServiceTests.swift
+++ b/IntelliNestTests/RestAPIServiceTests.swift
@@ -1,0 +1,105 @@
+@testable import IntelliNest
+import XCTest
+
+@MainActor
+class RestAPIServiceTests: XCTestCase {
+    var restAPIService: RestAPIService!
+    var urlCreator: URLCreator!
+
+    override func setUp() async throws {
+        URLProtocolStub.startInterceptingRequests()
+        let stubbedSession = URLProtocolStub.createStubbedURLSession()
+        urlCreator = URLCreator(session: stubbedSession)
+        urlCreator.connectionState = .local
+        restAPIService = RestAPIService(
+            urlCreator: urlCreator,
+            session: stubbedSession,
+            setErrorBannerText: { _, _ in },
+            repeatReloadAction: { _ in }
+        )
+    }
+
+    override func tearDown() async throws {
+        URLProtocolStub.stopInterceptingRequests()
+        restAPIService = nil
+        urlCreator = nil
+    }
+
+    // MARK: - Helpers
+
+    private func stubInternalEntityURL(entityID: EntityId, state: String) {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/states/\(entityID.rawValue)"
+        let url = components.url!
+        let data = makeEntityJSON(entityId: entityID.rawValue, state: state)
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: data, response: response, error: nil)
+    }
+
+    private func stubExternalEntityURL(entityID: EntityId, state: String) {
+        var components = URLComponents(string: GlobalConstants.baseExternalUrlString)!
+        components.path = "/api/states/\(entityID.rawValue)"
+        let url = components.url!
+        let data = makeEntityJSON(entityId: entityID.rawValue, state: state)
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: data, response: response, error: nil)
+    }
+
+    // MARK: - get<T>() tests
+
+    func testGetSucceedsWithLocalURL() async throws {
+        stubInternalEntityURL(entityID: .pulsePower, state: "1500")
+
+        let entity: Entity = try await restAPIService.get(entityId: .pulsePower, entityType: Entity.self)
+
+        XCTAssertEqual(entity.state, "1500")
+    }
+
+    func testGetFallsBackToExternalURLWhenLocalFails() async throws {
+        // Local URL has no stub — URLProtocolStub returns notConnectedToInternet by default
+        stubExternalEntityURL(entityID: .coffeeMachine, state: "on")
+
+        let entity: Entity = try await restAPIService.get(entityId: .coffeeMachine, entityType: Entity.self)
+
+        XCTAssertEqual(entity.state, "on")
+    }
+
+    func testGetThrowsWhenBothURLsFail() async {
+        // No stubs registered — both internal and external return notConnectedToInternet
+        do {
+            let _: Entity = try await restAPIService.get(entityId: .coffeeMachine, entityType: Entity.self)
+            XCTFail("Expected get() to throw when both URLs fail")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
+
+    // MARK: - reloadState() tests
+
+    func testReloadStateSucceedsWithLocalURL() async throws {
+        stubInternalEntityURL(entityID: .washerState, state: "run")
+
+        let entity = try await restAPIService.reloadState(entityID: .washerState)
+
+        XCTAssertEqual(entity.state, "run")
+    }
+
+    func testReloadStateFallsBackToExternalURLWhenLocalFails() async throws {
+        // Local URL has no stub — URLProtocolStub returns notConnectedToInternet by default
+        stubExternalEntityURL(entityID: .coffeeMachine, state: "off")
+
+        let entity = try await restAPIService.reloadState(entityID: .coffeeMachine)
+
+        XCTAssertEqual(entity.state, "off")
+    }
+
+    func testReloadStateThrowsWhenBothURLsFail() async {
+        // No stubs registered — both internal and external return notConnectedToInternet
+        do {
+            _ = try await restAPIService.reloadState(entityID: .coffeeMachine)
+            XCTFail("Expected reloadState() to throw when both URLs fail")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
+}


### PR DESCRIPTION
- Added external URL fallback to get<T>() and reloadState() in RestAPIService, matching the existing retry logic that was only present in sendPostRequest()
- Reset shouldRetryOnFailure to true in URLCreator whenever connection succeeds (SSID match, local HTTP check, or external HTTP check) so future disconnections can retry rather than being permanently suppressed after one failure
- Added RestAPIServiceTests covering the new fallback and throw-on-both-fail paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network request resilience with automatic fallback to external URLs when local requests fail.

* **Tests**
  * Added comprehensive test suite verifying request handling, retry behavior, and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->