### PR TITLE
Per-speaker volume controls and clearer selected speaker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ xcodebuild test \
   -project IntelliNest.xcodeproj \
   -scheme "IntelliNest-github" \
   -testPlan "IntelliNest-github" \
-  -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
+  -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
   -configuration "Github actions" \
   CODE_SIGNING_ALLOWED=NO | xcbeautify
 ```
@@ -20,7 +20,7 @@ xcodebuild test \
 xcodebuild test \
   -project IntelliNest.xcodeproj \
   -scheme "IntelliNest-github" \
-  -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
+  -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
   -configuration "Github actions" \
   -only-testing:IntelliNestTests/HomeViewModelTests \
   CODE_SIGNING_ALLOWED=NO | xcbeautify

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -279,8 +279,15 @@ class MusicViewModel: ObservableObject, Reloadable {
         guard let activeSpeakerID else {
             return
         }
-        speakers[activeSpeakerID]?.volumeLevel = volume
-        restAPIService.setVolume(entityID: activeSpeakerID, volume: volume)
+        setVolume(volume, for: activeSpeakerID)
+    }
+
+    /// Sets the volume of a specific speaker. Volume is always per-speaker (never
+    /// redirected to a group leader), so any speaker in the list can be adjusted
+    /// in place.
+    func setVolume(_ volume: Double, for speakerID: EntityId) {
+        speakers[speakerID]?.volumeLevel = volume
+        restAPIService.setVolume(entityID: speakerID, volume: volume)
     }
 
     func toggleShuffle() {

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -13,6 +13,24 @@ struct NowPlayingView: View {
 
     var body: some View {
         VStack(spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "hifispeaker.fill")
+                    .foregroundStyle(.yellow)
+                Text(speaker.friendlyName)
+                    .font(.headline)
+                    .foregroundStyle(.yellow)
+                    .lineLimit(1)
+                Spacer()
+                Button {
+                    viewModel.activeSpeakerID = nil
+                } label: {
+                    Image(systemName: "hifispeaker.2.fill")
+                }
+                .accessibilityLabel("Byt högtalare")
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Vald högtalare: \(speaker.friendlyName)")
+
             HStack(spacing: 12) {
                 AlbumArtView(urlString: speaker.entityPicture, size: 64)
                 VStack(alignment: .leading, spacing: 2) {
@@ -25,17 +43,8 @@ struct NowPlayingView: View {
                             .foregroundStyle(.white.opacity(0.7))
                             .lineLimit(1)
                     }
-                    Text(speaker.friendlyName)
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.5))
                 }
                 Spacer()
-                Button {
-                    viewModel.activeSpeakerID = nil
-                } label: {
-                    Image(systemName: "hifispeaker.2.fill")
-                }
-                .accessibilityLabel("Byt högtalare")
             }
 
             TransportControlsView(speaker: speaker, viewModel: viewModel)
@@ -46,6 +55,10 @@ struct NowPlayingView: View {
         .padding()
         .background(Color.white.opacity(0.08))
         .cornerRadius(16)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.yellow.opacity(0.7), lineWidth: 2)
+        )
     }
 }
 
@@ -108,7 +121,7 @@ private struct TransportControlsView: View {
     }
 }
 
-private struct VolumeSliderView: View {
+struct VolumeSliderView: View {
     let volume: Double
     let onChange: DoubleClosure
 

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -22,22 +22,34 @@ struct SpeakerGroupingView: View {
                 .font(.headline)
             ForEach(otherSpeakers, id: \.entityId) { speaker in
                 let grouped = viewModel.isGrouped(speaker.entityId)
-                Button {
-                    viewModel.toggleGroupMember(speaker.entityId)
-                } label: {
-                    HStack {
-                        Image(systemName: grouped ? "checkmark.circle.fill" : "circle")
-                            .foregroundStyle(grouped ? .yellow : .white.opacity(0.6))
-                        Text(speaker.friendlyName)
-                        Spacer()
+                VStack(spacing: 8) {
+                    Button {
+                        viewModel.toggleGroupMember(speaker.entityId)
+                    } label: {
+                        HStack {
+                            Image(systemName: grouped ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(grouped ? .yellow : .white.opacity(0.6))
+                            Text(speaker.friendlyName)
+                            if speaker.isPlaying {
+                                Image(systemName: "speaker.wave.2.fill")
+                                    .font(.caption)
+                                    .foregroundStyle(.green)
+                                    .accessibilityLabel("Spelar nu")
+                            }
+                            Spacer()
+                        }
                     }
-                    .padding(.vertical, 8)
-                    .padding(.horizontal, 12)
-                    .background(Color.white.opacity(0.06))
-                    .cornerRadius(10)
+                    .accessibilityLabel("\(grouped ? "Ta bort" : "Lägg till") \(speaker.friendlyName) i gruppen")
+                    .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
+
+                    VolumeSliderView(volume: speaker.volumeLevel,
+                                     onChange: { viewModel.setVolume($0, for: speaker.entityId) })
+                        .accessibilityLabel("Volym \(speaker.friendlyName)")
                 }
-                .accessibilityLabel("\(grouped ? "Ta bort" : "Lägg till") \(speaker.friendlyName) i gruppen")
-                .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
+                .padding(.vertical, 8)
+                .padding(.horizontal, 12)
+                .background(grouped ? Color.yellow.opacity(0.12) : Color.white.opacity(0.06))
+                .cornerRadius(10)
             }
         }
         .padding()

--- a/IntelliNest/Views/Music/SpeakerPickerView.swift
+++ b/IntelliNest/Views/Music/SpeakerPickerView.swift
@@ -17,25 +17,34 @@ struct SpeakerPickerView: View {
             Text("Välj högtalare")
                 .font(.headline)
             ForEach(viewModel.availableSpeakers, id: \.entityId) { speaker in
-                Button {
-                    viewModel.selectSpeaker(speaker.entityId)
-                } label: {
-                    HStack {
-                        Image(systemName: "hifispeaker.fill")
-                        Text(speaker.friendlyName)
-                        Spacer()
-                        if speaker.isPlaying {
-                            Image(systemName: "speaker.wave.2.fill")
-                                .foregroundStyle(.green)
-                                .accessibilityLabel("Spelar nu")
+                VStack(spacing: 8) {
+                    Button {
+                        viewModel.selectSpeaker(speaker.entityId)
+                    } label: {
+                        HStack {
+                            Image(systemName: "hifispeaker.fill")
+                            Text(speaker.friendlyName)
+                            Spacer()
+                            if speaker.isPlaying {
+                                Image(systemName: "speaker.wave.2.fill")
+                                    .foregroundStyle(.green)
+                                    .accessibilityLabel("Spelar nu")
+                            }
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(.white.opacity(0.5))
                         }
                     }
-                    .padding(.vertical, 10)
-                    .padding(.horizontal, 12)
-                    .background(Color.white.opacity(0.08))
-                    .cornerRadius(10)
+                    .accessibilityLabel("Välj \(speaker.friendlyName)")
+
+                    VolumeSliderView(volume: speaker.volumeLevel,
+                                     onChange: { viewModel.setVolume($0, for: speaker.entityId) })
+                        .accessibilityLabel("Volym \(speaker.friendlyName)")
                 }
-                .accessibilityLabel("Välj \(speaker.friendlyName)")
+                .padding(.vertical, 10)
+                .padding(.horizontal, 12)
+                .background(Color.white.opacity(0.08))
+                .cornerRadius(10)
             }
         }
         .padding()

--- a/IntelliNestTests/MusicViewModelTests.swift
+++ b/IntelliNestTests/MusicViewModelTests.swift
@@ -333,6 +333,21 @@ class MusicViewModelTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 2.0)
     }
 
+    func testSetVolumeForSpecificSpeakerAdjustsThatSpeakerWithoutSelecting() async {
+        // No active speaker — volume can still be set on any speaker in place.
+        let expectation = XCTestExpectation(description: "POST volume_set")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/volume_set") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/volume_set")
+        viewModel.setVolume(0.42, for: .mediaPlayerSpa)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerSpa]?.volumeLevel, 0.42)
+        XCTAssertNil(viewModel.activeSpeakerID)
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
     // MARK: - Shuffle / Repeat
 
     func testToggleShuffle() async {


### PR DESCRIPTION
## Summary
- **In-place volume per speaker:** every speaker row now has its own volume slider — in the speaker picker (no speaker selected yet) and in the grouping list (other speakers). Combined with the now-playing slider, every speaker is adjustable in place without selecting it first.
- **Clearer selected speaker:** the active speaker's Now Playing card now has a yellow accent border and shows the speaker name prominently in accent at the top (was a faint caption). Grouped speakers get a subtle highlight, and currently-playing speakers keep the green badge.
- Volume is always per-speaker (never redirected to a group leader), via a new `setVolume(_:for:)`.
- Docs: updated the CLAUDE.md test commands to the `iPhone 17` simulator (iPhone 16 is no longer installed on the runner or locally).

## Test plan
- Added a unit test for setting volume on a specific (non-active) speaker.
- Music model + view-model suites pass on iPhone 17; SwiftFormat + SwiftLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-speaker volume control—adjust volume for individual speakers independently.

* **UI/UX Improvements**
  * Enhanced speaker selection with visual indicators and improved layout.
  * Speaker grouping interface redesigned with card-style presentation and individual volume controls.
  * Now Playing view updated with improved speaker name display and visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->