### PR TITLE
Music polish: layout, search tabs, grouped playback, playlist drill-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             -project IntelliNest.xcodeproj \
             -scheme "IntelliNest-github" \
             -testPlan "IntelliNest-github" \
-            -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
+            -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
             -configuration "Github actions" \
             -parallel-testing-enabled YES \
             -maximum-parallel-testing-workers 2 \

--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -1447,7 +1447,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "IntelliNest/Supporting Files/IntelliNest.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_ASSET_PATHS = "\"IntelliNest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1469,7 +1469,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.04.01;
+				MARKETING_VERSION = 2026.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1488,7 +1488,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "IntelliNest/Supporting Files/IntelliNest.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_ASSET_PATHS = "\"IntelliNest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1510,7 +1510,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.04.01;
+				MARKETING_VERSION = 2026.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1528,7 +1528,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1536,7 +1536,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.04.01;
+				MARKETING_VERSION = 2026.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1553,7 +1553,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1561,7 +1561,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.04.01;
+				MARKETING_VERSION = 2026.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1579,7 +1579,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = IntelliWidget/IntelliWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1593,7 +1593,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2026.04.01;
+				MARKETING_VERSION = 2026.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest.IntelliWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1612,7 +1612,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = IntelliWidget/IntelliWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1626,7 +1626,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2026.04.01;
+				MARKETING_VERSION = 2026.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest.IntelliWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1644,7 +1644,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = IntelliWidget/IntelliWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1658,7 +1658,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2026.04.01;
+				MARKETING_VERSION = 2026.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest.IntelliWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1738,7 +1738,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "IntelliNest/Supporting Files/IntelliNest.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_ASSET_PATHS = "\"IntelliNest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1760,7 +1760,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.04.01;
+				MARKETING_VERSION = 2026.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1778,7 +1778,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1786,7 +1786,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2026.04.01;
+				MARKETING_VERSION = 2026.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = se.laross.IntelliNestTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/IntelliNest/Model/MediaPlayerEntity.swift
+++ b/IntelliNest/Model/MediaPlayerEntity.swift
@@ -114,10 +114,13 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
     static func == (lhs: MediaPlayerEntity, rhs: MediaPlayerEntity) -> Bool {
         lhs.entityId == rhs.entityId &&
             lhs.state == rhs.state &&
+            lhs.friendlyName == rhs.friendlyName &&
             lhs.volumeLevel == rhs.volumeLevel &&
             lhs.mediaTitle == rhs.mediaTitle &&
             lhs.mediaArtist == rhs.mediaArtist &&
+            lhs.mediaAlbumName == rhs.mediaAlbumName &&
             lhs.mediaContentID == rhs.mediaContentID &&
+            lhs.entityPicture == rhs.entityPicture &&
             lhs.groupMembers == rhs.groupMembers &&
             lhs.shuffle == rhs.shuffle &&
             lhs.repeatMode == rhs.repeatMode

--- a/IntelliNest/Model/MusicSearchResult.swift
+++ b/IntelliNest/Model/MusicSearchResult.swift
@@ -31,7 +31,7 @@ enum MusicMediaType: String, CaseIterable, Decodable {
 
 /// A single Music Assistant search result item. `uri` is the playable media id
 /// (e.g. `spotify://track/3SjXx3rbNGk8nCho8YEoz5`).
-struct MusicSearchItem: Identifiable, Equatable {
+struct MusicSearchItem: Identifiable, Equatable, Hashable {
     let uri: String
     let name: String
     let mediaType: MusicMediaType
@@ -118,5 +118,67 @@ struct MusicSearchResponse: Decodable {
             }
         }
         sections = builtSections
+    }
+}
+
+/// A single track inside a playlist, decoded from a `browse_media` response.
+struct MusicPlaylistTrack: Identifiable, Equatable {
+    let uri: String
+    let title: String
+    let imageURL: String?
+
+    var id: String { uri }
+}
+
+/// Decodes a `media_player.browse_media` response for a playlist. The browsed
+/// node is nested under a single dynamic entity-id key; its `children` are the
+/// playlist's tracks (each a track uri in `media_content_id`, a `title`, and an
+/// optional `thumbnail`).
+struct MusicPlaylistBrowseResponse: Decodable {
+    let tracks: [MusicPlaylistTrack]
+
+    private struct Node: Decodable {
+        let children: [Child]?
+    }
+
+    private struct Child: Decodable {
+        let title: String?
+        let mediaContentID: String?
+        let thumbnail: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case title
+            case mediaContentID = "media_content_id"
+            case thumbnail
+        }
+    }
+
+    private struct DynamicKey: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+            intValue = nil
+        }
+
+        init?(intValue: Int) {
+            self.intValue = intValue
+            stringValue = String(intValue)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicKey.self)
+        guard let entityKey = container.allKeys.first,
+              let node = try? container.decode(Node.self, forKey: entityKey) else {
+            tracks = []
+            return
+        }
+        tracks = (node.children ?? []).compactMap { child in
+            guard let uri = child.mediaContentID, let title = child.title else {
+                return nil
+            }
+            return MusicPlaylistTrack(uri: uri, title: title, imageURL: child.thumbnail)
+        }
     }
 }

--- a/IntelliNest/Model/MusicSearchResult.swift
+++ b/IntelliNest/Model/MusicSearchResult.swift
@@ -169,11 +169,13 @@ struct MusicPlaylistBrowseResponse: Decodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DynamicKey.self)
-        guard let entityKey = container.allKeys.first,
-              let node = try? container.decode(Node.self, forKey: entityKey) else {
-            tracks = []
-            return
+        guard let entityKey = container.allKeys.first else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "Expected a browsed playlist node keyed by entity id."
+            ))
         }
+        let node = try container.decode(Node.self, forKey: entityKey)
         tracks = (node.children ?? []).compactMap { child in
             guard let uri = child.mediaContentID, let title = child.title else {
                 return nil

--- a/IntelliNest/Services/RestAPIService+Music.swift
+++ b/IntelliNest/Services/RestAPIService+Music.swift
@@ -16,12 +16,39 @@ extension RestAPIService {
     /// discards bodies).
     func searchMusic(query: String, limit: Int = 10) async throws -> MusicSearchResponse {
         let path = "/api/services/\(Domain.musicAssistant.rawValue)/\(Action.search.rawValue)"
-        let queryParams = ["return_response": "true"]
         var json = [JSONKey: Any]()
         json[.configEntryID] = GlobalConstants.musicAssistantConfigEntryID
         json[.name] = query
         json[.mediaType] = MusicMediaType.allCases.map(\.rawValue)
         json[.limit] = limit
+
+        let data = try await postExpectingResponseData(path: path, json: json)
+        return try decodeSearchResponse(from: data)
+    }
+
+    /// Browses a playlist's tracks via `media_player.browse_media`. The browse
+    /// runs against `entityID` (any available speaker), but only reads the
+    /// playlist contents — it does not change what that speaker is playing.
+    func browsePlaylistTracks(playlistURI: String, on entityID: EntityId) async throws -> [MusicPlaylistTrack] {
+        let path = "/api/services/\(Domain.mediaPlayer.rawValue)/\(Action.browseMedia.rawValue)"
+        var json = [JSONKey: Any]()
+        json[.entityID] = entityID.rawValue
+        json[.mediaContentType] = MusicMediaType.playlist.rawValue
+        json[.mediaContentID] = playlistURI
+
+        let data = try await postExpectingResponseData(path: path, json: json)
+        let decoder = JSONDecoder()
+        if let wrapper = try? decoder.decode(MusicPlaylistBrowseServiceResponse.self, from: data) {
+            return wrapper.serviceResponse.tracks
+        }
+        return try decoder.decode(MusicPlaylistBrowseResponse.self, from: data).tracks
+    }
+
+    /// POSTs a service call with `?return_response` and returns the response
+    /// body, retrying against the external URL when the internal one fails.
+    /// Used by the music services that read data back (search, browse).
+    private func postExpectingResponseData(path: String, json: [JSONKey: Any]) async throws -> Data {
+        let queryParams = ["return_response": "true"]
         let jsonData = createJSONData(json: json)
 
         guard let request = createURLRequest(path: path, jsonData: jsonData, queryParams: queryParams, method: .post) else {
@@ -30,7 +57,7 @@ extension RestAPIService {
 
         let (statusCode, data) = await sendRequest(request)
         if statusCode == statusCodeOK, let data {
-            return try decodeSearchResponse(from: data)
+            return data
         }
 
         let url = request.url?.absoluteString ?? ""
@@ -48,7 +75,7 @@ extension RestAPIService {
         guard externalStatusCode == statusCodeOK, let externalData else {
             throw EntityError.httpRequestFailure
         }
-        return try decodeSearchResponse(from: externalData)
+        return externalData
     }
 
     /// The service envelope wraps the actual result under `service_response`.
@@ -65,12 +92,12 @@ extension RestAPIService {
     /// (a `spotify://…` uri). Returns whether the request succeeded so the
     /// caller can surface a failure instead of showing a false playing state.
     @discardableResult
-    func playMedia(on entityID: EntityId, mediaID: String, mediaType: MusicMediaType) async -> Bool {
+    func playMedia(on entityID: EntityId, mediaID: String, mediaType: MusicMediaType, enqueue: String = "replace") async -> Bool {
         var json = [JSONKey: Any]()
         json[.entityID] = entityID.rawValue
         json[.mediaID] = mediaID
         json[.mediaType] = mediaType.rawValue
-        json[.enqueue] = "replace"
+        json[.enqueue] = enqueue
         return await sendMusicPostExpectingSuccess(domain: .musicAssistant, action: .playMedia, json: json)
     }
 
@@ -155,6 +182,15 @@ extension RestAPIService {
 /// Wrapper for the Home Assistant service-call response envelope.
 private struct MusicSearchServiceResponse: Decodable {
     let serviceResponse: MusicSearchResponse
+
+    enum CodingKeys: String, CodingKey {
+        case serviceResponse = "service_response"
+    }
+}
+
+/// Wrapper for the `browse_media` service-call response envelope.
+private struct MusicPlaylistBrowseServiceResponse: Decodable {
+    let serviceResponse: MusicPlaylistBrowseResponse
 
     enum CodingKeys: String, CodingKey {
         case serviceResponse = "service_response"

--- a/IntelliNest/Utils/Constants/Actions.swift
+++ b/IntelliNest/Utils/Constants/Actions.swift
@@ -53,4 +53,5 @@ enum Action: String, Codable {
     case repeatSet = "repeat_set"
     case join
     case unjoin
+    case browseMedia = "browse_media"
 }

--- a/IntelliNest/Utils/Constants/JSONKey.swift
+++ b/IntelliNest/Utils/Constants/JSONKey.swift
@@ -54,6 +54,8 @@ enum JSONKey: String, Equatable, Codable, Hashable {
     case mediaType = "media_type"
     case limit
     case mediaID = "media_id"
+    case mediaContentID = "media_content_id"
+    case mediaContentType = "media_content_type"
     case enqueue
     case volumeLevel = "volume_level"
     case shuffle

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -32,6 +32,9 @@ class MusicViewModel: ObservableObject, Reloadable {
 
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false
+    /// Increments on every search so a slow, older response can't overwrite the
+    /// results of a newer query.
+    private var searchRequestToken = 0
 
     private let restAPIService: RestAPIService
     private let setErrorBannerText: StringStringClosure
@@ -120,18 +123,32 @@ class MusicViewModel: ObservableObject, Reloadable {
             return
         }
 
+        searchRequestToken += 1
+        let token = searchRequestToken
         isShowingSearchResults = true
         isSearching = true
         hasSearched = true
         do {
             let response = try await restAPIService.searchMusic(query: query)
+            guard token == searchRequestToken else {
+                return
+            }
             searchSections = response.sections
         } catch {
+            guard token == searchRequestToken else {
+                return
+            }
             Log.error("Music search failed: \(error)")
+            // Don't leave the UI in a "no results" state — close the results
+            // sheet and surface the failure through the error banner instead.
             searchSections = []
+            hasSearched = false
+            isShowingSearchResults = false
             setErrorBannerText("Sökningen misslyckades", "Kunde inte söka efter musik")
         }
-        isSearching = false
+        if token == searchRequestToken {
+            isSearching = false
+        }
     }
 
     var hasNoResults: Bool {

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -29,6 +29,11 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// Drives the search-results sheet, which presents the grouped results in a
     /// separate view with a tab per media-type category.
     @Published var isShowingSearchResults = false
+    /// The playlist the user drilled into (nil = showing the result list). Tapping
+    /// a playlist opens it here instead of playing it immediately.
+    @Published var openedPlaylist: MusicSearchItem?
+    @Published var playlistTracks: [MusicPlaylistTrack] = []
+    @Published var isLoadingPlaylist = false
 
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false
@@ -125,6 +130,7 @@ class MusicViewModel: ObservableObject, Reloadable {
 
         searchRequestToken += 1
         let token = searchRequestToken
+        openedPlaylist = nil
         isShowingSearchResults = true
         isSearching = true
         hasSearched = true
@@ -168,23 +174,82 @@ class MusicViewModel: ObservableObject, Reloadable {
     }
 
     func play(item: MusicSearchItem) async {
+        if await startPlayback(uri: item.uri, mediaType: item.mediaType, title: item.name, artist: item.artist) {
+            closeSearchResults()
+        }
+    }
+
+    /// Starts (or enqueues) playback of a media item on the active speaker's
+    /// group leader. Returns whether the request succeeded so callers can chain
+    /// follow-up actions and avoid showing a false playing state.
+    @discardableResult
+    private func startPlayback(uri: String,
+                               mediaType: MusicMediaType,
+                               title: String?,
+                               artist: String?,
+                               enqueue: String = "replace") async -> Bool {
         guard let activeSpeakerID, let targetID = playbackTargetID else {
             setErrorBannerText("Ingen högtalare vald", "Välj en högtalare innan du spelar musik")
-            return
+            return false
         }
 
-        let success = await restAPIService.playMedia(on: targetID,
-                                                     mediaID: item.uri,
-                                                     mediaType: item.mediaType)
+        let success = await restAPIService.playMedia(on: targetID, mediaID: uri, mediaType: mediaType, enqueue: enqueue)
         if success {
             // Optimistically reflect what we just started; a reload confirms it.
             speakers[activeSpeakerID]?.state = "playing"
-            speakers[activeSpeakerID]?.mediaTitle = item.name
-            speakers[activeSpeakerID]?.mediaArtist = item.artist
+            speakers[activeSpeakerID]?.mediaTitle = title
+            speakers[activeSpeakerID]?.mediaArtist = artist
             restAPIService.triggerRepeatReload(times: 3)
         } else {
             setErrorBannerText("Kunde inte spela", "Det gick inte att starta uppspelningen")
         }
+        return success
+    }
+
+    // MARK: - Playlists
+
+    /// Opens a playlist for browsing instead of playing it: records the opened
+    /// playlist (which drills the sheet into the detail view) and loads its
+    /// tracks. Browsing reads the playlist contents and never changes playback.
+    func openPlaylist(_ playlist: MusicSearchItem) async {
+        openedPlaylist = playlist
+        playlistTracks = []
+        isLoadingPlaylist = true
+        let browseSpeaker = activeSpeakerID ?? availableSpeakers.first?.entityId
+        if let browseSpeaker {
+            do {
+                playlistTracks = try await restAPIService.browsePlaylistTracks(playlistURI: playlist.uri, on: browseSpeaker)
+            } catch {
+                Log.error("Failed to browse playlist: \(error)")
+                setErrorBannerText("Kunde inte öppna spellistan", "Det gick inte att hämta låtarna")
+            }
+        }
+        isLoadingPlaylist = false
+    }
+
+    /// Plays the whole playlist from the start on the active speaker.
+    func playPlaylist(_ playlist: MusicSearchItem) async {
+        if await startPlayback(uri: playlist.uri, mediaType: .playlist, title: playlist.name, artist: nil) {
+            closeSearchResults()
+        }
+    }
+
+    /// Plays the chosen track now, then queues the rest of the playlist after it,
+    /// so the tapped song is followed by the playlist.
+    func playTrackInPlaylist(_ track: MusicPlaylistTrack, from playlist: MusicSearchItem) async {
+        guard await startPlayback(uri: track.uri, mediaType: .track, title: track.title, artist: nil) else {
+            return
+        }
+        if let targetID = playbackTargetID {
+            await restAPIService.playMedia(on: targetID, mediaID: playlist.uri, mediaType: .playlist, enqueue: "add")
+        }
+        closeSearchResults()
+    }
+
+    /// Dismisses the search-results sheet and clears any opened playlist.
+    func closeSearchResults() {
+        isShowingSearchResults = false
+        openedPlaylist = nil
     }
 
     func togglePlayPause() {

--- a/IntelliNest/Views/Dashboards/HomeView.swift
+++ b/IntelliNest/Views/Dashboards/HomeView.swift
@@ -69,15 +69,15 @@ private struct HouseInfoView: View {
                     .lineLimit(6)
             }
             Spacer()
-            VStack {
-                Text("""
-                Elnät: ***\(viewModel.pulsePower.state.toKW)***
-                Pris: ***\(viewModel.tibberPrice.state.toOre)***
-                Producerat idag: ***\(viewModel.solarProductionToday.state.toKWh)***
-                Köpt idag: ***\(viewModel.pulseConsumptionToday.state.toKWh)***
-                """)
-                .font(.buttonFontMedium)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Elnät: ***\(viewModel.pulsePower.state.toKW)***")
+                Text("Pris: ***\(viewModel.tibberPrice.state.toOre)***")
+                Text("Producerat idag: ***\(viewModel.solarProductionToday.state.toKWh)***")
+                Text("Köpt idag: ***\(viewModel.pulseConsumptionToday.state.toKWh)***")
             }
+            .font(.buttonFontMedium)
+            .fixedSize(horizontal: true, vertical: false)
+            .layoutPriority(1)
             .padding(.trailing, 20)
         }
         .foregroundStyle(.white)

--- a/IntelliNest/Views/Music/MusicSearchResultsView.swift
+++ b/IntelliNest/Views/Music/MusicSearchResultsView.swift
@@ -9,10 +9,10 @@ import SwiftUI
 
 /// Presents the search results in their own sheet with a tab per media-type
 /// category (Låtar / Album / Artister / Spellistor). Shows a spinner while the
-/// search runs and a Swedish "no results" state when nothing matched.
+/// search runs and a Swedish "no results" state when nothing matched. Tapping a
+/// playlist drills into ``MusicPlaylistView`` rather than playing immediately.
 struct MusicSearchResultsView: View {
     @ObservedObject var viewModel: MusicViewModel
-    @Environment(\.dismiss) private var dismiss
     @State private var selectedType: MusicMediaType?
 
     var body: some View {
@@ -29,9 +29,12 @@ struct MusicSearchResultsView: View {
                             .lineLimit(1)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
-                        Button("Stäng") { dismiss() }
+                        Button("Stäng") { viewModel.closeSearchResults() }
                             .foregroundStyle(.white)
                     }
+                }
+                .navigationDestination(item: $viewModel.openedPlaylist) { playlist in
+                    MusicPlaylistView(viewModel: viewModel, playlist: playlist)
                 }
         }
     }
@@ -69,10 +72,14 @@ struct MusicSearchResultsView: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 8) {
                     ForEach(section.items) { item in
-                        MusicResultRow(item: item) {
-                            Task {
-                                await viewModel.play(item: item)
-                                dismiss()
+                        if item.mediaType == .playlist {
+                            // A playlist opens its track list instead of playing.
+                            MusicResultRow(item: item, trailingSystemImage: "chevron.right") {
+                                Task { await viewModel.openPlaylist(item) }
+                            }
+                        } else {
+                            MusicResultRow(item: item) {
+                                Task { await viewModel.play(item: item) }
                             }
                         }
                     }
@@ -102,8 +109,97 @@ struct MusicSearchResultsView: View {
     }
 }
 
+/// The drill-in view for a playlist: a header with cover art and a play button
+/// that plays the whole list, plus the track list where tapping a song plays
+/// that song followed by the rest of the playlist.
+struct MusicPlaylistView: View {
+    @ObservedObject var viewModel: MusicViewModel
+    let playlist: MusicSearchItem
+
+    var body: some View {
+        VStack(spacing: 16) {
+            header
+            trackList
+        }
+        .padding(.horizontal)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .backgroundModifier()
+        .foregroundStyle(.white)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(playlist.name)
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            AlbumArtView(urlString: playlist.imageURL, size: 140)
+            Text(playlist.name)
+                .font(.title3)
+                .bold()
+                .multilineTextAlignment(.center)
+            Button {
+                Task { await viewModel.playPlaylist(playlist) }
+            } label: {
+                Label("Spela", systemImage: "play.fill")
+                    .font(.headline)
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 28)
+                    .background(Color.white.opacity(0.15))
+                    .clipShape(Capsule())
+            }
+            .accessibilityLabel("Spela spellistan \(playlist.name)")
+        }
+        .padding(.top, 12)
+    }
+
+    @ViewBuilder private var trackList: some View {
+        if viewModel.isLoadingPlaylist {
+            ProgressView()
+                .tint(.white)
+                .padding(.top, 40)
+            Spacer()
+        } else if viewModel.playlistTracks.isEmpty {
+            Text("Inga låtar")
+                .foregroundStyle(.white.opacity(0.7))
+                .padding(.top, 40)
+            Spacer()
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(viewModel.playlistTracks) { track in
+                        Button {
+                            Task { await viewModel.playTrackInPlaylist(track, from: playlist) }
+                        } label: {
+                            HStack(spacing: 12) {
+                                AlbumArtView(urlString: track.imageURL, size: 44)
+                                Text(track.title)
+                                    .font(.body)
+                                    .lineLimit(1)
+                                Spacer()
+                                Image(systemName: "play.fill")
+                                    .foregroundStyle(.white.opacity(0.6))
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        .foregroundStyle(.white)
+                        .accessibilityLabel("Spela \(track.title)")
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}
+
 private struct MusicResultRow: View {
     let item: MusicSearchItem
+    var trailingSystemImage = "play.fill"
     let onTap: MainActorVoidClosure
 
     var body: some View {
@@ -122,12 +218,12 @@ private struct MusicResultRow: View {
                     }
                 }
                 Spacer()
-                Image(systemName: "play.fill")
+                Image(systemName: trailingSystemImage)
                     .foregroundStyle(.white.opacity(0.6))
             }
             .padding(.vertical, 4)
         }
         .foregroundStyle(.white)
-        .accessibilityLabel("Spela \(item.name)")
+        .accessibilityLabel(item.mediaType == .playlist ? "Öppna \(item.name)" : "Spela \(item.name)")
     }
 }

--- a/IntelliNestTests/MusicModelTests.swift
+++ b/IntelliNestTests/MusicModelTests.swift
@@ -333,6 +333,12 @@ final class MusicModelTests: XCTestCase {
         XCTAssertTrue(response.tracks.isEmpty)
     }
 
+    func testPlaylistBrowseResponseThrowsOnMalformedPayload() {
+        // No entity-id node at all — must surface as a failure, not an empty playlist.
+        let json = "{}"
+        XCTAssertThrowsError(try JSONDecoder().decode(MusicPlaylistBrowseResponse.self, from: Data(json.utf8)))
+    }
+
     @MainActor
     func testBrowsePlaylistTracksUnwrapsEnvelopeAndFallsBackToExternalURL() async throws {
         URLProtocolStub.startInterceptingRequests()

--- a/IntelliNestTests/MusicModelTests.swift
+++ b/IntelliNestTests/MusicModelTests.swift
@@ -139,7 +139,9 @@ final class MusicModelTests: XCTestCase {
         base.volumeLevel = 0.5
         base.mediaTitle = trackName
         base.mediaArtist = trackArtist
+        base.mediaAlbumName = "A Night at the Opera"
         base.mediaContentID = trackURI
+        base.entityPicture = "/api/media_player_proxy/kitchen.jpg"
         base.groupMembers = [.mediaPlayerLivingRoom]
         base.shuffle = true
         base.repeatMode = .one
@@ -149,10 +151,13 @@ final class MusicModelTests: XCTestCase {
 
         // Each mutated property must break equality, exercising every clause of ==.
         same = base; same.state = "paused"; XCTAssertNotEqual(base, same)
+        same = base; same.friendlyName = "Köket"; XCTAssertNotEqual(base, same)
         same = base; same.volumeLevel = 0.9; XCTAssertNotEqual(base, same)
         same = base; same.mediaTitle = "Other"; XCTAssertNotEqual(base, same)
         same = base; same.mediaArtist = "Other"; XCTAssertNotEqual(base, same)
+        same = base; same.mediaAlbumName = "Other album"; XCTAssertNotEqual(base, same)
         same = base; same.mediaContentID = "spotify://track/other"; XCTAssertNotEqual(base, same)
+        same = base; same.entityPicture = "/api/media_player_proxy/other.jpg"; XCTAssertNotEqual(base, same)
         same = base; same.groupMembers = []; XCTAssertNotEqual(base, same)
         same = base; same.shuffle = false; XCTAssertNotEqual(base, same)
         same = base; same.repeatMode = .off; XCTAssertNotEqual(base, same)

--- a/IntelliNestTests/MusicModelTests.swift
+++ b/IntelliNestTests/MusicModelTests.swift
@@ -307,4 +307,51 @@ final class MusicModelTests: XCTestCase {
 
         XCTAssertFalse(success)
     }
+
+    // MARK: - Playlist browse
+
+    func testPlaylistBrowseResponseDecodesTracksAndDropsInvalid() throws {
+        let json = """
+        {"media_player.kitchen":{"title":"Sommar","media_class":"playlist","children":[
+          {"title":"Song A","media_content_id":"spotify://track/a","thumbnail":"https://img/a.jpg"},
+          {"title":"Song B","media_content_id":"spotify://track/b","thumbnail":null},
+          {"title":null,"media_content_id":"spotify://track/c"},
+          {"title":"Missing uri","media_content_id":null}
+        ]}}
+        """
+        let response = try JSONDecoder().decode(MusicPlaylistBrowseResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(response.tracks.count, 2)
+        XCTAssertEqual(response.tracks.first?.uri, "spotify://track/a")
+        XCTAssertEqual(response.tracks.first?.title, "Song A")
+        XCTAssertEqual(response.tracks.first?.imageURL, "https://img/a.jpg")
+        XCTAssertNil(response.tracks.last?.imageURL)
+    }
+
+    func testPlaylistBrowseResponseEmptyWhenNoChildren() throws {
+        let json = "{\"media_player.kitchen\":{\"title\":\"Sommar\"}}"
+        let response = try JSONDecoder().decode(MusicPlaylistBrowseResponse.self, from: Data(json.utf8))
+        XCTAssertTrue(response.tracks.isEmpty)
+    }
+
+    @MainActor
+    func testBrowsePlaylistTracksUnwrapsEnvelopeAndFallsBackToExternalURL() async throws {
+        URLProtocolStub.startInterceptingRequests()
+        defer { URLProtocolStub.stopInterceptingRequests() }
+        let (service, _) = makeService()
+        // Only the external URL is stubbed, so the internal attempt must fail over.
+        var components = URLComponents(string: GlobalConstants.baseExternalUrlString)!
+        components.path = "/api/services/media_player/browse_media"
+        components.queryItems = [URLQueryItem(name: "return_response", value: "true")]
+        let url = components.url!
+        let body = "{\"service_response\":{\"media_player.kitchen\":{\"children\":" +
+            "[{\"title\":\"Song A\",\"media_content_id\":\"spotify://track/a\"}]}}}"
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(body.utf8), response: response, error: nil)
+
+        let tracks = try await service.browsePlaylistTracks(playlistURI: "spotify://playlist/p1", on: .mediaPlayerKitchen)
+
+        XCTAssertEqual(tracks.count, 1)
+        XCTAssertEqual(tracks.first?.uri, "spotify://track/a")
+        XCTAssertEqual(tracks.first?.title, "Song A")
+    }
 }

--- a/IntelliNestTests/MusicViewModelTests.swift
+++ b/IntelliNestTests/MusicViewModelTests.swift
@@ -210,6 +210,9 @@ class MusicViewModelTests: XCTestCase {
         await viewModel.search()
         XCTAssertTrue(viewModel.searchSections.isEmpty)
         XCTAssertTrue(bannerTitles.contains("Sökningen misslyckades"))
+        // A failure must not look like an empty result, and it closes the sheet.
+        XCTAssertFalse(viewModel.hasNoResults)
+        XCTAssertFalse(viewModel.isShowingSearchResults)
     }
 
     // MARK: - Play

--- a/IntelliNestTests/MusicViewModelTests.swift
+++ b/IntelliNestTests/MusicViewModelTests.swift
@@ -458,4 +458,84 @@ extension MusicViewModelTests {
         XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.volumeLevel, 0.9)
         XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.mediaTitle, trackName)
     }
+
+    // MARK: - Playlists
+
+    private var playlistItem: MusicSearchItem {
+        MusicSearchItem(uri: "spotify://playlist/p1", name: "Sommar", mediaType: .playlist, imageURL: nil, artist: nil)
+    }
+
+    private func browseURL() -> URL {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/services/media_player/browse_media"
+        components.queryItems = [URLQueryItem(name: "return_response", value: "true")]
+        return components.url!
+    }
+
+    private func stubBrowse(json: String, statusCode: Int = 200) {
+        let url = browseURL()
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(json.utf8), response: response, error: nil)
+    }
+
+    func testOpenPlaylistDrillsInAndLoadsTracks() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubBrowse(json: "{\"service_response\":{\"media_player.kitchen\":{\"children\":" +
+            "[{\"title\":\"Song A\",\"media_content_id\":\"spotify://track/a\"}]}}}")
+        await viewModel.openPlaylist(playlistItem)
+        XCTAssertEqual(viewModel.openedPlaylist, playlistItem)
+        XCTAssertEqual(viewModel.playlistTracks.count, 1)
+        XCTAssertEqual(viewModel.playlistTracks.first?.uri, "spotify://track/a")
+        XCTAssertFalse(viewModel.isLoadingPlaylist)
+    }
+
+    func testOpenPlaylistFailureShowsBanner() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubBrowse(json: "boom", statusCode: 500)
+        await viewModel.openPlaylist(playlistItem)
+        XCTAssertTrue(viewModel.playlistTracks.isEmpty)
+        XCTAssertTrue(bannerTitles.contains("Kunde inte öppna spellistan"))
+        XCTAssertFalse(viewModel.isLoadingPlaylist)
+    }
+
+    func testPlayPlaylistStartsPlaybackAndClosesSheet() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        viewModel.isShowingSearchResults = true
+        viewModel.openedPlaylist = playlistItem
+        stubPlayMedia(statusCode: 200)
+        await viewModel.playPlaylist(playlistItem)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+        XCTAssertFalse(viewModel.isShowingSearchResults)
+        XCTAssertNil(viewModel.openedPlaylist)
+    }
+
+    func testPlayTrackInPlaylistPlaysTrackThenClosesSheet() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        viewModel.isShowingSearchResults = true
+        viewModel.openedPlaylist = playlistItem
+        stubPlayMedia(statusCode: 200)
+        let track = MusicPlaylistTrack(uri: "spotify://track/a", title: "Song A", imageURL: nil)
+        await viewModel.playTrackInPlaylist(track, from: playlistItem)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.mediaTitle, "Song A")
+        XCTAssertFalse(viewModel.isShowingSearchResults)
+        XCTAssertNil(viewModel.openedPlaylist)
+    }
+
+    func testCloseSearchResultsResetsState() {
+        viewModel.isShowingSearchResults = true
+        viewModel.openedPlaylist = playlistItem
+        viewModel.closeSearchResults()
+        XCTAssertFalse(viewModel.isShowingSearchResults)
+        XCTAssertNil(viewModel.openedPlaylist)
+    }
+
+    func testSearchClearsOpenedPlaylist() async {
+        viewModel.openedPlaylist = playlistItem
+        stubSearch(json: "{\"tracks\":[{\"uri\":\"spotify://track/a\",\"name\":\"Song A\"}]}")
+        viewModel.searchText = "song"
+        await viewModel.search()
+        XCTAssertNil(viewModel.openedPlaylist)
+        XCTAssertTrue(viewModel.isShowingSearchResults)
+    }
 }


### PR DESCRIPTION
## Summary
Follow-up polish on the music controller plus the dashboard, all on top of the merged music feature.

- **Dashboard:** moved the power-grid button up to the top row next to the car; Musik now sits in the grid's old spot (one fewer row).
- **Search field** no longer slides up behind the navigation bar when the keyboard appears (search bar pinned, content scrolls).
- **Search results** now open in their own sheet with a tab per category (Låtar / Album / Artister / Spellistor).
- **Grouped-speaker playback fixed:** playback / transport / shuffle / repeat now target the group leader, so synced speakers (e.g. Gästrummet + Lekrummet) play instead of failing. Volume stays per-speaker.
- **Speaker icon** is consistent again; "playing" shows as an intentional green badge rather than a different icon.
- **Home info stats** no longer collapse to a single truncated line — each stat renders on its own row, full width, no ellipsis.
- **Playlist drill-in:** tapping a playlist opens its track list (it no longer auto-plays). The detail view has a Spela button that plays the whole list, and tapping any song plays that song followed by the rest of the playlist.
- **Review feedback from #115 addressed:** `MediaPlayerEntity.==` now compares the displayed metadata fields; `search()` has request sequencing so a slow old response can't overwrite newer results and a failure no longer shows a misleading "no results" state.
- Version bumped to **2026.6.1 (build 92)**.

## Test plan
- Full suite green on iPhone 17 simulator; added unit tests for the group-leader playback target, search sequencing/failure state, the expanded equality, playlist browse decoding (incl. envelope + external-URL fallback), and the playlist open/play/tap-to-play flows.
- SwiftFormat clean, SwiftLint 0 errors.

Note: playlist contents are read via Music Assistant `browse_media` (read-only); no playback was triggered against the live system during development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added playlist browsing and track exploration from music search results.
  * Enabled playlist playback with individual track selection within playlist context.

* **Chores**
  * Updated app version to 2026.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->