### PR TITLE
Show volume percentage next to each speaker slider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,7 @@ jobs:
           # Runner images drop/rename device types (iPhone 16 -> 17 -> ...), and
           # xcodebuild sometimes fails to enumerate simulators by name; querying
           # simctl directly is more reliable and version-agnostic.
-          SIM_ID=$(xcrun simctl list devices available -j | python3 -c "import sys, json
-devices = json.load(sys.stdin)['devices']
-candidates = [device for runtime in sorted(devices) for device in devices[runtime] if device['name'].startswith('iPhone')]
-candidates.sort(key=lambda device: device['name'])
-print(candidates[-1]['udid'] if candidates else '')")
+          SIM_ID=$(xcrun simctl list devices available -j | python3 -c "import sys, json; ds = json.load(sys.stdin)['devices']; phones = sorted([d for r in ds for d in ds[r] if d['name'].startswith('iPhone')], key=lambda d: d['name']); print(phones[-1]['udid'] if phones else '')")
           if [ -z "$SIM_ID" ]; then
             echo "No iPhone simulator available on the runner:"
             xcrun simctl list devices available

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,26 @@ jobs:
       - name: Build and Test
         run: |
           set -o pipefail
+          # Resolve an available iPhone simulator by UDID instead of pinning a name.
+          # Runner images drop/rename device types (iPhone 16 -> 17 -> ...), and
+          # xcodebuild sometimes fails to enumerate simulators by name; querying
+          # simctl directly is more reliable and version-agnostic.
+          SIM_ID=$(xcrun simctl list devices available -j | python3 -c "import sys, json
+devices = json.load(sys.stdin)['devices']
+candidates = [device for runtime in sorted(devices) for device in devices[runtime] if device['name'].startswith('iPhone')]
+candidates.sort(key=lambda device: device['name'])
+print(candidates[-1]['udid'] if candidates else '')")
+          if [ -z "$SIM_ID" ]; then
+            echo "No iPhone simulator available on the runner:"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Using simulator id=$SIM_ID"
           xcodebuild test \
             -project IntelliNest.xcodeproj \
             -scheme "IntelliNest-github" \
             -testPlan "IntelliNest-github" \
-            -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
+            -destination "platform=iOS Simulator,id=$SIM_ID" \
             -configuration "Github actions" \
             -parallel-testing-enabled YES \
             -maximum-parallel-testing-workers 2 \

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -215,7 +215,7 @@ private struct FillSlider: View {
                            height: axis == .vertical ? geometry.size.height * clamped : nil)
             }
             .clipShape(RoundedRectangle(cornerRadius: radius))
-            .overlay(RoundedRectangle(cornerRadius: radius).stroke(.black.opacity(0.5), lineWidth: 1))
+            .overlay(RoundedRectangle(cornerRadius: radius).stroke(Color.black.opacity(0.5), lineWidth: 1))
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -206,13 +206,15 @@ private struct FillSlider: View {
 
     var body: some View {
         GeometryReader { geometry in
-            let clamped = min(max(fraction, 0), 1)
-            let radius = min(geometry.size.width, geometry.size.height) / 2.5
+            let width = geometry.size.width
+            let height = geometry.size.height
+            let clamped = CGFloat(min(max(fraction, 0), 1))
+            let radius = min(width, height) / 2.5
             ZStack(alignment: axis == .horizontal ? .leading : .bottom) {
                 Rectangle().fill(trackColor)
                 Rectangle().fill(fillColor)
-                    .frame(width: axis == .horizontal ? geometry.size.width * clamped : nil,
-                           height: axis == .vertical ? geometry.size.height * clamped : nil)
+                    .frame(width: axis == .horizontal ? width * clamped : nil,
+                           height: axis == .vertical ? height * clamped : nil)
             }
             .clipShape(RoundedRectangle(cornerRadius: radius))
             .overlay(RoundedRectangle(cornerRadius: radius).stroke(Color.black.opacity(0.5), lineWidth: 1))
@@ -220,10 +222,10 @@ private struct FillSlider: View {
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        let fraction: Double = axis == .horizontal
-                            ? value.location.x / geometry.size.width
-                            : 1 - value.location.y / geometry.size.height
-                        onChange(min(max(fraction, 0), 1))
+                        let position: CGFloat = axis == .horizontal
+                            ? value.location.x / width
+                            : CGFloat(1) - value.location.y / height
+                        onChange(Double(min(max(position, 0), 1)))
                     }
                     .onEnded { _ in onCommit() }
             )

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -50,7 +50,7 @@ struct NowPlayingView: View {
             TransportControlsView(speaker: speaker, viewModel: viewModel)
 
             VolumeSliderView(volume: speaker.volumeLevel,
-                             onChange: { viewModel.setVolume($0) })
+                             onCommit: { viewModel.setVolume($0) })
         }
         .padding()
         .background(Color.white.opacity(0.08))
@@ -121,27 +121,82 @@ private struct TransportControlsView: View {
     }
 }
 
+/// Volume control styled like the light-brightness slider (`VerticalSlider`):
+/// a custom fill bar that updates the label live while dragging and commits the
+/// new volume to Home Assistant only on release (no request spam mid-drag).
 struct VolumeSliderView: View {
     let volume: Double
-    let onChange: DoubleClosure
+    let onCommit: DoubleClosure
+
+    @State private var dragValue: Double?
+
+    private var displayed: Double {
+        dragValue ?? volume
+    }
 
     private var percent: Int {
-        Int((volume * 100).rounded())
+        Int((displayed * 100).rounded())
     }
 
     var body: some View {
         HStack {
             Image(systemName: "speaker.fill")
                 .foregroundStyle(.white.opacity(0.7))
-            Slider(value: Binding(get: { volume }, set: { onChange($0) }), in: 0 ... 1)
-                .accessibilityLabel("Volym")
-                .accessibilityValue("\(percent) procent")
+            HorizontalFillSlider(fraction: displayed,
+                                 onChange: { dragValue = $0 },
+                                 onCommit: {
+                                     if let dragValue {
+                                         onCommit(dragValue)
+                                     }
+                                     dragValue = nil
+                                 })
+                                 .frame(height: 26)
+                                 .accessibilityElement()
+                                 .accessibilityLabel("Volym")
+                                 .accessibilityValue("\(percent) procent")
+                                 .accessibilityAdjustableAction { direction in
+                                     let step = 0.05
+                                     let next = min(max(displayed + (direction == .increment ? step : -step), 0), 1)
+                                     onCommit(next)
+                                 }
             Text("\(percent)%")
                 .font(.caption)
                 .monospacedDigit()
                 .foregroundStyle(.white.opacity(0.7))
                 .frame(width: 40, alignment: .trailing)
                 .accessibilityHidden(true)
+        }
+    }
+}
+
+/// A horizontal fill slider mirroring `VerticalSlider`'s look (dark track, light
+/// fill, thin border). Tapping or dragging sets the value from the touch x; the
+/// change is reported live and committed on release.
+private struct HorizontalFillSlider: View {
+    let fraction: Double
+    let onChange: DoubleClosure
+    let onCommit: MainActorVoidClosure
+
+    private let trackColor = Color(white: 57.0 / 255).opacity(0.3)
+    private let fillColor = Color(white: 201.0 / 255)
+
+    var body: some View {
+        GeometryReader { geometry in
+            let clamped = min(max(fraction, 0), 1)
+            ZStack(alignment: .leading) {
+                Capsule().fill(trackColor)
+                Capsule().fill(fillColor)
+                    .frame(width: geometry.size.width * clamped)
+            }
+            .overlay(Capsule().stroke(.black.opacity(0.5), lineWidth: 1))
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        onChange(min(max(value.location.x / geometry.size.width, 0), 1))
+                    }
+                    .onEnded { _ in onCommit() }
+            )
         }
     }
 }

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -124,8 +124,10 @@ private struct TransportControlsView: View {
 /// Volume control styled like the light-brightness slider (`VerticalSlider`):
 /// a custom fill bar that updates the label live while dragging and commits the
 /// new volume to Home Assistant only on release (no request spam mid-drag).
+/// Pass `axis: .vertical` to rotate it 90° into a tall brightness-style bar.
 struct VolumeSliderView: View {
     let volume: Double
+    var axis: Axis = .horizontal
     let onCommit: DoubleClosure
 
     @State private var dragValue: Double?
@@ -138,42 +140,64 @@ struct VolumeSliderView: View {
         Int((displayed * 100).rounded())
     }
 
+    private var slider: some View {
+        FillSlider(fraction: displayed,
+                   axis: axis,
+                   onChange: { dragValue = $0 },
+                   onCommit: {
+                       if let dragValue {
+                           onCommit(dragValue)
+                       }
+                       dragValue = nil
+                   })
+                   .accessibilityElement()
+                   .accessibilityLabel("Volym")
+                   .accessibilityValue("\(percent) procent")
+                   .accessibilityAdjustableAction { direction in
+                       let step = 0.05
+                       let next = min(max(displayed + (direction == .increment ? step : -step), 0), 1)
+                       onCommit(next)
+                   }
+    }
+
+    private var label: some View {
+        Text("\(percent)%")
+            .font(.caption)
+            .monospacedDigit()
+            .foregroundStyle(.white.opacity(0.7))
+            .accessibilityHidden(true)
+    }
+
+    private var speakerIcon: some View {
+        Image(systemName: "speaker.fill")
+            .foregroundStyle(.white.opacity(0.7))
+    }
+
     var body: some View {
-        HStack {
-            Image(systemName: "speaker.fill")
-                .foregroundStyle(.white.opacity(0.7))
-            HorizontalFillSlider(fraction: displayed,
-                                 onChange: { dragValue = $0 },
-                                 onCommit: {
-                                     if let dragValue {
-                                         onCommit(dragValue)
-                                     }
-                                     dragValue = nil
-                                 })
-                                 .frame(height: 26)
-                                 .accessibilityElement()
-                                 .accessibilityLabel("Volym")
-                                 .accessibilityValue("\(percent) procent")
-                                 .accessibilityAdjustableAction { direction in
-                                     let step = 0.05
-                                     let next = min(max(displayed + (direction == .increment ? step : -step), 0), 1)
-                                     onCommit(next)
-                                 }
-            Text("\(percent)%")
-                .font(.caption)
-                .monospacedDigit()
-                .foregroundStyle(.white.opacity(0.7))
-                .frame(width: 40, alignment: .trailing)
-                .accessibilityHidden(true)
+        switch axis {
+        case .horizontal:
+            HStack {
+                speakerIcon
+                slider.frame(height: 26)
+                label.frame(width: 40, alignment: .trailing)
+            }
+        case .vertical:
+            VStack(spacing: 6) {
+                label
+                slider.frame(width: 36, height: 140)
+                speakerIcon
+            }
         }
     }
 }
 
-/// A horizontal fill slider mirroring `VerticalSlider`'s look (dark track, light
-/// fill, thin border). Tapping or dragging sets the value from the touch x; the
-/// change is reported live and committed on release.
-private struct HorizontalFillSlider: View {
+/// A fill slider mirroring `VerticalSlider`'s look (dark track, light fill, thin
+/// border). Tapping or dragging sets the value from the touch position; the
+/// change is reported live and committed on release. `axis` rotates it 90°:
+/// `.horizontal` fills left-to-right, `.vertical` fills bottom-to-top.
+private struct FillSlider: View {
     let fraction: Double
+    var axis: Axis = .horizontal
     let onChange: DoubleClosure
     let onCommit: MainActorVoidClosure
 
@@ -183,17 +207,23 @@ private struct HorizontalFillSlider: View {
     var body: some View {
         GeometryReader { geometry in
             let clamped = min(max(fraction, 0), 1)
-            ZStack(alignment: .leading) {
-                Capsule().fill(trackColor)
-                Capsule().fill(fillColor)
-                    .frame(width: geometry.size.width * clamped)
+            let radius = min(geometry.size.width, geometry.size.height) / 2.5
+            ZStack(alignment: axis == .horizontal ? .leading : .bottom) {
+                Rectangle().fill(trackColor)
+                Rectangle().fill(fillColor)
+                    .frame(width: axis == .horizontal ? geometry.size.width * clamped : nil,
+                           height: axis == .vertical ? geometry.size.height * clamped : nil)
             }
-            .overlay(Capsule().stroke(.black.opacity(0.5), lineWidth: 1))
+            .clipShape(RoundedRectangle(cornerRadius: radius))
+            .overlay(RoundedRectangle(cornerRadius: radius).stroke(.black.opacity(0.5), lineWidth: 1))
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        onChange(min(max(value.location.x / geometry.size.width, 0), 1))
+                        let fraction: Double = axis == .horizontal
+                            ? value.location.x / geometry.size.width
+                            : 1 - value.location.y / geometry.size.height
+                        onChange(min(max(fraction, 0), 1))
                     }
                     .onEnded { _ in onCommit() }
             )

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -125,14 +125,23 @@ struct VolumeSliderView: View {
     let volume: Double
     let onChange: DoubleClosure
 
+    private var percent: Int {
+        Int((volume * 100).rounded())
+    }
+
     var body: some View {
         HStack {
             Image(systemName: "speaker.fill")
                 .foregroundStyle(.white.opacity(0.7))
             Slider(value: Binding(get: { volume }, set: { onChange($0) }), in: 0 ... 1)
                 .accessibilityLabel("Volym")
-            Image(systemName: "speaker.wave.3.fill")
+                .accessibilityValue("\(percent) procent")
+            Text("\(percent)%")
+                .font(.caption)
+                .monospacedDigit()
                 .foregroundStyle(.white.opacity(0.7))
+                .frame(width: 40, alignment: .trailing)
+                .accessibilityHidden(true)
         }
     }
 }

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -43,7 +43,7 @@ struct SpeakerGroupingView: View {
                     .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
 
                     VolumeSliderView(volume: speaker.volumeLevel,
-                                     onChange: { viewModel.setVolume($0, for: speaker.entityId) })
+                                     onCommit: { viewModel.setVolume($0, for: speaker.entityId) })
                         .accessibilityLabel("Volym \(speaker.friendlyName)")
                 }
                 .padding(.vertical, 8)

--- a/IntelliNest/Views/Music/SpeakerPickerView.swift
+++ b/IntelliNest/Views/Music/SpeakerPickerView.swift
@@ -38,7 +38,7 @@ struct SpeakerPickerView: View {
                     .accessibilityLabel("Välj \(speaker.friendlyName)")
 
                     VolumeSliderView(volume: speaker.volumeLevel,
-                                     onChange: { viewModel.setVolume($0, for: speaker.entityId) })
+                                     onCommit: { viewModel.setVolume($0, for: speaker.entityId) })
                         .accessibilityLabel("Volym \(speaker.friendlyName)")
                 }
                 .padding(.vertical, 10)


### PR DESCRIPTION
## Summary
- Each volume slider now shows the volume as a percentage at its trailing edge (monospaced digits, fixed width so it doesn't shift while dragging).
- Applies everywhere the shared `VolumeSliderView` is used: now-playing, the speaker picker, and the grouping list.
- VoiceOver reads the percentage as the slider's accessibility value; the visual label is hidden from VoiceOver to avoid duplication.

## Test plan
- Music model + view-model suites pass on iPhone 17; SwiftFormat + SwiftLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for vertical volume sliders alongside horizontal orientation.
  * Improved CI reliability with dynamic simulator detection for testing.

* **Bug Fixes**
  * Volume controls now update only after adjusting finishes, preventing unintended changes during interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->