### PR TITLE
Add music controller with Spotify search and speaker grouping

### DIFF
--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -51,6 +51,18 @@
 		F62750AB2A00EE8800C1253F /* ToolbarBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62750AA2A00EE8800C1253F /* ToolbarBackButton.swift */; };
 		F62750AF2A01123500C1253F /* ToolbarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62750AE2A01123500C1253F /* ToolbarItems.swift */; };
 		F62750B32A066B4500C1253F /* URLProtocolStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62750B22A066B4500C1253F /* URLProtocolStub.swift */; };
+		EE0000010000000000000001 /* MediaPlayerEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000010000000000000001 /* MediaPlayerEntity.swift */; };
+		EE0000020000000000000002 /* MusicSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000020000000000000002 /* MusicSearchResult.swift */; };
+		EE0000030000000000000003 /* RestAPIService+Music.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000030000000000000003 /* RestAPIService+Music.swift */; };
+		EE0000040000000000000004 /* MusicViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000040000000000000004 /* MusicViewModel.swift */; };
+		EE0000050000000000000005 /* MusicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000050000000000000005 /* MusicView.swift */; };
+		EE0000060000000000000006 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000060000000000000006 /* NowPlayingView.swift */; };
+		EE0000070000000000000007 /* AlbumArtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000070000000000000007 /* AlbumArtView.swift */; };
+		EE0000080000000000000008 /* SpeakerPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000080000000000000008 /* SpeakerPickerView.swift */; };
+		EE0000090000000000000009 /* SpeakerGroupingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000090000000000000009 /* SpeakerGroupingView.swift */; };
+		EE000010000000000000000A /* MusicSearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF000010000000000000000A /* MusicSearchResultsView.swift */; };
+		EE000011000000000000000B /* MusicViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF000011000000000000000B /* MusicViewModelTests.swift */; };
+		EE000012000000000000000C /* MusicModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF000012000000000000000C /* MusicModelTests.swift */; };
 		F62CD2E0286D950A00462092 /* LightEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62CD2DF286D950A00462092 /* LightEntity.swift */; };
 		F62CD2E328770D5500462092 /* LightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62CD2E228770D5500462092 /* LightsViewModel.swift */; };
 		F62CD2E528770F3B00462092 /* RestAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62CD2E428770F3B00462092 /* RestAPIService.swift */; };
@@ -265,6 +277,18 @@
 		F62750AE2A01123500C1253F /* ToolbarItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarItems.swift; sourceTree = "<group>"; };
 		F62750B22A066B4500C1253F /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
 		F62CD2DF286D950A00462092 /* LightEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightEntity.swift; sourceTree = "<group>"; };
+		EF0000010000000000000001 /* MediaPlayerEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerEntity.swift; sourceTree = "<group>"; };
+		EF0000020000000000000002 /* MusicSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSearchResult.swift; sourceTree = "<group>"; };
+		EF0000030000000000000003 /* RestAPIService+Music.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestAPIService+Music.swift"; sourceTree = "<group>"; };
+		EF0000040000000000000004 /* MusicViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModel.swift; sourceTree = "<group>"; };
+		EF0000050000000000000005 /* MusicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicView.swift; sourceTree = "<group>"; };
+		EF0000060000000000000006 /* NowPlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingView.swift; sourceTree = "<group>"; };
+		EF0000070000000000000007 /* AlbumArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumArtView.swift; sourceTree = "<group>"; };
+		EF0000080000000000000008 /* SpeakerPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerPickerView.swift; sourceTree = "<group>"; };
+		EF0000090000000000000009 /* SpeakerGroupingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerGroupingView.swift; sourceTree = "<group>"; };
+		EF000010000000000000000A /* MusicSearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSearchResultsView.swift; sourceTree = "<group>"; };
+		EF000011000000000000000B /* MusicViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelTests.swift; sourceTree = "<group>"; };
+		EF000012000000000000000C /* MusicModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicModelTests.swift; sourceTree = "<group>"; };
 		F62CD2E228770D5500462092 /* LightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightsViewModel.swift; sourceTree = "<group>"; };
 		F62CD2E428770F3B00462092 /* RestAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestAPIService.swift; sourceTree = "<group>"; };
 		F6CC110028770F3B00CC0001 /* RestAPIService+PostRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestAPIService+PostRequest.swift"; sourceTree = "<group>"; };
@@ -471,6 +495,8 @@
 				8D7AA547F46C2F6F2C2DC77A /* PurifierSpeed.swift */,
 				386D85613C7069D1CC652E21 /* RoborockImageEntity.swift */,
 				B126D511CCFBA5E7EF7F80F9 /* HomeLocationEntity.swift */,
+				EF0000010000000000000001 /* MediaPlayerEntity.swift */,
+				EF0000020000000000000002 /* MusicSearchResult.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -485,6 +511,7 @@
 				F62CD2E92877275400462092 /* Light */,
 				F6633F2A286324DE004D0B76 /* Heater */,
 				F6633F3B28632BF1004D0B76 /* Roborock */,
+				EFA000000000000000000000 /* Music */,
 				F6D167C827C1282500DCC155 /* Labels */,
 				F60345C727A9378300212D04 /* Dashboards */,
 			);
@@ -509,6 +536,7 @@
 			children = (
 				F62CD2E428770F3B00462092 /* RestAPIService.swift */,
 				F6CC110028770F3B00CC0001 /* RestAPIService+PostRequest.swift */,
+				EF0000030000000000000003 /* RestAPIService+Music.swift */,
 				F6FDBE2C2A1A2F970081BC3D /* URLRequestBuilder.swift */,
 				F60345CB27A93BD700212D04 /* URLCreator.swift */,
 				F64D2693283E8FAB0073A7BF /* NetworkTask.swift */,
@@ -553,6 +581,8 @@
 			AA0000008000000000000008 /* DoubleExtensionTests.swift */,
 			AA000000A00000000000000A /* StringExtensionTests.swift */,
 			AA000000C00000000000000C /* HeaterEntityTests.swift */,
+				EF000011000000000000000B /* MusicViewModelTests.swift */,
+				EF000012000000000000000C /* MusicModelTests.swift */,
 			);
 			path = IntelliNestTests;
 			sourceTree = "<group>";
@@ -582,6 +612,7 @@
 				F66E28AD2A34FBDE0003EC70 /* VLCMediaplayerMock.swift */,
 				F685F8002B2B153C008E47AF /* ElectricityViewModel.swift */,
 				D89BCA06BE3A45F2A8E3DAE4 /* LynkViewModelHelpers.swift */,
+				EF0000040000000000000004 /* MusicViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -672,6 +703,19 @@
 				F6633F4628633122004D0B76 /* RoborockMainButtons.swift */,
 			);
 			path = Roborock;
+			sourceTree = "<group>";
+		};
+		EFA000000000000000000000 /* Music */ = {
+			isa = PBXGroup;
+			children = (
+				EF0000050000000000000005 /* MusicView.swift */,
+				EF0000060000000000000006 /* NowPlayingView.swift */,
+				EF0000070000000000000007 /* AlbumArtView.swift */,
+				EF0000080000000000000008 /* SpeakerPickerView.swift */,
+				EF0000090000000000000009 /* SpeakerGroupingView.swift */,
+				EF000010000000000000000A /* MusicSearchResultsView.swift */,
+			);
+			path = Music;
 			sourceTree = "<group>";
 		};
 		F67023EE27A177320070FFBB = {
@@ -1185,6 +1229,16 @@
 				F6F94B5E28B60DED006B1F12 /* LynkViewModel.swift in Sources */,
 				F6EF35AF2A3A33BE00895250 /* DateTimePickerView.swift in Sources */,
 				F62CD2E328770D5500462092 /* LightsViewModel.swift in Sources */,
+				EE0000010000000000000001 /* MediaPlayerEntity.swift in Sources */,
+				EE0000020000000000000002 /* MusicSearchResult.swift in Sources */,
+				EE0000030000000000000003 /* RestAPIService+Music.swift in Sources */,
+				EE0000040000000000000004 /* MusicViewModel.swift in Sources */,
+				EE0000050000000000000005 /* MusicView.swift in Sources */,
+				EE0000060000000000000006 /* NowPlayingView.swift in Sources */,
+				EE0000070000000000000007 /* AlbumArtView.swift in Sources */,
+				EE0000080000000000000008 /* SpeakerPickerView.swift in Sources */,
+				EE0000090000000000000009 /* SpeakerGroupingView.swift in Sources */,
+				EE000010000000000000000A /* MusicSearchResultsView.swift in Sources */,
 				CD215FD8D5AD91EE27DAAB00 /* FuelView.swift in Sources */,
 				3D1653ABAE6D49DB4CCAC158 /* PurifierView.swift in Sources */,
 				65450E96A215D8CB2443B2D6 /* INText.swift in Sources */,
@@ -1213,6 +1267,8 @@
 			BB0000001000000000000001 /* HeatersViewModelTests.swift in Sources */,
 			DD0000001000000000000001 /* LynkViewModelTests.swift in Sources */,
 			DD0000003000000000000003 /* RoborockViewModelTests.swift in Sources */,
+				EE000011000000000000000B /* MusicViewModelTests.swift in Sources */,
+				EE000012000000000000000C /* MusicModelTests.swift in Sources */,
 			BB0000003000000000000003 /* LightsViewModelTests.swift in Sources */,
 			BB0000005000000000000005 /* RoborockEntityTests.swift in Sources */,
 			BB0000007000000000000007 /* LockableTests.swift in Sources */,

--- a/IntelliNest/Model/MediaPlayerEntity.swift
+++ b/IntelliNest/Model/MediaPlayerEntity.swift
@@ -1,0 +1,117 @@
+//
+//  MediaPlayerEntity.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import Foundation
+
+enum MediaRepeatMode: String, Decodable {
+    case off
+    case all
+    case one
+}
+
+/// A Music Assistant `media_player.*` entity. Decodes the playback attributes
+/// the music controller needs: now-playing metadata, volume, shuffle/repeat,
+/// and the current group members.
+struct MediaPlayerEntity: EntityProtocol, Decodable {
+    var entityId: EntityId
+    var state: String
+    var nextUpdate = Date().addingTimeInterval(-1)
+
+    var friendlyName: String
+    var volumeLevel: Double
+    var mediaTitle: String?
+    var mediaArtist: String?
+    var mediaAlbumName: String?
+    var mediaContentID: String?
+    var entityPicture: String?
+    var groupMembers: [EntityId]
+    var shuffle: Bool
+    var repeatMode: MediaRepeatMode
+
+    var isActive: Bool {
+        state == "playing"
+    }
+
+    var isPlaying: Bool {
+        state == "playing"
+    }
+
+    var isUnavailable: Bool {
+        state == "unavailable"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case entityId = "entity_id"
+        case state
+        case attributes
+    }
+
+    private enum AttributesCodingKeys: String, CodingKey {
+        case friendlyName = "friendly_name"
+        case volumeLevel = "volume_level"
+        case mediaTitle = "media_title"
+        case mediaArtist = "media_artist"
+        case mediaAlbumName = "media_album_name"
+        case mediaContentID = "media_content_id"
+        case entityPicture = "entity_picture"
+        case groupMembers = "group_members"
+        case shuffle
+        case repeatMode = "repeat"
+    }
+
+    init(entityId: EntityId, state: String = "Loading", friendlyName: String = "") {
+        self.entityId = entityId
+        self.state = state
+        self.friendlyName = friendlyName
+        volumeLevel = 0
+        groupMembers = []
+        shuffle = false
+        repeatMode = .off
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        entityId = try container.decode(EntityId.self, forKey: .entityId)
+        state = try container.decode(String.self, forKey: .state)
+
+        if let attributes = try? container.nestedContainer(keyedBy: AttributesCodingKeys.self, forKey: .attributes) {
+            friendlyName = try attributes.decodeIfPresent(String.self, forKey: .friendlyName) ?? ""
+            volumeLevel = try attributes.decodeIfPresent(Double.self, forKey: .volumeLevel) ?? 0
+            mediaTitle = try attributes.decodeIfPresent(String.self, forKey: .mediaTitle)
+            mediaArtist = try attributes.decodeIfPresent(String.self, forKey: .mediaArtist)
+            mediaAlbumName = try attributes.decodeIfPresent(String.self, forKey: .mediaAlbumName)
+            mediaContentID = try attributes.decodeIfPresent(String.self, forKey: .mediaContentID)
+            entityPicture = try attributes.decodeIfPresent(String.self, forKey: .entityPicture)
+            let memberStrings = try attributes.decodeIfPresent([String].self, forKey: .groupMembers) ?? []
+            groupMembers = memberStrings.compactMap { EntityId(rawValue: $0) }
+            shuffle = try attributes.decodeIfPresent(Bool.self, forKey: .shuffle) ?? false
+            repeatMode = try attributes.decodeIfPresent(MediaRepeatMode.self, forKey: .repeatMode) ?? .off
+        } else {
+            friendlyName = ""
+            volumeLevel = 0
+            groupMembers = []
+            shuffle = false
+            repeatMode = .off
+        }
+    }
+
+    mutating func setNextUpdateTime() {
+        nextUpdate = Date().addingTimeInterval(0.5)
+    }
+
+    static func == (lhs: MediaPlayerEntity, rhs: MediaPlayerEntity) -> Bool {
+        lhs.entityId == rhs.entityId &&
+            lhs.state == rhs.state &&
+            lhs.volumeLevel == rhs.volumeLevel &&
+            lhs.mediaTitle == rhs.mediaTitle &&
+            lhs.mediaArtist == rhs.mediaArtist &&
+            lhs.mediaContentID == rhs.mediaContentID &&
+            lhs.groupMembers == rhs.groupMembers &&
+            lhs.shuffle == rhs.shuffle &&
+            lhs.repeatMode == rhs.repeatMode
+    }
+}

--- a/IntelliNest/Model/MusicSearchResult.swift
+++ b/IntelliNest/Model/MusicSearchResult.swift
@@ -1,0 +1,122 @@
+//
+//  MusicSearchResult.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import Foundation
+
+/// The four media types Music Assistant search returns, in display order.
+enum MusicMediaType: String, CaseIterable, Decodable {
+    case track
+    case album
+    case artist
+    case playlist
+
+    /// Swedish section heading for grouped search results.
+    var swedishTitle: String {
+        switch self {
+        case .track:
+            "Låtar"
+        case .album:
+            "Album"
+        case .artist:
+            "Artister"
+        case .playlist:
+            "Spellistor"
+        }
+    }
+}
+
+/// A single Music Assistant search result item. `uri` is the playable media id
+/// (e.g. `spotify://track/3SjXx3rbNGk8nCho8YEoz5`).
+struct MusicSearchItem: Identifiable, Equatable {
+    let uri: String
+    let name: String
+    let mediaType: MusicMediaType
+    let imageURL: String?
+    let artist: String?
+
+    var id: String { uri }
+}
+
+/// Results for one media type, used to render grouped sections.
+struct MusicSearchSection: Identifiable, Equatable {
+    let mediaType: MusicMediaType
+    let items: [MusicSearchItem]
+
+    var id: String { mediaType.rawValue }
+}
+
+/// Decodes the `music_assistant.search` `return_response` body. The response
+/// is a JSON object whose top-level keys are pluralised media types
+/// (`tracks`, `albums`, `artists`, `playlists`), each an array of items. Each
+/// item carries a `uri`, `name`, optional `image`, and `artists` metadata.
+struct MusicSearchResponse: Decodable {
+    let sections: [MusicSearchSection]
+
+    private struct RawItem: Decodable {
+        let uri: String?
+        let name: String?
+        let image: String?
+        let artists: [RawArtist]?
+
+        private enum CodingKeys: String, CodingKey {
+            case uri
+            case name
+            case image
+            case mediaImage = "media_image"
+            case artists
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            uri = try container.decodeIfPresent(String.self, forKey: .uri)
+            name = try container.decodeIfPresent(String.self, forKey: .name)
+            image = try container.decodeIfPresent(String.self, forKey: .image)
+                ?? container.decodeIfPresent(String.self, forKey: .mediaImage)
+            artists = try container.decodeIfPresent([RawArtist].self, forKey: .artists)
+        }
+    }
+
+    private struct RawArtist: Decodable {
+        let name: String?
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case tracks
+        case albums
+        case artists
+        case playlists
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawByType: [(MusicMediaType, CodingKeys)] = [
+            (.track, .tracks),
+            (.album, .albums),
+            (.artist, .artists),
+            (.playlist, .playlists)
+        ]
+
+        var builtSections: [MusicSearchSection] = []
+        for (mediaType, key) in rawByType {
+            let rawItems = try container.decodeIfPresent([RawItem].self, forKey: key) ?? []
+            let items: [MusicSearchItem] = rawItems.compactMap { rawItem in
+                guard let uri = rawItem.uri, let name = rawItem.name else {
+                    return nil
+                }
+                return MusicSearchItem(uri: uri,
+                                       name: name,
+                                       mediaType: mediaType,
+                                       imageURL: rawItem.image,
+                                       artist: rawItem.artists?.first?.name)
+            }
+            if items.isNotEmpty {
+                builtSections.append(MusicSearchSection(mediaType: mediaType, items: items))
+            }
+        }
+        sections = builtSections
+    }
+}

--- a/IntelliNest/Navigation/Destination.swift
+++ b/IntelliNest/Navigation/Destination.swift
@@ -16,6 +16,7 @@ enum Destination: String {
     case playroomHeaterDetails
     case roborock
     case lights
+    case music
 
     var title: String {
         switch self {
@@ -35,6 +36,8 @@ enum Destination: String {
             "Roborock"
         case .lights:
             "Lampor"
+        case .music:
+            "Musik"
         }
     }
 }

--- a/IntelliNest/Navigation/Navigator.swift
+++ b/IntelliNest/Navigation/Navigator.swift
@@ -87,6 +87,9 @@ class Navigator: ObservableObject {
                                            showLightsAction: { [weak self] in
                                                self?.push(.lights)
                                            },
+                                           showMusicAction: { [weak self] in
+                                               self?.push(.music)
+                                           },
                                            toolbarReloadAction: toolbarReload)
     lazy var electricityViewModel = ElectricityViewModel(restAPIService: restAPIService)
     lazy var heatersViewModel = HeatersViewModel(restAPIService: restAPIService,
@@ -100,6 +103,10 @@ class Navigator: ObservableObject {
     lazy var lynkViewModel = LynkViewModel(restAPIService: restAPIService)
     lazy var roborockViewModel = RoborockViewModel(restAPIService: restAPIService)
     lazy var lightsViewModel = LightsViewModel(restAPIService: restAPIService)
+    lazy var musicViewModel = MusicViewModel(restAPIService: restAPIService,
+                                             setErrorBannerText: { [weak self] title, message in
+                                                 self?.setErrorBannerText(title: title, message: message)
+                                             })
 
     init() {
         WidgetCenter.shared.reloadAllTimelines()
@@ -150,6 +157,8 @@ class Navigator: ObservableObject {
             await lightsViewModel.reload()
         case .roborock:
             await roborockViewModel.reload()
+        case .music:
+            await musicViewModel.reload()
         }
     }
 

--- a/IntelliNest/Navigation/NavigatorHelpers.swift
+++ b/IntelliNest/Navigation/NavigatorHelpers.swift
@@ -24,6 +24,8 @@ extension Navigator {
                 showRoborockView()
             case .lights:
                 showLightsView()
+            case .music:
+                showMusicView()
             }
         }
         .backgroundModifier()
@@ -73,5 +75,9 @@ extension Navigator {
 
     func showLightsView() -> LightsView {
         LightsView(viewModel: lightsViewModel)
+    }
+
+    func showMusicView() -> MusicView {
+        MusicView(viewModel: musicViewModel)
     }
 }

--- a/IntelliNest/Services/RestAPIService+Music.swift
+++ b/IntelliNest/Services/RestAPIService+Music.swift
@@ -1,0 +1,162 @@
+//
+//  RestAPIService+Music.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import Foundation
+import ShipBookSDK
+
+extension RestAPIService {
+    /// Calls `music_assistant.search` with `?return_response` and decodes the
+    /// grouped result body. Music Assistant search is the only service in the
+    /// app that returns a response body, so it gets a dedicated POST path that
+    /// reads the JSON back instead of going through `sendPostRequest` (which
+    /// discards bodies).
+    func searchMusic(query: String, limit: Int = 10) async throws -> MusicSearchResponse {
+        let path = "/api/services/\(Domain.musicAssistant.rawValue)/\(Action.search.rawValue)"
+        let queryParams = ["return_response": "true"]
+        var json = [JSONKey: Any]()
+        json[.configEntryID] = GlobalConstants.musicAssistantConfigEntryID
+        json[.name] = query
+        json[.mediaType] = MusicMediaType.allCases.map(\.rawValue)
+        json[.limit] = limit
+        let jsonData = createJSONData(json: json)
+
+        guard let request = createURLRequest(path: path, jsonData: jsonData, queryParams: queryParams, method: .post) else {
+            throw EntityError.badRequest
+        }
+
+        let (statusCode, data) = await sendRequest(request)
+        if statusCode == statusCodeOK, let data {
+            return try decodeSearchResponse(from: data)
+        }
+
+        let url = request.url?.absoluteString ?? ""
+        guard !url.contains(GlobalConstants.baseExternalUrlString) else {
+            throw EntityError.httpRequestFailure
+        }
+        guard let externalRequest = createURLRequest(shouldForceExternalURL: true,
+                                                     path: path,
+                                                     jsonData: jsonData,
+                                                     queryParams: queryParams,
+                                                     method: .post) else {
+            throw EntityError.badRequest
+        }
+        let (externalStatusCode, externalData) = await sendRequest(externalRequest)
+        guard externalStatusCode == statusCodeOK, let externalData else {
+            throw EntityError.httpRequestFailure
+        }
+        return try decodeSearchResponse(from: externalData)
+    }
+
+    /// The service envelope wraps the actual result under `service_response`.
+    /// Decode that wrapper when present, otherwise decode the body directly.
+    private func decodeSearchResponse(from data: Data) throws -> MusicSearchResponse {
+        let decoder = JSONDecoder()
+        if let wrapper = try? decoder.decode(MusicSearchServiceResponse.self, from: data) {
+            return wrapper.serviceResponse
+        }
+        return try decoder.decode(MusicSearchResponse.self, from: data)
+    }
+
+    /// Replaces the active speaker's queue and starts playback of `mediaID`
+    /// (a `spotify://…` uri). Returns whether the request succeeded so the
+    /// caller can surface a failure instead of showing a false playing state.
+    @discardableResult
+    func playMedia(on entityID: EntityId, mediaID: String, mediaType: MusicMediaType) async -> Bool {
+        var json = [JSONKey: Any]()
+        json[.entityID] = entityID.rawValue
+        json[.mediaID] = mediaID
+        json[.mediaType] = mediaType.rawValue
+        json[.enqueue] = "replace"
+        return await sendMusicPostExpectingSuccess(domain: .musicAssistant, action: .playMedia, json: json)
+    }
+
+    func mediaTransport(entityID: EntityId, action: Action, reloadTimes: Int = 2) {
+        update(entityID: entityID, domain: .mediaPlayer, action: action, reloadTimes: reloadTimes)
+    }
+
+    func setVolume(entityID: EntityId, volume: Double, reloadTimes: Int = 1) {
+        update(entityID: entityID,
+               domain: .mediaPlayer,
+               action: .volumeSet,
+               dataKey: .volumeLevel,
+               dataValue: volume,
+               reloadTimes: reloadTimes)
+    }
+
+    func setShuffle(entityID: EntityId, shuffle: Bool, reloadTimes: Int = 2) {
+        Task {
+            var json = [JSONKey: Any]()
+            json[.entityID] = entityID.rawValue
+            json[.shuffle] = shuffle
+            await sendPostRequest(json: json, domain: .mediaPlayer, action: .shuffleSet)
+            triggerRepeatReload(times: reloadTimes)
+        }
+    }
+
+    func setRepeat(entityID: EntityId, repeatMode: MediaRepeatMode, reloadTimes: Int = 2) {
+        update(entityID: entityID,
+               domain: .mediaPlayer,
+               action: .repeatSet,
+               dataKey: .repeatMode,
+               dataValue: repeatMode.rawValue,
+               reloadTimes: reloadTimes)
+    }
+
+    /// Adds `memberIDs` into the group led by `leaderID`.
+    func joinSpeakers(leaderID: EntityId, memberIDs: [EntityId], reloadTimes: Int = 3) {
+        Task {
+            var json = [JSONKey: Any]()
+            json[.entityID] = leaderID.rawValue
+            json[.groupMembers] = memberIDs.map(\.rawValue)
+            await sendPostRequest(json: json, domain: .mediaPlayer, action: .join)
+            triggerRepeatReload(times: reloadTimes)
+        }
+    }
+
+    /// Removes `memberID` from whatever group it is currently in.
+    func unjoinSpeaker(memberID: EntityId, reloadTimes: Int = 3) {
+        Task {
+            var json = [JSONKey: Any]()
+            json[.entityID] = memberID.rawValue
+            await sendPostRequest(json: json, domain: .mediaPlayer, action: .unjoin)
+            triggerRepeatReload(times: reloadTimes)
+        }
+    }
+
+    private func sendMusicPostExpectingSuccess(domain: Domain, action: Action, json: [JSONKey: Any]) async -> Bool {
+        let path = "/api/services/\(domain.rawValue)/\(action.rawValue)"
+        let jsonData = createJSONData(json: json)
+        guard let request = createURLRequest(path: path, jsonData: jsonData, method: .post) else {
+            return false
+        }
+
+        let (statusCode, _) = await sendRequest(request)
+        if statusCode == statusCodeOK {
+            return true
+        }
+
+        let url = request.url?.absoluteString ?? ""
+        guard !url.contains(GlobalConstants.baseExternalUrlString),
+              let externalRequest = createURLRequest(shouldForceExternalURL: true,
+                                                     path: path,
+                                                     jsonData: jsonData,
+                                                     method: .post) else {
+            return false
+        }
+        let (externalStatusCode, _) = await sendRequest(externalRequest)
+        return externalStatusCode == statusCodeOK
+    }
+}
+
+/// Wrapper for the Home Assistant service-call response envelope.
+private struct MusicSearchServiceResponse: Decodable {
+    let serviceResponse: MusicSearchResponse
+
+    enum CodingKeys: String, CodingKey {
+        case serviceResponse = "service_response"
+    }
+}

--- a/IntelliNest/Services/RestAPIService.swift
+++ b/IntelliNest/Services/RestAPIService.swift
@@ -287,6 +287,10 @@ class RestAPIService: URLRequestBuilder {
         repeatReloadAction(reloadTimes)
     }
 
+    func triggerRepeatReload(times: Int) {
+        repeatReloadAction(times)
+    }
+
     func sendRequest(_ request: URLRequest) async -> (Int, Data?) {
         do {
             let (data, response) = try await session.data(for: request)

--- a/IntelliNest/Utils/Constants/Actions.swift
+++ b/IntelliNest/Utils/Constants/Actions.swift
@@ -41,4 +41,16 @@ enum Action: String, Codable {
     case setPercentage = "set_percentage"
     case setHvacMode = "set_hvac_mode"
     case updateEntity = "update_entity"
+    /* Music Assistant / media_player */
+    case search
+    case playMedia = "play_media"
+    case mediaPlay = "media_play"
+    case mediaPause = "media_pause"
+    case mediaNextTrack = "media_next_track"
+    case mediaPreviousTrack = "media_previous_track"
+    case volumeSet = "volume_set"
+    case shuffleSet = "shuffle_set"
+    case repeatSet = "repeat_set"
+    case join
+    case unjoin
 }

--- a/IntelliNest/Utils/Constants/Domain.swift
+++ b/IntelliNest/Utils/Constants/Domain.swift
@@ -28,5 +28,7 @@ enum Domain: String, Encodable {
     case binarySensor = "binary_sensor"
     case kiaUvo = "kia_uvo"
     case vacuum
+    case mediaPlayer = "media_player"
+    case musicAssistant = "music_assistant"
     case unknown
 }

--- a/IntelliNest/Utils/Constants/EntityId.swift
+++ b/IntelliNest/Utils/Constants/EntityId.swift
@@ -142,6 +142,14 @@ enum EntityId: String, Decodable, CaseIterable {
     case cameraCarport = "camera.carporten_frigate"
     case cameraBack = "camera.baksidan_frigate"
 
+    /* Music Assistant speakers */
+    case mediaPlayerKitchen = "media_player.kitchen"
+    case mediaPlayerGuestRoom = "media_player.gastrummet"
+    case mediaPlayerPlayroom = "media_player.lekrummet"
+    case mediaPlayerLivingRoom = "media_player.vardagsrummet"
+    case mediaPlayerOutdoorTable = "media_player.matbord_ute"
+    case mediaPlayerSpa = "media_player.spa"
+
     /* Yale Access token */
     case yaleAccessTokenPart1 = "input_text.yale_access_token_part1"
     case yaleAccessTokenPart2 = "input_text.yale_access_token_part2"

--- a/IntelliNest/Utils/Constants/GlobalConstants.swift
+++ b/IntelliNest/Utils/Constants/GlobalConstants.swift
@@ -90,6 +90,7 @@ enum GlobalConstants {
         return ""
     }
 
+    static let musicAssistantConfigEntryID = "01JZ57QTQPB79NSC7GJ2VQPA8V"
     static let baseInternalUrlString = "http://192.168.1.205:8123/"
     static let githubFakeUrlString = "https://192.218.223.123/"
     static var shouldUseLocalSSID: Bool {

--- a/IntelliNest/Utils/Constants/JSONKey.swift
+++ b/IntelliNest/Utils/Constants/JSONKey.swift
@@ -48,4 +48,15 @@ enum JSONKey: String, Equatable, Codable, Hashable {
     case value
     case vin
     case watt
+    /* Music Assistant / media_player */
+    case configEntryID = "config_entry_id"
+    case name
+    case mediaType = "media_type"
+    case limit
+    case mediaID = "media_id"
+    case enqueue
+    case volumeLevel = "volume_level"
+    case shuffle
+    case repeatMode = "repeat"
+    case groupMembers = "group_members"
 }

--- a/IntelliNest/ViewModels/HomeViewModel.swift
+++ b/IntelliNest/ViewModels/HomeViewModel.swift
@@ -68,6 +68,7 @@ class HomeViewModel: ObservableObject, Reloadable {
     let showRoborockAction: MainActorVoidClosure
     let showPowerGridAction: MainActorVoidClosure
     let showLightsAction: MainActorVoidClosure
+    let showMusicAction: MainActorVoidClosure
     private(set) var toolbarReloadAction: MainActorAsyncVoidClosure
 
     init(restAPIService: RestAPIService,
@@ -78,6 +79,7 @@ class HomeViewModel: ObservableObject, Reloadable {
          showRoborockAction: @escaping MainActorVoidClosure,
          showPowerGridAction: @escaping MainActorVoidClosure,
          showLightsAction: @escaping MainActorVoidClosure,
+         showMusicAction: @escaping MainActorVoidClosure,
          toolbarReloadAction: @escaping MainActorAsyncVoidClosure) {
         self.restAPIService = restAPIService
         self.yaleApiService = yaleApiService
@@ -87,6 +89,7 @@ class HomeViewModel: ObservableObject, Reloadable {
         self.showRoborockAction = showRoborockAction
         self.showPowerGridAction = showPowerGridAction
         self.showLightsAction = showLightsAction
+        self.showMusicAction = showMusicAction
         self.toolbarReloadAction = toolbarReloadAction
     }
 

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -1,0 +1,235 @@
+//
+//  MusicViewModel.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import Foundation
+import ShipBookSDK
+
+@MainActor
+class MusicViewModel: ObservableObject, Reloadable {
+    /// The six controllable Music Assistant speakers, in display order.
+    static let speakerIDs: [EntityId] = [
+        .mediaPlayerKitchen,
+        .mediaPlayerGuestRoom,
+        .mediaPlayerPlayroom,
+        .mediaPlayerLivingRoom,
+        .mediaPlayerOutdoorTable,
+        .mediaPlayerSpa
+    ]
+
+    @Published var speakers: [EntityId: MediaPlayerEntity]
+    @Published var activeSpeakerID: EntityId?
+    @Published var searchText = ""
+    @Published var searchSections: [MusicSearchSection] = []
+    @Published var hasSearched = false
+    @Published var isSearching = false
+
+    var isReloading = false
+    private var hasSelectedDefaultSpeaker = false
+
+    private let restAPIService: RestAPIService
+    private let setErrorBannerText: StringStringClosure
+
+    /// Speakers that are reachable right now (anything not `unavailable`),
+    /// in the fixed display order.
+    var availableSpeakers: [MediaPlayerEntity] {
+        Self.speakerIDs.compactMap { speakers[$0] }.filter { !$0.isUnavailable }
+    }
+
+    var activeSpeaker: MediaPlayerEntity? {
+        guard let activeSpeakerID else {
+            return nil
+        }
+        return speakers[activeSpeakerID]
+    }
+
+    init(restAPIService: RestAPIService, setErrorBannerText: @escaping StringStringClosure = { _, _ in }) {
+        self.restAPIService = restAPIService
+        self.setErrorBannerText = setErrorBannerText
+        var initialSpeakers: [EntityId: MediaPlayerEntity] = [:]
+        for speakerID in Self.speakerIDs {
+            initialSpeakers[speakerID] = MediaPlayerEntity(entityId: speakerID)
+        }
+        speakers = initialSpeakers
+    }
+
+    func reload() async {
+        await withReloadGuard {
+            let service = self.restAPIService
+            await withTaskGroup(of: (EntityId, MediaPlayerEntity)?.self) { group in
+                for speakerID in Self.speakerIDs {
+                    group.addTask {
+                        do {
+                            let speaker = try await service.reload(entityId: speakerID, entityType: MediaPlayerEntity.self)
+                            return (speakerID, speaker)
+                        } catch {
+                            Log.error("Failed to reload speaker: \(speakerID): \(error)")
+                            return nil
+                        }
+                    }
+                }
+
+                for await result in group {
+                    if let (speakerID, speaker) = result {
+                        self.speakers[speakerID] = speaker
+                    }
+                }
+            }
+
+            self.selectDefaultSpeakerIfNeeded()
+            self.dropActiveSpeakerIfUnavailable()
+        }
+    }
+
+    /// On the first reload after the view appears, default the active speaker to
+    /// whatever is currently playing. If nothing is playing, leave it unselected
+    /// so the picker is shown. Runs only once so it never overrides a manual pick.
+    private func selectDefaultSpeakerIfNeeded() {
+        guard !hasSelectedDefaultSpeaker else {
+            return
+        }
+        hasSelectedDefaultSpeaker = true
+        if let playing = availableSpeakers.first(where: { $0.isPlaying }) {
+            activeSpeakerID = playing.entityId
+        }
+    }
+
+    private func dropActiveSpeakerIfUnavailable() {
+        if let activeSpeakerID, speakers[activeSpeakerID]?.isUnavailable == true {
+            self.activeSpeakerID = nil
+        }
+    }
+
+    func selectSpeaker(_ entityID: EntityId) {
+        activeSpeakerID = entityID
+    }
+
+    // MARK: - Search
+
+    func search() async {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard query.isNotEmpty else {
+            searchSections = []
+            hasSearched = false
+            return
+        }
+
+        isSearching = true
+        hasSearched = true
+        do {
+            let response = try await restAPIService.searchMusic(query: query)
+            searchSections = response.sections
+        } catch {
+            Log.error("Music search failed: \(error)")
+            searchSections = []
+            setErrorBannerText("Sökningen misslyckades", "Kunde inte söka efter musik")
+        }
+        isSearching = false
+    }
+
+    var hasNoResults: Bool {
+        hasSearched && !isSearching && searchSections.isEmpty
+    }
+
+    // MARK: - Playback
+
+    func play(item: MusicSearchItem) async {
+        guard let activeSpeakerID else {
+            setErrorBannerText("Ingen högtalare vald", "Välj en högtalare innan du spelar musik")
+            return
+        }
+
+        let success = await restAPIService.playMedia(on: activeSpeakerID,
+                                                     mediaID: item.uri,
+                                                     mediaType: item.mediaType)
+        if success {
+            // Optimistically reflect what we just started; a reload confirms it.
+            speakers[activeSpeakerID]?.state = "playing"
+            speakers[activeSpeakerID]?.mediaTitle = item.name
+            speakers[activeSpeakerID]?.mediaArtist = item.artist
+            restAPIService.triggerRepeatReload(times: 3)
+        } else {
+            setErrorBannerText("Kunde inte spela", "Det gick inte att starta uppspelningen")
+        }
+    }
+
+    func togglePlayPause() {
+        guard let activeSpeaker else {
+            return
+        }
+        let action: Action = activeSpeaker.isPlaying ? .mediaPause : .mediaPlay
+        speakers[activeSpeaker.entityId]?.state = activeSpeaker.isPlaying ? "paused" : "playing"
+        restAPIService.mediaTransport(entityID: activeSpeaker.entityId, action: action)
+    }
+
+    func nextTrack() {
+        guard let activeSpeakerID else {
+            return
+        }
+        restAPIService.mediaTransport(entityID: activeSpeakerID, action: .mediaNextTrack)
+    }
+
+    func previousTrack() {
+        guard let activeSpeakerID else {
+            return
+        }
+        restAPIService.mediaTransport(entityID: activeSpeakerID, action: .mediaPreviousTrack)
+    }
+
+    func setVolume(_ volume: Double) {
+        guard let activeSpeakerID else {
+            return
+        }
+        speakers[activeSpeakerID]?.volumeLevel = volume
+        restAPIService.setVolume(entityID: activeSpeakerID, volume: volume)
+    }
+
+    func toggleShuffle() {
+        guard let activeSpeaker else {
+            return
+        }
+        let newValue = !activeSpeaker.shuffle
+        speakers[activeSpeaker.entityId]?.shuffle = newValue
+        restAPIService.setShuffle(entityID: activeSpeaker.entityId, shuffle: newValue)
+    }
+
+    func toggleRepeat() {
+        guard let activeSpeaker else {
+            return
+        }
+        // Cycle off → all → one → off, matching the Sonos-style three-state control.
+        let newMode: MediaRepeatMode = switch activeSpeaker.repeatMode {
+        case .off: .all
+        case .all: .one
+        case .one: .off
+        }
+        speakers[activeSpeaker.entityId]?.repeatMode = newMode
+        restAPIService.setRepeat(entityID: activeSpeaker.entityId, repeatMode: newMode)
+    }
+
+    // MARK: - Grouping
+
+    /// Whether `speakerID` is currently grouped with the active speaker.
+    func isGrouped(_ speakerID: EntityId) -> Bool {
+        guard let activeSpeaker, speakerID != activeSpeaker.entityId else {
+            return false
+        }
+        return activeSpeaker.groupMembers.contains(speakerID)
+    }
+
+    /// Toggles `speakerID` into or out of the active speaker's group. The active
+    /// speaker stays the group leader (the `join` sync source).
+    func toggleGroupMember(_ speakerID: EntityId) {
+        guard let activeSpeakerID, speakerID != activeSpeakerID else {
+            return
+        }
+        if isGrouped(speakerID) {
+            restAPIService.unjoinSpeaker(memberID: speakerID)
+        } else {
+            restAPIService.joinSpeakers(leaderID: activeSpeakerID, memberIDs: [speakerID])
+        }
+    }
+}

--- a/IntelliNest/Views/Dashboards/HomeView.swift
+++ b/IntelliNest/Views/Dashboards/HomeView.swift
@@ -118,6 +118,13 @@ private struct NavigationButtonsView: View {
                                      buttonImageHeight: 50,
                                      action: viewModel.showRoborockAction)
             }
+            HStack(spacing: 15) {
+                NavigationButtonView(buttonTitle: "Musik",
+                                     image: Image(systemName: "music.note"),
+                                     buttonImageWidth: 30,
+                                     buttonImageHeight: 35,
+                                     action: viewModel.showMusicAction)
+            }
         }
     }
 }
@@ -251,6 +258,7 @@ struct Home_Previews: PreviewProvider {
                                       showRoborockAction: {},
                                       showPowerGridAction: {},
                                       showLightsAction: {},
+                                      showMusicAction: {},
                                       toolbarReloadAction: {})
 
         HomeView(viewModel: viewModel)

--- a/IntelliNest/Views/Music/AlbumArtView.swift
+++ b/IntelliNest/Views/Music/AlbumArtView.swift
@@ -1,0 +1,53 @@
+//
+//  AlbumArtView.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import SwiftUI
+
+/// Renders album art from a Music Assistant image URL. MA search items return
+/// absolute http(s) URLs, while a speaker's `entity_picture` is relative to the
+/// Home Assistant base — this view resolves either form before loading.
+struct AlbumArtView: View {
+    let urlString: String?
+    let size: CGFloat
+
+    var body: some View {
+        Group {
+            if let url = resolvedURL {
+                AsyncImage(url: url) { image in
+                    image.resizable().aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    placeholder
+                }
+            } else {
+                placeholder
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var placeholder: some View {
+        ZStack {
+            Color.white.opacity(0.1)
+            Image(systemName: "music.note")
+                .foregroundStyle(.white.opacity(0.5))
+        }
+    }
+
+    private var resolvedURL: URL? {
+        guard let urlString, urlString.isNotEmpty else {
+            return nil
+        }
+        if urlString.hasPrefix("http") {
+            return URL(string: urlString)
+        }
+        let base = GlobalConstants.baseInternalUrlString
+        let trimmedBase = base.hasSuffix("/") ? String(base.dropLast()) : base
+        let path = urlString.hasPrefix("/") ? urlString : "/\(urlString)"
+        return URL(string: trimmedBase + path)
+    }
+}

--- a/IntelliNest/Views/Music/MusicSearchResultsView.swift
+++ b/IntelliNest/Views/Music/MusicSearchResultsView.swift
@@ -1,0 +1,74 @@
+//
+//  MusicSearchResultsView.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import SwiftUI
+
+/// Renders search results grouped by media type, or a Swedish "no results"
+/// state when a search returned nothing.
+struct MusicSearchResultsView: View {
+    @ObservedObject var viewModel: MusicViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.isSearching {
+                ProgressView()
+                    .tint(.white)
+                    .padding()
+            } else if viewModel.hasNoResults {
+                Text("Inga resultat")
+                    .foregroundStyle(.white.opacity(0.7))
+                    .padding()
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        ForEach(viewModel.searchSections) { section in
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(section.mediaType.swedishTitle)
+                                    .font(.headline)
+                                ForEach(section.items) { item in
+                                    MusicResultRow(item: item) {
+                                        Task { await viewModel.play(item: item) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct MusicResultRow: View {
+    let item: MusicSearchItem
+    let onTap: MainActorVoidClosure
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                AlbumArtView(urlString: item.imageURL, size: 44)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.name)
+                        .font(.body)
+                        .lineLimit(1)
+                    if let artist = item.artist {
+                        Text(artist)
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.6))
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                Image(systemName: "play.fill")
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+            .padding(.vertical, 4)
+        }
+        .accessibilityLabel("Spela \(item.name)")
+    }
+}

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -1,0 +1,57 @@
+//
+//  MusicView.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import SwiftUI
+
+struct MusicView: View {
+    @ObservedObject var viewModel: MusicViewModel
+
+    var body: some View {
+        VStack(spacing: 16) {
+            MusicSearchBar(searchText: $viewModel.searchText,
+                           onSubmit: { Task { await viewModel.search() } })
+
+            if let activeSpeaker = viewModel.activeSpeaker {
+                NowPlayingView(speaker: activeSpeaker, viewModel: viewModel)
+                SpeakerGroupingView(viewModel: viewModel)
+            } else {
+                SpeakerPickerView(viewModel: viewModel)
+            }
+
+            MusicSearchResultsView(viewModel: viewModel)
+        }
+        .padding(.horizontal)
+        .foregroundStyle(.white)
+    }
+}
+
+private struct MusicSearchBar: View {
+    @Binding var searchText: String
+    let onSubmit: MainActorVoidClosure
+
+    var body: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.white.opacity(0.7))
+            TextField("", text: $searchText, prompt: Text("Sök på Spotify").foregroundColor(.white.opacity(0.6)))
+                .foregroundStyle(.white)
+                .submitLabel(.search)
+                .onSubmit(onSubmit)
+                .accessibilityLabel("Sök efter musik")
+        }
+        .padding(10)
+        .background(Color.white.opacity(0.12))
+        .cornerRadius(12)
+    }
+}
+
+struct MusicView_Previews: PreviewProvider {
+    static var previews: some View {
+        MusicView(viewModel: MusicViewModel(restAPIService: PreviewProviderUtil.restAPIService))
+            .backgroundModifier()
+    }
+}

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -1,0 +1,125 @@
+//
+//  NowPlayingView.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import SwiftUI
+
+struct NowPlayingView: View {
+    let speaker: MediaPlayerEntity
+    @ObservedObject var viewModel: MusicViewModel
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                AlbumArtView(urlString: speaker.entityPicture, size: 64)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(speaker.mediaTitle ?? "Inget spelas")
+                        .font(.headline)
+                        .lineLimit(1)
+                    if let artist = speaker.mediaArtist {
+                        Text(artist)
+                            .font(.subheadline)
+                            .foregroundStyle(.white.opacity(0.7))
+                            .lineLimit(1)
+                    }
+                    Text(speaker.friendlyName)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.5))
+                }
+                Spacer()
+                Button {
+                    viewModel.activeSpeakerID = nil
+                } label: {
+                    Image(systemName: "hifispeaker.2.fill")
+                }
+                .accessibilityLabel("Byt högtalare")
+            }
+
+            TransportControlsView(speaker: speaker, viewModel: viewModel)
+
+            VolumeSliderView(volume: speaker.volumeLevel,
+                             onChange: { viewModel.setVolume($0) })
+        }
+        .padding()
+        .background(Color.white.opacity(0.08))
+        .cornerRadius(16)
+    }
+}
+
+private struct TransportControlsView: View {
+    let speaker: MediaPlayerEntity
+    @ObservedObject var viewModel: MusicViewModel
+
+    var body: some View {
+        HStack(spacing: 28) {
+            Button {
+                viewModel.toggleShuffle()
+            } label: {
+                Image(systemName: "shuffle")
+                    .foregroundStyle(speaker.shuffle ? .yellow : .white)
+            }
+            .accessibilityLabel("Blanda")
+            .accessibilityValue(speaker.shuffle ? "På" : "Av")
+
+            Button {
+                viewModel.previousTrack()
+            } label: {
+                Image(systemName: "backward.fill")
+            }
+            .accessibilityLabel("Föregående låt")
+
+            Button {
+                viewModel.togglePlayPause()
+            } label: {
+                Image(systemName: speaker.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                    .resizable()
+                    .frame(width: 54, height: 54)
+            }
+            .accessibilityLabel(speaker.isPlaying ? "Pausa" : "Spela")
+
+            Button {
+                viewModel.nextTrack()
+            } label: {
+                Image(systemName: "forward.fill")
+            }
+            .accessibilityLabel("Nästa låt")
+
+            Button {
+                viewModel.toggleRepeat()
+            } label: {
+                Image(systemName: speaker.repeatMode == .one ? "repeat.1" : "repeat")
+                    .foregroundStyle(speaker.repeatMode == .off ? .white : .yellow)
+            }
+            .accessibilityLabel("Upprepa")
+            .accessibilityValue(repeatAccessibilityValue)
+        }
+        .font(.title2)
+    }
+
+    private var repeatAccessibilityValue: String {
+        switch speaker.repeatMode {
+        case .off: "Av"
+        case .all: "Alla"
+        case .one: "En"
+        }
+    }
+}
+
+private struct VolumeSliderView: View {
+    let volume: Double
+    let onChange: DoubleClosure
+
+    var body: some View {
+        HStack {
+            Image(systemName: "speaker.fill")
+                .foregroundStyle(.white.opacity(0.7))
+            Slider(value: Binding(get: { volume }, set: { onChange($0) }), in: 0 ... 1)
+                .accessibilityLabel("Volym")
+            Image(systemName: "speaker.wave.3.fill")
+                .foregroundStyle(.white.opacity(0.7))
+        }
+    }
+}

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -1,0 +1,47 @@
+//
+//  SpeakerGroupingView.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import SwiftUI
+
+/// Sonos-style grouping: the active speaker is the leader, and the other
+/// available speakers can be toggled into or out of its group.
+struct SpeakerGroupingView: View {
+    @ObservedObject var viewModel: MusicViewModel
+
+    private var otherSpeakers: [MediaPlayerEntity] {
+        viewModel.availableSpeakers.filter { $0.entityId != viewModel.activeSpeakerID }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Gruppera högtalare")
+                .font(.headline)
+            ForEach(otherSpeakers, id: \.entityId) { speaker in
+                let grouped = viewModel.isGrouped(speaker.entityId)
+                Button {
+                    viewModel.toggleGroupMember(speaker.entityId)
+                } label: {
+                    HStack {
+                        Image(systemName: grouped ? "checkmark.circle.fill" : "circle")
+                            .foregroundStyle(grouped ? .yellow : .white.opacity(0.6))
+                        Text(speaker.friendlyName)
+                        Spacer()
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 12)
+                    .background(Color.white.opacity(0.06))
+                    .cornerRadius(10)
+                }
+                .accessibilityLabel("\(grouped ? "Ta bort" : "Lägg till") \(speaker.friendlyName) i gruppen")
+                .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
+            }
+        }
+        .padding()
+        .background(Color.white.opacity(0.05))
+        .cornerRadius(16)
+    }
+}

--- a/IntelliNest/Views/Music/SpeakerPickerView.swift
+++ b/IntelliNest/Views/Music/SpeakerPickerView.swift
@@ -1,0 +1,40 @@
+//
+//  SpeakerPickerView.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import SwiftUI
+
+/// Shown when no speaker is active. Lists the available speakers so the user can
+/// pick one to control.
+struct SpeakerPickerView: View {
+    @ObservedObject var viewModel: MusicViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Välj högtalare")
+                .font(.headline)
+            ForEach(viewModel.availableSpeakers, id: \.entityId) { speaker in
+                Button {
+                    viewModel.selectSpeaker(speaker.entityId)
+                } label: {
+                    HStack {
+                        Image(systemName: speaker.isPlaying ? "speaker.wave.2.fill" : "hifispeaker.fill")
+                        Text(speaker.friendlyName)
+                        Spacer()
+                    }
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 12)
+                    .background(Color.white.opacity(0.08))
+                    .cornerRadius(10)
+                }
+                .accessibilityLabel("Välj \(speaker.friendlyName)")
+            }
+        }
+        .padding()
+        .background(Color.white.opacity(0.05))
+        .cornerRadius(16)
+    }
+}

--- a/IntelliNestTests/HomeViewModelTests.swift
+++ b/IntelliNestTests/HomeViewModelTests.swift
@@ -29,6 +29,7 @@ class HomeViewModelTests: XCTestCase {
             showRoborockAction: {},
             showPowerGridAction: {},
             showLightsAction: {},
+            showMusicAction: {},
             toolbarReloadAction: {}
         )
     }

--- a/IntelliNestTests/MusicModelTests.swift
+++ b/IntelliNestTests/MusicModelTests.swift
@@ -1,0 +1,289 @@
+@testable import IntelliNest
+import XCTest
+
+// Covers the music feature's model decoding (MediaPlayerEntity, MusicSearchResult)
+// and the RestAPIService+Music external-URL fallback paths. The ViewModel itself is
+// covered in MusicViewModelTests.
+final class MusicModelTests: XCTestCase {
+    // Fixed, grep-searchable literals — no random data.
+    private let trackURI = "spotify://track/3SjXx3rbNGk8nCho8YEoz5"
+    private let trackName = "Bohemian Rhapsody"
+    private let trackArtist = "Queen"
+
+    // MARK: - MediaPlayerEntity decoding
+
+    func testMediaPlayerDecodesAllAttributes() throws {
+        let json = makeEntityJSON(
+            entityId: EntityId.mediaPlayerKitchen.rawValue,
+            state: "playing",
+            attributes: [
+                "friendly_name": "Kitchen",
+                "volume_level": 0.42,
+                "media_title": trackName,
+                "media_artist": trackArtist,
+                "media_album_name": "A Night at the Opera",
+                "media_content_id": trackURI,
+                "entity_picture": "/api/media_player_proxy/kitchen.jpg",
+                "group_members": [
+                    EntityId.mediaPlayerKitchen.rawValue,
+                    EntityId.mediaPlayerLivingRoom.rawValue,
+                    "media_player.phantom_unknown"
+                ],
+                "shuffle": true,
+                "repeat": "all"
+            ]
+        )
+
+        let entity = try JSONDecoder().decode(MediaPlayerEntity.self, from: json)
+
+        XCTAssertEqual(entity.entityId, .mediaPlayerKitchen)
+        XCTAssertEqual(entity.state, "playing")
+        XCTAssertEqual(entity.friendlyName, "Kitchen")
+        XCTAssertEqual(entity.volumeLevel, 0.42)
+        XCTAssertEqual(entity.mediaTitle, trackName)
+        XCTAssertEqual(entity.mediaArtist, trackArtist)
+        XCTAssertEqual(entity.mediaAlbumName, "A Night at the Opera")
+        XCTAssertEqual(entity.mediaContentID, trackURI)
+        XCTAssertEqual(entity.entityPicture, "/api/media_player_proxy/kitchen.jpg")
+        // Unknown phantom id is dropped; only the two real ids remain.
+        XCTAssertEqual(entity.groupMembers, [.mediaPlayerKitchen, .mediaPlayerLivingRoom])
+        XCTAssertTrue(entity.shuffle)
+        XCTAssertEqual(entity.repeatMode, .all)
+    }
+
+    func testMediaPlayerDecodesWithMissingAttributesUsesDefaults() throws {
+        // No `attributes` object at all — the decoder takes the fallback branch.
+        let json = Data("""
+        {"entity_id":"\(EntityId.mediaPlayerSpa.rawValue)","state":"idle"}
+        """.utf8)
+
+        let entity = try JSONDecoder().decode(MediaPlayerEntity.self, from: json)
+
+        XCTAssertEqual(entity.entityId, .mediaPlayerSpa)
+        XCTAssertEqual(entity.state, "idle")
+        XCTAssertEqual(entity.friendlyName, "")
+        XCTAssertEqual(entity.volumeLevel, 0)
+        XCTAssertNil(entity.mediaTitle)
+        XCTAssertTrue(entity.groupMembers.isEmpty)
+        XCTAssertFalse(entity.shuffle)
+        XCTAssertEqual(entity.repeatMode, .off)
+    }
+
+    private struct StateFlagsCase {
+        let state: String
+        let isPlaying: Bool
+        let isActive: Bool
+        let isUnavailable: Bool
+    }
+
+    func testMediaPlayerDecodesAttributesPresentButKeysMissingUsesDefaults() throws {
+        // `attributes` exists but omits friendly_name, volume_level, group_members,
+        // shuffle, and repeat — exercising each `?? default` autoclosure.
+        let json = makeEntityJSON(
+            entityId: EntityId.mediaPlayerGuestRoom.rawValue,
+            state: "idle",
+            attributes: ["media_title": trackName]
+        )
+
+        let entity = try JSONDecoder().decode(MediaPlayerEntity.self, from: json)
+
+        XCTAssertEqual(entity.mediaTitle, trackName)
+        XCTAssertEqual(entity.friendlyName, "")
+        XCTAssertEqual(entity.volumeLevel, 0)
+        XCTAssertTrue(entity.groupMembers.isEmpty)
+        XCTAssertFalse(entity.shuffle)
+        XCTAssertEqual(entity.repeatMode, .off)
+    }
+
+    func testMediaPlayerStateFlags() {
+        let cases: [StateFlagsCase] = [
+            StateFlagsCase(state: "playing", isPlaying: true, isActive: true, isUnavailable: false),
+            StateFlagsCase(state: "paused", isPlaying: false, isActive: false, isUnavailable: false),
+            StateFlagsCase(state: "idle", isPlaying: false, isActive: false, isUnavailable: false),
+            StateFlagsCase(state: "unavailable", isPlaying: false, isActive: false, isUnavailable: true)
+        ]
+        for testCase in cases {
+            var entity = MediaPlayerEntity(entityId: .mediaPlayerKitchen)
+            entity.state = testCase.state
+            XCTAssertEqual(entity.isPlaying, testCase.isPlaying, "isPlaying for \(testCase.state)")
+            XCTAssertEqual(entity.isActive, testCase.isActive, "isActive for \(testCase.state)")
+            XCTAssertEqual(entity.isUnavailable, testCase.isUnavailable, "isUnavailable for \(testCase.state)")
+        }
+    }
+
+    func testMediaPlayerSetNextUpdateTimeMovesIntoFuture() {
+        var entity = MediaPlayerEntity(entityId: .mediaPlayerKitchen)
+        let before = Date()
+        entity.setNextUpdateTime()
+        XCTAssertGreaterThan(entity.nextUpdate, before)
+    }
+
+    func testMediaPlayerEquality() {
+        var base = MediaPlayerEntity(entityId: .mediaPlayerKitchen, state: "playing", friendlyName: "Kitchen")
+        base.volumeLevel = 0.5
+        base.mediaTitle = trackName
+        base.mediaArtist = trackArtist
+        base.mediaContentID = trackURI
+        base.groupMembers = [.mediaPlayerLivingRoom]
+        base.shuffle = true
+        base.repeatMode = .one
+
+        var same = base
+        XCTAssertEqual(base, same)
+
+        // Each mutated property must break equality, exercising every clause of ==.
+        same = base; same.state = "paused"; XCTAssertNotEqual(base, same)
+        same = base; same.volumeLevel = 0.9; XCTAssertNotEqual(base, same)
+        same = base; same.mediaTitle = "Other"; XCTAssertNotEqual(base, same)
+        same = base; same.mediaArtist = "Other"; XCTAssertNotEqual(base, same)
+        same = base; same.mediaContentID = "spotify://track/other"; XCTAssertNotEqual(base, same)
+        same = base; same.groupMembers = []; XCTAssertNotEqual(base, same)
+        same = base; same.shuffle = false; XCTAssertNotEqual(base, same)
+        same = base; same.repeatMode = .off; XCTAssertNotEqual(base, same)
+
+        var differentEntityId = base
+        differentEntityId.entityId = .mediaPlayerSpa
+        XCTAssertNotEqual(base, differentEntityId)
+    }
+
+    // MARK: - MusicSearchResult
+
+    func testSwedishTitleForEachMediaType() {
+        let expected: [MusicMediaType: String] = [
+            .track: "Låtar",
+            .album: "Album",
+            .artist: "Artister",
+            .playlist: "Spellistor"
+        ]
+        for mediaType in MusicMediaType.allCases {
+            XCTAssertEqual(mediaType.swedishTitle, expected[mediaType])
+        }
+    }
+
+    func testSearchItemAndSectionIDsDeriveFromContent() {
+        let item = MusicSearchItem(uri: trackURI, name: trackName, mediaType: .track, imageURL: nil, artist: trackArtist)
+        XCTAssertEqual(item.id, trackURI)
+
+        let section = MusicSearchSection(mediaType: .album, items: [item])
+        XCTAssertEqual(section.id, MusicMediaType.album.rawValue)
+    }
+
+    func testSearchResponseDropsItemsMissingURIOrNameAndEmptySections() throws {
+        // One valid track, one missing uri, one missing name; albums all invalid (section dropped).
+        let json = Data("""
+        {
+          "tracks": [
+            {"uri":"\(trackURI)","name":"\(trackName)","media_image":"https://img/track.jpg",
+             "artists":[{"name":"\(trackArtist)"}]},
+            {"name":"No URI Track"},
+            {"uri":"spotify://track/missing-name"}
+          ],
+          "albums": [
+            {"name":"No URI Album"}
+          ]
+        }
+        """.utf8)
+
+        let response = try JSONDecoder().decode(MusicSearchResponse.self, from: json)
+
+        // Only the track section survives, with exactly the one valid item.
+        XCTAssertEqual(response.sections.count, 1)
+        let section = try XCTUnwrap(response.sections.first)
+        XCTAssertEqual(section.mediaType, .track)
+        XCTAssertEqual(section.items.count, 1)
+        let item = try XCTUnwrap(section.items.first)
+        XCTAssertEqual(item.uri, trackURI)
+        XCTAssertEqual(item.name, trackName)
+        // `media_image` is read when `image` is absent.
+        XCTAssertEqual(item.imageURL, "https://img/track.jpg")
+        XCTAssertEqual(item.artist, trackArtist)
+    }
+
+    // MARK: - RestAPIService+Music external fallback
+
+    @MainActor
+    private func makeService() -> (RestAPIService, URLCreator) {
+        let stubbedSession = URLProtocolStub.createStubbedURLSession()
+        let urlCreator = URLCreator(session: stubbedSession)
+        urlCreator.connectionState = .local
+        let service = RestAPIService(
+            urlCreator: urlCreator,
+            session: stubbedSession,
+            setErrorBannerText: { _, _ in },
+            repeatReloadAction: { _ in }
+        )
+        return (service, urlCreator)
+    }
+
+    private func searchURL(baseURLString: String) -> URL {
+        var components = URLComponents(string: baseURLString)!
+        components.path = "/api/services/music_assistant/search"
+        components.queryItems = [URLQueryItem(name: "return_response", value: "true")]
+        return components.url!
+    }
+
+    private func stubSearch(baseURLString: String, json: String, statusCode: Int) {
+        let url = searchURL(baseURLString: baseURLString)
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(json.utf8), response: response, error: nil)
+    }
+
+    @MainActor
+    func testSearchMusicFallsBackToExternalURL() async throws {
+        URLProtocolStub.startInterceptingRequests()
+        defer { URLProtocolStub.stopInterceptingRequests() }
+        let (service, _) = makeService()
+        // Internal URL has no stub — only external succeeds.
+        let json = """
+        {"tracks":[{"uri":"\(trackURI)","name":"\(trackName)"}]}
+        """
+        stubSearch(baseURLString: GlobalConstants.baseExternalUrlString, json: json, statusCode: 200)
+
+        let response = try await service.searchMusic(query: trackName)
+
+        XCTAssertEqual(response.sections.count, 1)
+        XCTAssertEqual(response.sections.first?.items.first?.uri, trackURI)
+    }
+
+    @MainActor
+    func testSearchMusicThrowsWhenBothURLsFail() async {
+        URLProtocolStub.startInterceptingRequests()
+        defer { URLProtocolStub.stopInterceptingRequests() }
+        let (service, _) = makeService()
+        // No stubs — both internal and external fail.
+        do {
+            _ = try await service.searchMusic(query: trackName)
+            XCTFail("Expected searchMusic to throw when both URLs fail")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
+
+    @MainActor
+    func testPlayMediaFallsBackToExternalURL() async {
+        URLProtocolStub.startInterceptingRequests()
+        defer { URLProtocolStub.stopInterceptingRequests() }
+        let (service, _) = makeService()
+        // Internal URL has no stub — only external POST succeeds.
+        var components = URLComponents(string: GlobalConstants.baseExternalUrlString)!
+        components.path = "/api/services/music_assistant/play_media"
+        let url = components.url!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data("[]".utf8), response: response, error: nil)
+
+        let success = await service.playMedia(on: .mediaPlayerKitchen, mediaID: trackURI, mediaType: .track)
+
+        XCTAssertTrue(success)
+    }
+
+    @MainActor
+    func testPlayMediaReturnsFalseWhenBothURLsFail() async {
+        URLProtocolStub.startInterceptingRequests()
+        defer { URLProtocolStub.stopInterceptingRequests() }
+        let (service, _) = makeService()
+        // No stubs — both internal and external POST fail.
+        let success = await service.playMedia(on: .mediaPlayerKitchen, mediaID: trackURI, mediaType: .track)
+
+        XCTAssertFalse(success)
+    }
+}

--- a/IntelliNestTests/MusicViewModelTests.swift
+++ b/IntelliNestTests/MusicViewModelTests.swift
@@ -1,0 +1,458 @@
+@testable import IntelliNest
+import XCTest
+
+@MainActor
+class MusicViewModelTests: XCTestCase {
+    var viewModel: MusicViewModel!
+    var restAPIService: RestAPIService!
+    var urlCreator: URLCreator!
+    var bannerTitles: [String] = []
+
+    // Fixed, grep-searchable literals — no random data.
+    let trackURI = "spotify://track/3SjXx3rbNGk8nCho8YEoz5"
+    let trackName = "Bohemian Rhapsody"
+    let trackArtist = "Queen"
+
+    override func setUp() async throws {
+        bannerTitles = []
+        URLProtocolStub.startInterceptingRequests()
+        let stubbedSession = URLProtocolStub.createStubbedURLSession()
+        urlCreator = URLCreator(session: stubbedSession)
+        urlCreator.connectionState = .local
+        restAPIService = RestAPIService(
+            urlCreator: urlCreator,
+            session: stubbedSession,
+            setErrorBannerText: { _, _ in },
+            repeatReloadAction: { _ in }
+        )
+        viewModel = MusicViewModel(restAPIService: restAPIService,
+                                   setErrorBannerText: { [weak self] title, _ in
+                                       self?.bannerTitles.append(title)
+                                   })
+    }
+
+    override func tearDown() async throws {
+        URLProtocolStub.stopInterceptingRequests()
+        viewModel = nil
+        restAPIService = nil
+        urlCreator = nil
+    }
+
+    // MARK: - Helpers
+
+    private func speakerURL(_ entityID: EntityId) -> URL {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/states/\(entityID.rawValue)"
+        return components.url!
+    }
+
+    private func speakerJSON(entityID: EntityId,
+                             state: String,
+                             friendlyName: String,
+                             volume: Double = 0.3,
+                             title: String? = nil,
+                             artist: String? = nil,
+                             groupMembers: [String] = [],
+                             shuffle: Bool = false,
+                             repeatMode: String = "off") -> Data {
+        var attributes: [String: Any] = [
+            "friendly_name": friendlyName,
+            "volume_level": volume,
+            "group_members": groupMembers,
+            "shuffle": shuffle,
+            "repeat": repeatMode
+        ]
+        if let title { attributes["media_title"] = title }
+        if let artist { attributes["media_artist"] = artist }
+        return makeEntityJSON(entityId: entityID.rawValue, state: state, attributes: attributes)
+    }
+
+    private func stubSpeaker(_ entityID: EntityId, data: Data) {
+        let response = HTTPURLResponse(url: speakerURL(entityID), statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: speakerURL(entityID), data: data, response: response, error: nil)
+    }
+
+    private func stubAllSpeakers(playing: EntityId? = nil, unavailable: Set<EntityId> = []) {
+        for entityID in MusicViewModel.speakerIDs {
+            let state: String = if unavailable.contains(entityID) {
+                "unavailable"
+            } else if entityID == playing {
+                "playing"
+            } else {
+                "idle"
+            }
+            stubSpeaker(entityID, data: speakerJSON(entityID: entityID,
+                                                    state: state,
+                                                    friendlyName: entityID.rawValue))
+        }
+    }
+
+    private func searchURL() -> URL {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/services/music_assistant/search"
+        components.queryItems = [URLQueryItem(name: "return_response", value: "true")]
+        return components.url!
+    }
+
+    private func stubSearch(json: String, statusCode: Int = 200) {
+        let url = searchURL()
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(json.utf8), response: response, error: nil)
+    }
+
+    // MARK: - Initial State
+
+    func testInitialState() {
+        XCTAssertEqual(viewModel.speakers.count, 6)
+        XCTAssertNil(viewModel.activeSpeakerID)
+        XCTAssertTrue(viewModel.searchSections.isEmpty)
+        XCTAssertFalse(viewModel.hasSearched)
+        XCTAssertFalse(viewModel.hasNoResults)
+    }
+
+    // MARK: - Default active speaker selection
+
+    func testDefaultActiveSpeaker_picksPlayingSpeaker() async {
+        stubAllSpeakers(playing: .mediaPlayerLivingRoom)
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerLivingRoom)
+    }
+
+    func testDefaultActiveSpeaker_noneWhenNothingPlaying() async {
+        stubAllSpeakers(playing: nil)
+        await viewModel.reload()
+        XCTAssertNil(viewModel.activeSpeakerID)
+    }
+
+    func testDefaultSelection_runsOnlyOnce() async {
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerKitchen)
+
+        // User switches; a later reload where Kitchen still plays must not override.
+        viewModel.selectSpeaker(.mediaPlayerSpa)
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerSpa)
+    }
+
+    // MARK: - Unavailable speaker filtering
+
+    func testUnavailableSpeakersFilteredOut() async {
+        stubAllSpeakers(playing: nil, unavailable: [.mediaPlayerSpa])
+        await viewModel.reload()
+        let availableIDs = viewModel.availableSpeakers.map(\.entityId)
+        XCTAssertEqual(availableIDs.count, 5)
+        XCTAssertFalse(availableIDs.contains(.mediaPlayerSpa))
+    }
+
+    func testActiveSpeakerDroppedWhenItBecomesUnavailable() async {
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerKitchen)
+
+        stubAllSpeakers(playing: nil, unavailable: [.mediaPlayerKitchen])
+        await viewModel.reload()
+        XCTAssertNil(viewModel.activeSpeakerID)
+    }
+
+    // MARK: - Search
+
+    func testSearchGroupsResultsByType() async {
+        let json = """
+        {"tracks":[{"uri":"\(trackURI)","name":"\(trackName)","image":"https://img/track.jpg",
+        "artists":[{"name":"\(trackArtist)"}]}],
+        "albums":[{"uri":"spotify://album/1","name":"A Night at the Opera"}],
+        "artists":[{"uri":"spotify://artist/1","name":"\(trackArtist)"}],
+        "playlists":[{"uri":"spotify://playlist/1","name":"Rock Classics"}]}
+        """
+        stubSearch(json: json)
+        viewModel.searchText = trackName
+        await viewModel.search()
+
+        XCTAssertEqual(viewModel.searchSections.count, 4)
+        XCTAssertEqual(viewModel.searchSections.map(\.mediaType), [.track, .album, .artist, .playlist])
+        let firstTrack = viewModel.searchSections.first?.items.first
+        XCTAssertEqual(firstTrack?.uri, trackURI)
+        XCTAssertEqual(firstTrack?.name, trackName)
+        XCTAssertEqual(firstTrack?.artist, trackArtist)
+        XCTAssertFalse(viewModel.hasNoResults)
+    }
+
+    func testSearchUnwrapsServiceResponseEnvelope() async {
+        let json = """
+        {"service_response":{"tracks":[{"uri":"\(trackURI)","name":"\(trackName)"}]}}
+        """
+        stubSearch(json: json)
+        viewModel.searchText = trackName
+        await viewModel.search()
+        XCTAssertEqual(viewModel.searchSections.count, 1)
+        XCTAssertEqual(viewModel.searchSections.first?.items.first?.uri, trackURI)
+    }
+
+    func testEmptySearchResultsShowsNoResultsState() async {
+        stubSearch(json: "{\"tracks\":[],\"albums\":[]}")
+        viewModel.searchText = "zzzznotfound"
+        await viewModel.search()
+        XCTAssertTrue(viewModel.searchSections.isEmpty)
+        XCTAssertTrue(viewModel.hasNoResults)
+    }
+
+    func testBlankSearchTextDoesNotSearch() async {
+        viewModel.searchText = "   "
+        await viewModel.search()
+        XCTAssertFalse(viewModel.hasSearched)
+        XCTAssertTrue(viewModel.searchSections.isEmpty)
+    }
+
+    func testSearchFailureShowsBanner() async {
+        stubSearch(json: "boom", statusCode: 500)
+        viewModel.searchText = trackName
+        await viewModel.search()
+        XCTAssertTrue(viewModel.searchSections.isEmpty)
+        XCTAssertTrue(bannerTitles.contains("Sökningen misslyckades"))
+    }
+
+    // MARK: - Play
+
+    private func stubPlayMedia(statusCode: Int) {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/services/music_assistant/play_media"
+        let url = components.url!
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data("[]".utf8), response: response, error: nil)
+    }
+
+    func testPlayOnActiveSpeakerSetsPlayingState() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubPlayMedia(statusCode: 200)
+        let item = MusicSearchItem(uri: trackURI, name: trackName, mediaType: .track,
+                                   imageURL: nil, artist: trackArtist)
+        await viewModel.play(item: item)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.mediaTitle, trackName)
+        XCTAssertTrue(bannerTitles.isEmpty)
+    }
+
+    func testPlayFailureKeepsNoFalsePlayingState() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        // Kitchen currently idle.
+        viewModel.speakers[.mediaPlayerKitchen]?.state = "idle"
+        stubPlayMedia(statusCode: 500)
+        let item = MusicSearchItem(uri: trackURI, name: trackName, mediaType: .track,
+                                   imageURL: nil, artist: trackArtist)
+        await viewModel.play(item: item)
+        XCTAssertNotEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+        XCTAssertTrue(bannerTitles.contains("Kunde inte spela"))
+    }
+
+    func testPlayWithoutActiveSpeakerShowsBanner() async {
+        let item = MusicSearchItem(uri: trackURI, name: trackName, mediaType: .track,
+                                   imageURL: nil, artist: trackArtist)
+        await viewModel.play(item: item)
+        XCTAssertTrue(bannerTitles.contains("Ingen högtalare vald"))
+    }
+
+    // MARK: - Transport
+
+    func testTogglePlayPause_pausesWhenPlaying() async {
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        let expectation = XCTestExpectation(description: "POST media_pause")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/media_pause") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/media_pause")
+        viewModel.togglePlayPause()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "paused")
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
+    func testTogglePlayPause_playsWhenPaused() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        viewModel.speakers[.mediaPlayerKitchen]?.state = "paused"
+        let expectation = XCTestExpectation(description: "POST media_play")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/media_play") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/media_play")
+        viewModel.togglePlayPause()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
+    func testNextAndPreviousTrack() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        let cases: [(action: () -> Void, path: String)] = [
+            (viewModel.nextTrack, "/api/services/media_player/media_next_track"),
+            (viewModel.previousTrack, "/api/services/media_player/media_previous_track")
+        ]
+        for testCase in cases {
+            let expectation = XCTestExpectation(description: "POST \(testCase.path)")
+            URLProtocolStub.observerRequests { request in
+                if request.httpMethod == "POST", request.url?.path == testCase.path {
+                    expectation.fulfill()
+                }
+            }
+            stubPostService(path: testCase.path)
+            testCase.action()
+            await fulfillment(of: [expectation], timeout: 2.0)
+        }
+    }
+
+    func testTransportWithoutActiveSpeakerDoesNothing() {
+        // No active speaker; these must be no-ops (no crash).
+        viewModel.togglePlayPause()
+        viewModel.nextTrack()
+        viewModel.previousTrack()
+        viewModel.setVolume(0.5)
+        viewModel.toggleShuffle()
+        viewModel.toggleRepeat()
+        XCTAssertNil(viewModel.activeSpeakerID)
+    }
+
+    // MARK: - Volume
+
+    func testSetVolumeUpdatesStateAndPosts() async {
+        viewModel.selectSpeaker(.mediaPlayerGuestRoom)
+        let expectation = XCTestExpectation(description: "POST volume_set")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/volume_set") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/volume_set")
+        viewModel.setVolume(0.75)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerGuestRoom]?.volumeLevel, 0.75)
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
+    // MARK: - Shuffle / Repeat
+
+    func testToggleShuffle() async {
+        viewModel.selectSpeaker(.mediaPlayerPlayroom)
+        viewModel.speakers[.mediaPlayerPlayroom]?.shuffle = false
+        let expectation = XCTestExpectation(description: "POST shuffle_set")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/shuffle_set") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/shuffle_set")
+        viewModel.toggleShuffle()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerPlayroom]?.shuffle, true)
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
+    func testToggleRepeatCyclesOffAllOne() async {
+        viewModel.selectSpeaker(.mediaPlayerPlayroom)
+        stubPostService(path: "/api/services/media_player/repeat_set")
+
+        viewModel.speakers[.mediaPlayerPlayroom]?.repeatMode = .off
+        viewModel.toggleRepeat()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerPlayroom]?.repeatMode, .all)
+        viewModel.toggleRepeat()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerPlayroom]?.repeatMode, .one)
+        viewModel.toggleRepeat()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerPlayroom]?.repeatMode, .off)
+    }
+
+    // MARK: - Helpers
+
+    fileprivate func stubPostService(path: String) {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = path
+        let url = components.url!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(), response: response, error: nil)
+    }
+}
+
+// MARK: - Grouping & live updates
+
+@MainActor
+extension MusicViewModelTests {
+    func testJoinAddsSpeakerToGroup() async {
+        viewModel.selectSpeaker(.mediaPlayerLivingRoom)
+        let expectation = XCTestExpectation(description: "POST join")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/media_player/join") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/join")
+        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerKitchen))
+        viewModel.toggleGroupMember(.mediaPlayerKitchen)
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
+    func testUnjoinRemovesSpeakerFromGroup() async {
+        // Living room is leader with Kitchen already grouped in.
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "playing",
+                                      friendlyName: "Vardagsrummet",
+                                      groupMembers: [EntityId.mediaPlayerKitchen.rawValue]))
+        for entityID in MusicViewModel.speakerIDs where entityID != .mediaPlayerLivingRoom {
+            stubSpeaker(entityID, data: speakerJSON(entityID: entityID, state: "idle", friendlyName: entityID.rawValue))
+        }
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerLivingRoom)
+        XCTAssertTrue(viewModel.isGrouped(.mediaPlayerKitchen))
+
+        let expectation = XCTestExpectation(description: "POST unjoin")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/media_player/unjoin") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/unjoin")
+        viewModel.toggleGroupMember(.mediaPlayerKitchen)
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
+    func testGroupingNoOpForActiveSpeakerItself() {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerKitchen))
+        // Toggling the leader against itself must do nothing (no crash).
+        viewModel.toggleGroupMember(.mediaPlayerKitchen)
+    }
+
+    // MARK: - Live updates
+
+    func testReloadKeepsOtherSpeakersWhenOneFailsToDecode() async {
+        // Kitchen returns a body that cannot decode into MediaPlayerEntity, hitting
+        // reload()'s per-speaker catch; the other speakers must still load.
+        stubAllSpeakers(playing: .mediaPlayerLivingRoom)
+        let badResponse = HTTPURLResponse(url: speakerURL(.mediaPlayerKitchen),
+                                          statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: speakerURL(.mediaPlayerKitchen),
+                                data: Data("not json".utf8), response: badResponse, error: nil)
+        await viewModel.reload()
+
+        // Kitchen keeps its initial loading entity; the playing speaker still resolves.
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "Loading")
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerLivingRoom)
+    }
+
+    func testReloadReflectsExternalChanges() async {
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+
+        // Someone changes volume + track elsewhere.
+        stubSpeaker(.mediaPlayerKitchen,
+                    data: speakerJSON(entityID: .mediaPlayerKitchen,
+                                      state: "playing",
+                                      friendlyName: "Kitchen",
+                                      volume: 0.9,
+                                      title: trackName,
+                                      artist: trackArtist))
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.volumeLevel, 0.9)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.mediaTitle, trackName)
+    }
+}


### PR DESCRIPTION
## Summary
- New "Musik" navigation button on the home dashboard opening a Sonos-app-style media controller.
- Searches Spotify via Home Assistant's Music Assistant for tracks, playlists, albums and artists, grouped by type.
- Tapping a result plays it immediately on the active speaker (replaces the queue).
- Now-playing controls: play/pause, next/previous, per-speaker volume, shuffle and 3-state repeat.
- One active speaker at a time, defaulting to whatever is currently playing; group/ungroup the other speakers into it (active speaker is the group leader).
- All six speakers available: 4 Sonos rooms (Kitchen, Gästrummet, Lekrummet, Vardagsrummet) + 2 Axis (Matbord ute, Spa); unavailable players filtered out.
- Live updates via the existing reload loop; Swedish UI with VoiceOver labels on transport/grouping controls.
- Drives everything through HA's Music Assistant integration only — no direct speaker or Spotify communication, no Spotify auth in-app.

## Test plan
- Unit tests: 39 new tests across MusicViewModelTests + MusicModelTests; full suite 437 passing, 0 failing.
- Coverage on feature source files: MediaPlayerEntity 100%, MusicSearchResult 100%, MusicViewModel 99.57%, RestAPIService+Music 95.1%.
- Linters: SwiftFormat clean, SwiftLint 0 errors.

## Note
- One runtime item to confirm against the live HA instance: the exact top-level key names in the `music_assistant.search` response. The decoder handles the grouped keys plus the `service_response` envelope; if your MA build differs, the search decoder is the single place to adjust.

Feature folder: ~/.claude/features/music-controller/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Music feature with search functionality for tracks, albums, artists, and playlists.
  * Added playback controls: play/pause, next/previous track, volume adjustment, shuffle, and repeat modes.
  * Added support for multiple speakers with speaker grouping capabilities and speaker selection interface.
  * Added now-playing display with album artwork.

* **Tests**
  * Added comprehensive music model and view model test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->