### PR TITLE
Added group volume, collapsible speakers and favourite/recent playlists to music

### DIFF
--- a/.swiftlint
+++ b/.swiftlint
@@ -8,3 +8,4 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods
   - R.generated.swift
   - .build # Where Swift Package Manager checks out dependency sources
+  - .claude # Tooling/skill assets and example snippets, not app source

--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		EE0000020000000000000002 /* MusicSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000020000000000000002 /* MusicSearchResult.swift */; };
 		EE0000030000000000000003 /* RestAPIService+Music.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000030000000000000003 /* RestAPIService+Music.swift */; };
 		EE0000040000000000000004 /* MusicViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000040000000000000004 /* MusicViewModel.swift */; };
+		EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00000400000000000000F1 /* MusicViewModel+Playback.swift */; };
 		EE0000050000000000000005 /* MusicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000050000000000000005 /* MusicView.swift */; };
 		EE0000060000000000000006 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000060000000000000006 /* NowPlayingView.swift */; };
 		EE0000070000000000000007 /* AlbumArtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000070000000000000007 /* AlbumArtView.swift */; };
@@ -60,6 +61,7 @@
 		EE0000090000000000000009 /* SpeakerGroupingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000090000000000000009 /* SpeakerGroupingView.swift */; };
 		EE000010000000000000000A /* MusicSearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF000010000000000000000A /* MusicSearchResultsView.swift */; };
 		EE000011000000000000000B /* MusicViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF000011000000000000000B /* MusicViewModelTests.swift */; };
+		EE00001100000000000000C1 /* MusicViewModelGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00001100000000000000C1 /* MusicViewModelGroupingTests.swift */; };
 		EE000012000000000000000C /* MusicModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF000012000000000000000C /* MusicModelTests.swift */; };
 		F62CD2E0286D950A00462092 /* LightEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62CD2DF286D950A00462092 /* LightEntity.swift */; };
 		F62CD2E328770D5500462092 /* LightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62CD2E228770D5500462092 /* LightsViewModel.swift */; };
@@ -268,6 +270,7 @@
 		EF0000020000000000000002 /* MusicSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSearchResult.swift; sourceTree = "<group>"; };
 		EF0000030000000000000003 /* RestAPIService+Music.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestAPIService+Music.swift"; sourceTree = "<group>"; };
 		EF0000040000000000000004 /* MusicViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModel.swift; sourceTree = "<group>"; };
+		EF00000400000000000000F1 /* MusicViewModel+Playback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Playback.swift"; sourceTree = "<group>"; };
 		EF0000050000000000000005 /* MusicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicView.swift; sourceTree = "<group>"; };
 		EF0000060000000000000006 /* NowPlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingView.swift; sourceTree = "<group>"; };
 		EF0000070000000000000007 /* AlbumArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumArtView.swift; sourceTree = "<group>"; };
@@ -275,6 +278,7 @@
 		EF0000090000000000000009 /* SpeakerGroupingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerGroupingView.swift; sourceTree = "<group>"; };
 		EF000010000000000000000A /* MusicSearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSearchResultsView.swift; sourceTree = "<group>"; };
 		EF000011000000000000000B /* MusicViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelTests.swift; sourceTree = "<group>"; };
+		EF00001100000000000000C1 /* MusicViewModelGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelGroupingTests.swift; sourceTree = "<group>"; };
 		EF000012000000000000000C /* MusicModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicModelTests.swift; sourceTree = "<group>"; };
 		F62CD2E228770D5500462092 /* LightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightsViewModel.swift; sourceTree = "<group>"; };
 		F62CD2E428770F3B00462092 /* RestAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestAPIService.swift; sourceTree = "<group>"; };
@@ -554,6 +558,7 @@
 			AA000000A00000000000000A /* StringExtensionTests.swift */,
 			AA000000C00000000000000C /* HeaterEntityTests.swift */,
 				EF000011000000000000000B /* MusicViewModelTests.swift */,
+				EF00001100000000000000C1 /* MusicViewModelGroupingTests.swift */,
 				EF000012000000000000000C /* MusicModelTests.swift */,
 			);
 			path = IntelliNestTests;
@@ -584,6 +589,7 @@
 				F685F8002B2B153C008E47AF /* ElectricityViewModel.swift */,
 				D89BCA06BE3A45F2A8E3DAE4 /* LynkViewModelHelpers.swift */,
 				EF0000040000000000000004 /* MusicViewModel.swift */,
+				EF00000400000000000000F1 /* MusicViewModel+Playback.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1184,6 +1190,7 @@
 				EE0000020000000000000002 /* MusicSearchResult.swift in Sources */,
 				EE0000030000000000000003 /* RestAPIService+Music.swift in Sources */,
 				EE0000040000000000000004 /* MusicViewModel.swift in Sources */,
+				EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */,
 				EE0000050000000000000005 /* MusicView.swift in Sources */,
 				EE0000060000000000000006 /* NowPlayingView.swift in Sources */,
 				EE0000070000000000000007 /* AlbumArtView.swift in Sources */,
@@ -1217,6 +1224,7 @@
 			BB0000001000000000000001 /* HeatersViewModelTests.swift in Sources */,
 			DD0000001000000000000001 /* LynkViewModelTests.swift in Sources */,
 				EE000011000000000000000B /* MusicViewModelTests.swift in Sources */,
+				EE00001100000000000000C1 /* MusicViewModelGroupingTests.swift in Sources */,
 				EE000012000000000000000C /* MusicModelTests.swift in Sources */,
 			BB0000003000000000000003 /* LightsViewModelTests.swift in Sources */,
 			BB0000007000000000000007 /* LockableTests.swift in Sources */,
@@ -1395,7 +1403,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "IntelliNest/Supporting Files/IntelliNest.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				DEVELOPMENT_ASSET_PATHS = "\"IntelliNest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1404,7 +1412,7 @@
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Need location access in order to handle geofence";
-				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "Need location access in order to handle geofence";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Need location access to get SSID";
 				INFOPLIST_KEY_NSSiriUsageDescription = "Used to avoid warnings";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1436,7 +1444,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "IntelliNest/Supporting Files/IntelliNest.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				DEVELOPMENT_ASSET_PATHS = "\"IntelliNest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1445,7 +1453,7 @@
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Need location access in order to handle geofence";
-				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "Need location access in order to handle geofence";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Need location access to get SSID";
 				INFOPLIST_KEY_NSSiriUsageDescription = "Used to avoid warnings";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1476,7 +1484,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1501,7 +1509,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1527,7 +1535,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = IntelliWidget/IntelliWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1560,7 +1568,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = IntelliWidget/IntelliWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1592,7 +1600,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = IntelliWidget/IntelliWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1686,7 +1694,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "IntelliNest/Supporting Files/IntelliNest.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				DEVELOPMENT_ASSET_PATHS = "\"IntelliNest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1695,7 +1703,7 @@
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Need location access in order to handle geofence";
-				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "Need location access in order to handle geofence";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Need location access to get SSID";
 				INFOPLIST_KEY_NSSiriUsageDescription = "Used to avoid warnings";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1726,7 +1734,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/IntelliNest/Model/MusicSearchResult.swift
+++ b/IntelliNest/Model/MusicSearchResult.swift
@@ -53,36 +53,52 @@ struct MusicSearchSection: Identifiable, Equatable {
 /// is a JSON object whose top-level keys are pluralised media types
 /// (`tracks`, `albums`, `artists`, `playlists`), each an array of items. Each
 /// item carries a `uri`, `name`, optional `image`, and `artists` metadata.
+/// A raw Music Assistant media item as returned by both `search` and
+/// `get_library`. Carries the playable `uri`, display `name`, an optional cover
+/// `image` (under either `image` or `media_image`), and `artists` metadata.
+private struct MusicRawMediaItem: Decodable {
+    let uri: String?
+    let name: String?
+    let image: String?
+    let artists: [MusicRawArtist]?
+
+    private enum CodingKeys: String, CodingKey {
+        case uri
+        case name
+        case image
+        case mediaImage = "media_image"
+        case artists
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        uri = try container.decodeIfPresent(String.self, forKey: .uri)
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        image = try container.decodeIfPresent(String.self, forKey: .image)
+            ?? container.decodeIfPresent(String.self, forKey: .mediaImage)
+        artists = try container.decodeIfPresent([MusicRawArtist].self, forKey: .artists)
+    }
+
+    /// Builds a `MusicSearchItem` of `mediaType`, or nil when the playable
+    /// fields (`uri`, `name`) are missing.
+    func searchItem(mediaType: MusicMediaType) -> MusicSearchItem? {
+        guard let uri, let name else {
+            return nil
+        }
+        return MusicSearchItem(uri: uri,
+                               name: name,
+                               mediaType: mediaType,
+                               imageURL: image,
+                               artist: artists?.first?.name)
+    }
+}
+
+private struct MusicRawArtist: Decodable {
+    let name: String?
+}
+
 struct MusicSearchResponse: Decodable {
     let sections: [MusicSearchSection]
-
-    private struct RawItem: Decodable {
-        let uri: String?
-        let name: String?
-        let image: String?
-        let artists: [RawArtist]?
-
-        private enum CodingKeys: String, CodingKey {
-            case uri
-            case name
-            case image
-            case mediaImage = "media_image"
-            case artists
-        }
-
-        init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            uri = try container.decodeIfPresent(String.self, forKey: .uri)
-            name = try container.decodeIfPresent(String.self, forKey: .name)
-            image = try container.decodeIfPresent(String.self, forKey: .image)
-                ?? container.decodeIfPresent(String.self, forKey: .mediaImage)
-            artists = try container.decodeIfPresent([RawArtist].self, forKey: .artists)
-        }
-    }
-
-    private struct RawArtist: Decodable {
-        let name: String?
-    }
 
     private enum CodingKeys: String, CodingKey {
         case tracks
@@ -102,22 +118,34 @@ struct MusicSearchResponse: Decodable {
 
         var builtSections: [MusicSearchSection] = []
         for (mediaType, key) in rawByType {
-            let rawItems = try container.decodeIfPresent([RawItem].self, forKey: key) ?? []
-            let items: [MusicSearchItem] = rawItems.compactMap { rawItem in
-                guard let uri = rawItem.uri, let name = rawItem.name else {
-                    return nil
-                }
-                return MusicSearchItem(uri: uri,
-                                       name: name,
-                                       mediaType: mediaType,
-                                       imageURL: rawItem.image,
-                                       artist: rawItem.artists?.first?.name)
-            }
+            let rawItems = try container.decodeIfPresent([MusicRawMediaItem].self, forKey: key) ?? []
+            let items = rawItems.compactMap { $0.searchItem(mediaType: mediaType) }
             if items.isNotEmpty {
                 builtSections.append(MusicSearchSection(mediaType: mediaType, items: items))
             }
         }
         sections = builtSections
+    }
+}
+
+/// Decodes a `music_assistant.get_library` `return_response` body for playlists.
+/// Music Assistant returns the items under an `items` array; some versions
+/// return a bare array instead, so both shapes are accepted.
+struct MusicLibraryResponse: Decodable {
+    let playlists: [MusicSearchItem]
+
+    private enum CodingKeys: String, CodingKey {
+        case items
+    }
+
+    init(from decoder: Decoder) throws {
+        let rawItems: [MusicRawMediaItem] = if let container = try? decoder.container(keyedBy: CodingKeys.self),
+                                               let items = try? container.decodeIfPresent([MusicRawMediaItem].self, forKey: .items) {
+            items
+        } else {
+            try decoder.singleValueContainer().decode([MusicRawMediaItem].self)
+        }
+        playlists = rawItems.compactMap { $0.searchItem(mediaType: .playlist) }
     }
 }
 

--- a/IntelliNest/Services/RestAPIService+Music.swift
+++ b/IntelliNest/Services/RestAPIService+Music.swift
@@ -26,6 +26,42 @@ extension RestAPIService {
         return try decodeSearchResponse(from: data)
     }
 
+    /// Fetches the user's favourite playlists from the Music Assistant library
+    /// via `music_assistant.get_library`, sorted by name.
+    func getFavoritePlaylists(limit: Int = 20) async throws -> [MusicSearchItem] {
+        try await getLibraryPlaylists(favorite: true, orderBy: "name", limit: limit)
+    }
+
+    /// Fetches the most recently played playlists from the Music Assistant
+    /// library. Music Assistant tracks last-played, so `order_by:
+    /// last_played_desc` returns them newest-first across every source (not just
+    /// plays started in this app). The favourite filter is left off so a played
+    /// non-favourite still shows up.
+    func getRecentlyPlayedPlaylists(limit: Int = 5) async throws -> [MusicSearchItem] {
+        try await getLibraryPlaylists(favorite: nil, orderBy: "last_played_desc", limit: limit)
+    }
+
+    /// Shared `get_library` call for playlists (`?return_response`). `favorite`
+    /// applies the favourite filter only when non-nil.
+    private func getLibraryPlaylists(favorite: Bool?, orderBy: String, limit: Int) async throws -> [MusicSearchItem] {
+        let path = "/api/services/\(Domain.musicAssistant.rawValue)/\(Action.getLibrary.rawValue)"
+        var json = [JSONKey: Any]()
+        json[.configEntryID] = GlobalConstants.musicAssistantConfigEntryID
+        json[.mediaType] = MusicMediaType.playlist.rawValue
+        if let favorite {
+            json[.favorite] = favorite
+        }
+        json[.orderBy] = orderBy
+        json[.limit] = limit
+
+        let data = try await postExpectingResponseData(path: path, json: json)
+        let decoder = JSONDecoder()
+        if let wrapper = try? decoder.decode(MusicLibraryServiceResponse.self, from: data) {
+            return wrapper.serviceResponse.playlists
+        }
+        return try decoder.decode(MusicLibraryResponse.self, from: data).playlists
+    }
+
     /// Browses a playlist's tracks via `media_player.browse_media`. The browse
     /// runs against `entityID` (any available speaker), but only reads the
     /// playlist contents — it does not change what that speaker is playing.
@@ -182,6 +218,15 @@ extension RestAPIService {
 /// Wrapper for the Home Assistant service-call response envelope.
 private struct MusicSearchServiceResponse: Decodable {
     let serviceResponse: MusicSearchResponse
+
+    enum CodingKeys: String, CodingKey {
+        case serviceResponse = "service_response"
+    }
+}
+
+/// Wrapper for the `get_library` service-call response envelope.
+private struct MusicLibraryServiceResponse: Decodable {
+    let serviceResponse: MusicLibraryResponse
 
     enum CodingKeys: String, CodingKey {
         case serviceResponse = "service_response"

--- a/IntelliNest/Services/RestAPIService.swift
+++ b/IntelliNest/Services/RestAPIService.swift
@@ -143,85 +143,6 @@ class RestAPIService: URLRequestBuilder {
 
     // MARK: Post requests
 
-    func update(entityID: EntityId, domain: Domain, action: Action, reloadTimes: Int = 1) {
-        Task {
-            var json = [JSONKey: Any]()
-            json[.entityID] = entityID.rawValue
-            await sendPostRequest(json: json, domain: domain, action: action)
-            repeatReloadAction(reloadTimes)
-        }
-    }
-
-    func update(lightIDs: [EntityId], action: Action, brightness: Int, reloadTimes: Int = 1) {
-        Task {
-            await withTaskGroup(of: Void.self) { group in
-                for lightID in lightIDs {
-                    group.addTask {
-                        var json = [JSONKey: Any]()
-                        json[.entityID] = lightID.rawValue
-                        if action == .turnOn && brightness > 0 {
-                            json[.brightness] = brightness
-                        }
-
-                        await self.sendPostRequest(json: json, domain: .light, action: action)
-                    }
-                }
-            }
-
-            repeatReloadAction(reloadTimes)
-        }
-    }
-
-    func update(dateEntityID: EntityId, date: Date, reloadTimes: Int = 1) {
-        Task {
-            var json = [JSONKey: Any]()
-            json[.entityID] = dateEntityID.rawValue
-            json[.dateTime] = date
-            await sendPostRequest(json: json, domain: .inputDateTime, action: .setDateTime)
-            repeatReloadAction(reloadTimes)
-        }
-    }
-
-    func update(entityID: EntityId, domain: Domain, action: Action, dataKey: JSONKey, dataValue: String, reloadTimes: Int = 1) {
-        Task {
-            var json = [JSONKey: Any]()
-            json[.entityID] = entityID.rawValue
-            json[dataKey] = dataValue
-            await sendPostRequest(json: json, domain: domain, action: action)
-            repeatReloadAction(reloadTimes)
-        }
-    }
-
-    func update(entityID: EntityId, domain: Domain, action: Action, dataKey: JSONKey, dataValue: Int, reloadTimes: Int = 1) {
-        Task {
-            var json = [JSONKey: Any]()
-            json[.entityID] = entityID.rawValue
-            json[dataKey] = dataValue
-            await sendPostRequest(json: json, domain: domain, action: action)
-            repeatReloadAction(reloadTimes)
-        }
-    }
-
-    func update(entityID: EntityId, domain: Domain, action: Action, dataKey: JSONKey, dataValue: Double, reloadTimes: Int = 1) {
-        Task {
-            var json = [JSONKey: Any]()
-            json[.entityID] = entityID.rawValue
-            json[dataKey] = dataValue
-            await sendPostRequest(json: json, domain: domain, action: action)
-            repeatReloadAction(reloadTimes)
-        }
-    }
-
-    func update(numberEntityID: EntityId, number: Double, reloadTimes: Int = 1) {
-        Task {
-            var json = [JSONKey: Any]()
-            json[.entityID] = numberEntityID.rawValue
-            json[.value] = number
-            await sendPostRequest(json: json, domain: .inputNumber, action: .setValue)
-            repeatReloadAction(reloadTimes)
-        }
-    }
-
     func callService(serviceID: ServiceID, domain: Domain, json: [JSONKey: Any]? = nil, reloadTimes: Int = 2) {
         Task {
             if let action = serviceID.toAction {
@@ -343,6 +264,89 @@ class RestAPIService: URLRequestBuilder {
         let capturedJSON = json
         Task {
             await sendPostRequest(customPath: path, json: capturedJSON, domain: .apnsToken, action: .register)
+        }
+    }
+}
+
+// MARK: - Entity update overloads
+
+extension RestAPIService {
+    func update(entityID: EntityId, domain: Domain, action: Action, reloadTimes: Int = 1) {
+        Task {
+            var json = [JSONKey: Any]()
+            json[.entityID] = entityID.rawValue
+            await sendPostRequest(json: json, domain: domain, action: action)
+            repeatReloadAction(reloadTimes)
+        }
+    }
+
+    func update(lightIDs: [EntityId], action: Action, brightness: Int, reloadTimes: Int = 1) {
+        Task {
+            await withTaskGroup(of: Void.self) { group in
+                for lightID in lightIDs {
+                    group.addTask {
+                        var json = [JSONKey: Any]()
+                        json[.entityID] = lightID.rawValue
+                        if action == .turnOn && brightness > 0 {
+                            json[.brightness] = brightness
+                        }
+
+                        await self.sendPostRequest(json: json, domain: .light, action: action)
+                    }
+                }
+            }
+
+            repeatReloadAction(reloadTimes)
+        }
+    }
+
+    func update(dateEntityID: EntityId, date: Date, reloadTimes: Int = 1) {
+        Task {
+            var json = [JSONKey: Any]()
+            json[.entityID] = dateEntityID.rawValue
+            json[.dateTime] = date
+            await sendPostRequest(json: json, domain: .inputDateTime, action: .setDateTime)
+            repeatReloadAction(reloadTimes)
+        }
+    }
+
+    func update(entityID: EntityId, domain: Domain, action: Action, dataKey: JSONKey, dataValue: String, reloadTimes: Int = 1) {
+        Task {
+            var json = [JSONKey: Any]()
+            json[.entityID] = entityID.rawValue
+            json[dataKey] = dataValue
+            await sendPostRequest(json: json, domain: domain, action: action)
+            repeatReloadAction(reloadTimes)
+        }
+    }
+
+    func update(entityID: EntityId, domain: Domain, action: Action, dataKey: JSONKey, dataValue: Int, reloadTimes: Int = 1) {
+        Task {
+            var json = [JSONKey: Any]()
+            json[.entityID] = entityID.rawValue
+            json[dataKey] = dataValue
+            await sendPostRequest(json: json, domain: domain, action: action)
+            repeatReloadAction(reloadTimes)
+        }
+    }
+
+    func update(entityID: EntityId, domain: Domain, action: Action, dataKey: JSONKey, dataValue: Double, reloadTimes: Int = 1) {
+        Task {
+            var json = [JSONKey: Any]()
+            json[.entityID] = entityID.rawValue
+            json[dataKey] = dataValue
+            await sendPostRequest(json: json, domain: domain, action: action)
+            repeatReloadAction(reloadTimes)
+        }
+    }
+
+    func update(numberEntityID: EntityId, number: Double, reloadTimes: Int = 1) {
+        Task {
+            var json = [JSONKey: Any]()
+            json[.entityID] = numberEntityID.rawValue
+            json[.value] = number
+            await sendPostRequest(json: json, domain: .inputNumber, action: .setValue)
+            repeatReloadAction(reloadTimes)
         }
     }
 }

--- a/IntelliNest/Utils/Constants/Actions.swift
+++ b/IntelliNest/Utils/Constants/Actions.swift
@@ -54,4 +54,5 @@ enum Action: String, Codable {
     case join
     case unjoin
     case browseMedia = "browse_media"
+    case getLibrary = "get_library"
 }

--- a/IntelliNest/Utils/Constants/JSONKey.swift
+++ b/IntelliNest/Utils/Constants/JSONKey.swift
@@ -61,4 +61,6 @@ enum JSONKey: String, Equatable, Codable, Hashable {
     case shuffle
     case repeatMode = "repeat"
     case groupMembers = "group_members"
+    case favorite
+    case orderBy = "order_by"
 }

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -1,0 +1,217 @@
+//
+//  MusicViewModel+Playback.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-09.
+//
+
+import Foundation
+import ShipBookSDK
+
+/// Playback, playlist browsing, and the favourite/recently-played library
+/// loaders, split out of `MusicViewModel` to keep that type focused on speaker
+/// and group state.
+extension MusicViewModel {
+    // MARK: - Library playlists
+
+    /// Loads the favourite and recently-played playlists on the first reload
+    /// after the view appears. Failures are logged but left silent — these are a
+    /// convenience shortcut, not core playback; a failed load retries next reload.
+    func loadLibraryPlaylistsIfNeeded() async {
+        guard !hasLoadedLibrary else {
+            return
+        }
+        let favorites = try? await restAPIService.getFavoritePlaylists()
+        let recents = try? await restAPIService.getRecentlyPlayedPlaylists()
+        guard favorites != nil || recents != nil else {
+            return
+        }
+        hasLoadedLibrary = true
+        if let favorites {
+            favoritePlaylists = favorites
+        }
+        if let recents {
+            recentlyPlayedPlaylists = recents
+        }
+    }
+
+    /// Re-fetches the recently-played list after a playlist launch so the new
+    /// play bubbles to the top. Silent on failure.
+    private func refreshRecentlyPlayed() async {
+        if let recents = try? await restAPIService.getRecentlyPlayedPlaylists() {
+            recentlyPlayedPlaylists = recents
+        }
+    }
+
+    /// Opens a favourite/recents playlist for browsing in its own sheet on the
+    /// main view, loading its tracks. The detail's play button starts playback;
+    /// opening it never changes what's playing.
+    func browseLibraryPlaylist(_ playlist: MusicSearchItem) async {
+        browsingLibraryPlaylist = playlist
+        await loadPlaylistTracks(playlist)
+    }
+
+    // MARK: - Playback
+
+    /// Playback and queue commands must go to the active speaker's group leader;
+    /// a synced follower rejects them. Returns the active speaker itself when it
+    /// is ungrouped. Volume stays per-speaker, so it is not redirected here.
+    private var playbackTargetID: EntityId? {
+        guard let activeSpeaker else {
+            return activeSpeakerID
+        }
+        return activeSpeaker.playbackTargetID
+    }
+
+    func play(item: MusicSearchItem) async {
+        if await startPlayback(uri: item.uri, mediaType: item.mediaType, title: item.name, artist: item.artist) {
+            closeSearchResults()
+        }
+    }
+
+    /// Starts (or enqueues) playback of a media item on the active speaker's
+    /// group leader. Returns whether the request succeeded so callers can chain
+    /// follow-up actions and avoid showing a false playing state.
+    @discardableResult
+    private func startPlayback(uri: String,
+                               mediaType: MusicMediaType,
+                               title: String?,
+                               artist: String?,
+                               enqueue: String = "replace") async -> Bool {
+        guard let activeSpeakerID, let targetID = playbackTargetID else {
+            setErrorBannerText("Ingen högtalare vald", "Välj en högtalare innan du spelar musik")
+            return false
+        }
+
+        let success = await restAPIService.playMedia(on: targetID, mediaID: uri, mediaType: mediaType, enqueue: enqueue)
+        if success {
+            // Optimistically reflect what we just started; a reload confirms it.
+            speakers[activeSpeakerID]?.state = "playing"
+            speakers[activeSpeakerID]?.mediaTitle = title
+            speakers[activeSpeakerID]?.mediaArtist = artist
+            restAPIService.triggerRepeatReload(times: 3)
+        } else {
+            setErrorBannerText("Kunde inte spela", "Det gick inte att starta uppspelningen")
+        }
+        return success
+    }
+
+    // MARK: - Playlists
+
+    /// Opens a playlist for browsing in the search-results sheet instead of
+    /// playing it: records the opened playlist (which drills the sheet into the
+    /// detail view) and loads its tracks. Browsing never changes playback.
+    func openPlaylist(_ playlist: MusicSearchItem) async {
+        openedPlaylist = playlist
+        await loadPlaylistTracks(playlist)
+    }
+
+    /// Loads a playlist's tracks into `playlistTracks`, toggling the loading
+    /// flag. Shared by the search-sheet drill-in and the main-view browse sheet.
+    private func loadPlaylistTracks(_ playlist: MusicSearchItem) async {
+        playlistTracks = []
+        isLoadingPlaylist = true
+        let browseSpeaker = activeSpeakerID ?? availableSpeakers.first?.entityId
+        if let browseSpeaker {
+            do {
+                playlistTracks = try await restAPIService.browsePlaylistTracks(playlistURI: playlist.uri, on: browseSpeaker)
+            } catch {
+                Log.error("Failed to browse playlist: \(error)")
+                setErrorBannerText("Kunde inte öppna spellistan", "Det gick inte att hämta låtarna")
+            }
+        }
+        isLoadingPlaylist = false
+    }
+
+    /// Plays the whole playlist from the start on the active speaker.
+    func playPlaylist(_ playlist: MusicSearchItem) async {
+        if await startPlayback(uri: playlist.uri, mediaType: .playlist, title: playlist.name, artist: nil) {
+            closeSearchResults()
+            await refreshRecentlyPlayed()
+        }
+    }
+
+    /// Plays the chosen track now, then queues the rest of the playlist after it,
+    /// so the tapped song is followed by the playlist.
+    func playTrackInPlaylist(_ track: MusicPlaylistTrack, from playlist: MusicSearchItem) async {
+        guard await startPlayback(uri: track.uri, mediaType: .track, title: track.title, artist: nil) else {
+            return
+        }
+        if let targetID = playbackTargetID {
+            await restAPIService.playMedia(on: targetID, mediaID: playlist.uri, mediaType: .playlist, enqueue: "add")
+        }
+        closeSearchResults()
+        await refreshRecentlyPlayed()
+    }
+
+    /// Dismisses any playlist presentation: the search-results sheet, its
+    /// drill-in, and the main-view browse sheet.
+    func closeSearchResults() {
+        isShowingSearchResults = false
+        openedPlaylist = nil
+        browsingLibraryPlaylist = nil
+    }
+
+    // MARK: - Transport & volume
+
+    func togglePlayPause() {
+        guard let activeSpeaker, let targetID = playbackTargetID else {
+            return
+        }
+        let action: Action = activeSpeaker.isPlaying ? .mediaPause : .mediaPlay
+        speakers[activeSpeaker.entityId]?.state = activeSpeaker.isPlaying ? "paused" : "playing"
+        restAPIService.mediaTransport(entityID: targetID, action: action)
+    }
+
+    func nextTrack() {
+        guard let targetID = playbackTargetID else {
+            return
+        }
+        restAPIService.mediaTransport(entityID: targetID, action: .mediaNextTrack)
+    }
+
+    func previousTrack() {
+        guard let targetID = playbackTargetID else {
+            return
+        }
+        restAPIService.mediaTransport(entityID: targetID, action: .mediaPreviousTrack)
+    }
+
+    func setVolume(_ volume: Double) {
+        guard let activeSpeakerID else {
+            return
+        }
+        setVolume(volume, for: activeSpeakerID)
+    }
+
+    /// Sets the volume of a specific speaker. Volume is always per-speaker (never
+    /// redirected to a group leader), so any speaker in the list can be adjusted
+    /// in place.
+    func setVolume(_ volume: Double, for speakerID: EntityId) {
+        speakers[speakerID]?.volumeLevel = volume
+        restAPIService.setVolume(entityID: speakerID, volume: volume)
+    }
+
+    func toggleShuffle() {
+        guard let activeSpeaker, let targetID = playbackTargetID else {
+            return
+        }
+        let newValue = !activeSpeaker.shuffle
+        speakers[activeSpeaker.entityId]?.shuffle = newValue
+        restAPIService.setShuffle(entityID: targetID, shuffle: newValue)
+    }
+
+    func toggleRepeat() {
+        guard let activeSpeaker, let targetID = playbackTargetID else {
+            return
+        }
+        // Cycle off → all → one → off, matching the Sonos-style three-state control.
+        let newMode: MediaRepeatMode = switch activeSpeaker.repeatMode {
+        case .off: .all
+        case .all: .one
+        case .one: .off
+        }
+        speakers[activeSpeaker.entityId]?.repeatMode = newMode
+        restAPIService.setRepeat(entityID: targetID, repeatMode: newMode)
+    }
+}

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -34,15 +34,28 @@ class MusicViewModel: ObservableObject, Reloadable {
     @Published var openedPlaylist: MusicSearchItem?
     @Published var playlistTracks: [MusicPlaylistTrack] = []
     @Published var isLoadingPlaylist = false
+    /// The user's favourite Spotify playlists, shown for quick launch in place of
+    /// the speaker list. Loaded on the first reload.
+    @Published var favoritePlaylists: [MusicSearchItem] = []
+    /// The most recently played playlists (Music Assistant `last_played` order),
+    /// shown above the favourites. Refreshed whenever a playlist is launched.
+    @Published var recentlyPlayedPlaylists: [MusicSearchItem] = []
+    /// A library playlist the user opened to browse from the main view (favourites
+    /// or recents), presented in its own sheet. Nil when no browse sheet is shown.
+    @Published var browsingLibraryPlaylist: MusicSearchItem?
 
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false
+    /// Read/written by the library-playlist loader in `MusicViewModel+Playback`.
+    var hasLoadedLibrary = false
     /// Increments on every search so a slow, older response can't overwrite the
     /// results of a newer query.
     private var searchRequestToken = 0
 
-    private let restAPIService: RestAPIService
-    private let setErrorBannerText: StringStringClosure
+    /// Injected dependencies — internal (not private) so the playback/playlist
+    /// methods extracted into `MusicViewModel+Playback` can reach them.
+    let restAPIService: RestAPIService
+    let setErrorBannerText: StringStringClosure
 
     /// Speakers that are reachable right now (anything not `unavailable`),
     /// in the fixed display order.
@@ -93,6 +106,7 @@ class MusicViewModel: ObservableObject, Reloadable {
             self.selectDefaultSpeakerIfNeeded()
             self.dropActiveSpeakerIfUnavailable()
         }
+        await loadLibraryPlaylistsIfNeeded()
     }
 
     /// On the first reload after the view appears, default the active speaker to
@@ -161,156 +175,45 @@ class MusicViewModel: ObservableObject, Reloadable {
         hasSearched && !isSearching && searchSections.isEmpty
     }
 
-    // MARK: - Playback
+    // MARK: - Group volume
 
-    /// Playback and queue commands must go to the active speaker's group leader;
-    /// a synced follower rejects them. Returns the active speaker itself when it
-    /// is ungrouped. Volume stays per-speaker, so it is not redirected here.
-    private var playbackTargetID: EntityId? {
+    /// The speakers currently synced with the active speaker (leader plus any
+    /// followers), in the fixed display order. When the active speaker is
+    /// ungrouped this is just the active speaker on its own.
+    var groupedSpeakers: [MediaPlayerEntity] {
         guard let activeSpeaker else {
-            return activeSpeakerID
+            return []
         }
-        return activeSpeaker.playbackTargetID
+        let memberIDs = activeSpeaker.groupMembers
+        guard memberIDs.count > 1 else {
+            return [activeSpeaker]
+        }
+        return Self.speakerIDs.filter { memberIDs.contains($0) }.compactMap { speakers[$0] }
     }
 
-    func play(item: MusicSearchItem) async {
-        if await startPlayback(uri: item.uri, mediaType: item.mediaType, title: item.name, artist: item.artist) {
-            closeSearchResults()
-        }
+    /// Whether the active speaker is synced with at least one other speaker, so
+    /// the volume control should act on the whole group.
+    var isGroupActive: Bool {
+        groupedSpeakers.count > 1
     }
 
-    /// Starts (or enqueues) playback of a media item on the active speaker's
-    /// group leader. Returns whether the request succeeded so callers can chain
-    /// follow-up actions and avoid showing a false playing state.
-    @discardableResult
-    private func startPlayback(uri: String,
-                               mediaType: MusicMediaType,
-                               title: String?,
-                               artist: String?,
-                               enqueue: String = "replace") async -> Bool {
-        guard let activeSpeakerID, let targetID = playbackTargetID else {
-            setErrorBannerText("Ingen högtalare vald", "Välj en högtalare innan du spelar musik")
-            return false
+    /// The single value shown on the group-volume banner: the average volume
+    /// across every grouped speaker.
+    var groupVolume: Double {
+        let grouped = groupedSpeakers
+        guard grouped.isNotEmpty else {
+            return 0
         }
-
-        let success = await restAPIService.playMedia(on: targetID, mediaID: uri, mediaType: mediaType, enqueue: enqueue)
-        if success {
-            // Optimistically reflect what we just started; a reload confirms it.
-            speakers[activeSpeakerID]?.state = "playing"
-            speakers[activeSpeakerID]?.mediaTitle = title
-            speakers[activeSpeakerID]?.mediaArtist = artist
-            restAPIService.triggerRepeatReload(times: 3)
-        } else {
-            setErrorBannerText("Kunde inte spela", "Det gick inte att starta uppspelningen")
-        }
-        return success
+        let total = grouped.reduce(0.0) { $0 + $1.volumeLevel }
+        return total / Double(grouped.count)
     }
 
-    // MARK: - Playlists
-
-    /// Opens a playlist for browsing instead of playing it: records the opened
-    /// playlist (which drills the sheet into the detail view) and loads its
-    /// tracks. Browsing reads the playlist contents and never changes playback.
-    func openPlaylist(_ playlist: MusicSearchItem) async {
-        openedPlaylist = playlist
-        playlistTracks = []
-        isLoadingPlaylist = true
-        let browseSpeaker = activeSpeakerID ?? availableSpeakers.first?.entityId
-        if let browseSpeaker {
-            do {
-                playlistTracks = try await restAPIService.browsePlaylistTracks(playlistURI: playlist.uri, on: browseSpeaker)
-            } catch {
-                Log.error("Failed to browse playlist: \(error)")
-                setErrorBannerText("Kunde inte öppna spellistan", "Det gick inte att hämta låtarna")
-            }
+    /// Sets every grouped speaker to the same absolute volume. Individual
+    /// speakers can still be rebalanced afterwards via their own sliders.
+    func setGroupVolume(_ volume: Double) {
+        for speaker in groupedSpeakers {
+            setVolume(volume, for: speaker.entityId)
         }
-        isLoadingPlaylist = false
-    }
-
-    /// Plays the whole playlist from the start on the active speaker.
-    func playPlaylist(_ playlist: MusicSearchItem) async {
-        if await startPlayback(uri: playlist.uri, mediaType: .playlist, title: playlist.name, artist: nil) {
-            closeSearchResults()
-        }
-    }
-
-    /// Plays the chosen track now, then queues the rest of the playlist after it,
-    /// so the tapped song is followed by the playlist.
-    func playTrackInPlaylist(_ track: MusicPlaylistTrack, from playlist: MusicSearchItem) async {
-        guard await startPlayback(uri: track.uri, mediaType: .track, title: track.title, artist: nil) else {
-            return
-        }
-        if let targetID = playbackTargetID {
-            await restAPIService.playMedia(on: targetID, mediaID: playlist.uri, mediaType: .playlist, enqueue: "add")
-        }
-        closeSearchResults()
-    }
-
-    /// Dismisses the search-results sheet and clears any opened playlist.
-    func closeSearchResults() {
-        isShowingSearchResults = false
-        openedPlaylist = nil
-    }
-
-    func togglePlayPause() {
-        guard let activeSpeaker, let targetID = playbackTargetID else {
-            return
-        }
-        let action: Action = activeSpeaker.isPlaying ? .mediaPause : .mediaPlay
-        speakers[activeSpeaker.entityId]?.state = activeSpeaker.isPlaying ? "paused" : "playing"
-        restAPIService.mediaTransport(entityID: targetID, action: action)
-    }
-
-    func nextTrack() {
-        guard let targetID = playbackTargetID else {
-            return
-        }
-        restAPIService.mediaTransport(entityID: targetID, action: .mediaNextTrack)
-    }
-
-    func previousTrack() {
-        guard let targetID = playbackTargetID else {
-            return
-        }
-        restAPIService.mediaTransport(entityID: targetID, action: .mediaPreviousTrack)
-    }
-
-    func setVolume(_ volume: Double) {
-        guard let activeSpeakerID else {
-            return
-        }
-        setVolume(volume, for: activeSpeakerID)
-    }
-
-    /// Sets the volume of a specific speaker. Volume is always per-speaker (never
-    /// redirected to a group leader), so any speaker in the list can be adjusted
-    /// in place.
-    func setVolume(_ volume: Double, for speakerID: EntityId) {
-        speakers[speakerID]?.volumeLevel = volume
-        restAPIService.setVolume(entityID: speakerID, volume: volume)
-    }
-
-    func toggleShuffle() {
-        guard let activeSpeaker, let targetID = playbackTargetID else {
-            return
-        }
-        let newValue = !activeSpeaker.shuffle
-        speakers[activeSpeaker.entityId]?.shuffle = newValue
-        restAPIService.setShuffle(entityID: targetID, shuffle: newValue)
-    }
-
-    func toggleRepeat() {
-        guard let activeSpeaker, let targetID = playbackTargetID else {
-            return
-        }
-        // Cycle off → all → one → off, matching the Sonos-style three-state control.
-        let newMode: MediaRepeatMode = switch activeSpeaker.repeatMode {
-        case .off: .all
-        case .all: .one
-        case .one: .off
-        }
-        speakers[activeSpeaker.entityId]?.repeatMode = newMode
-        restAPIService.setRepeat(entityID: targetID, repeatMode: newMode)
     }
 
     // MARK: - Grouping

--- a/IntelliNest/Views/Music/MusicSearchResultsView.swift
+++ b/IntelliNest/Views/Music/MusicSearchResultsView.swift
@@ -17,25 +17,27 @@ struct MusicSearchResultsView: View {
 
     var body: some View {
         NavigationStack {
-            content
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                .backgroundModifier()
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .principal) {
-                        Text(viewModel.searchText)
-                            .font(.headline)
-                            .foregroundStyle(.white)
-                            .lineLimit(1)
-                    }
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button("Stäng") { viewModel.closeSearchResults() }
-                            .foregroundStyle(.white)
-                    }
+            VStack(spacing: 16) {
+                // Keep an editable search bar in the sheet so a new query can be
+                // run without dismissing the results popup first.
+                MusicSearchBar(searchText: $viewModel.searchText,
+                               onSubmit: { Task { await viewModel.search() } })
+                    .padding(.horizontal)
+                    .padding(.top, 12)
+                content
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .backgroundModifier()
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Stäng") { viewModel.closeSearchResults() }
+                        .foregroundStyle(.white)
                 }
-                .navigationDestination(item: $viewModel.openedPlaylist) { playlist in
-                    MusicPlaylistView(viewModel: viewModel, playlist: playlist)
-                }
+            }
+            .navigationDestination(item: $viewModel.openedPlaylist) { playlist in
+                MusicPlaylistView(viewModel: viewModel, playlist: playlist)
+            }
         }
     }
 
@@ -54,7 +56,6 @@ struct MusicSearchResultsView: View {
                 resultsList
             }
             .padding(.horizontal)
-            .padding(.top, 12)
         }
     }
 

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -20,6 +20,12 @@ struct MusicView: View {
                     if let activeSpeaker = viewModel.activeSpeaker {
                         NowPlayingView(speaker: activeSpeaker, viewModel: viewModel)
                         SpeakerGroupingView(viewModel: viewModel)
+                        LibraryPlaylistsSection(title: "Senast spelade",
+                                                playlists: viewModel.recentlyPlayedPlaylists,
+                                                viewModel: viewModel)
+                        LibraryPlaylistsSection(title: "Favoriter",
+                                                playlists: viewModel.favoritePlaylists,
+                                                viewModel: viewModel)
                     } else {
                         SpeakerPickerView(viewModel: viewModel)
                     }
@@ -32,10 +38,21 @@ struct MusicView: View {
         .sheet(isPresented: $viewModel.isShowingSearchResults) {
             MusicSearchResultsView(viewModel: viewModel)
         }
+        .sheet(item: $viewModel.browsingLibraryPlaylist) { playlist in
+            NavigationStack {
+                MusicPlaylistView(viewModel: viewModel, playlist: playlist)
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button("Stäng") { viewModel.browsingLibraryPlaylist = nil }
+                                .foregroundStyle(.white)
+                        }
+                    }
+            }
+        }
     }
 }
 
-private struct MusicSearchBar: View {
+struct MusicSearchBar: View {
     @Binding var searchText: String
     let onSubmit: MainActorVoidClosure
 
@@ -52,6 +69,61 @@ private struct MusicSearchBar: View {
         .padding(10)
         .background(Color.white.opacity(0.12))
         .cornerRadius(12)
+    }
+}
+
+/// A titled card of library playlists (favourites or recently played) shown
+/// under the speaker grouping in place of the old per-speaker list. Renders
+/// nothing while the list is empty.
+struct LibraryPlaylistsSection: View {
+    let title: String
+    let playlists: [MusicSearchItem]
+    @ObservedObject var viewModel: MusicViewModel
+
+    var body: some View {
+        if playlists.isNotEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.headline)
+                ForEach(playlists) { playlist in
+                    LibraryPlaylistRow(
+                        playlist: playlist,
+                        onOpen: { Task { await viewModel.browseLibraryPlaylist(playlist) } }
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(Color.white.opacity(0.05))
+            .cornerRadius(16)
+        }
+    }
+}
+
+/// A single playlist row. The whole row navigates into the playlist detail
+/// (Spotify-style), where playback lives — so the trailing chevron honestly
+/// signals "tapping the row opens it". The detail's play button starts it.
+private struct LibraryPlaylistRow: View {
+    let playlist: MusicSearchItem
+    let onOpen: MainActorVoidClosure
+
+    var body: some View {
+        Button(action: onOpen) {
+            HStack(spacing: 12) {
+                AlbumArtView(urlString: playlist.imageURL, size: 48)
+                Text(playlist.name)
+                    .font(.body)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.white.opacity(0.4))
+            }
+            .contentShape(Rectangle())
+        }
+        .foregroundStyle(.white)
+        .accessibilityLabel(playlist.name)
+        .accessibilityHint("Öppna spellistan")
     }
 }
 

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -49,8 +49,12 @@ struct NowPlayingView: View {
 
             TransportControlsView(speaker: speaker, viewModel: viewModel)
 
-            VolumeSliderView(volume: speaker.volumeLevel,
-                             onCommit: { viewModel.setVolume($0) })
+            if viewModel.isGroupActive {
+                GroupVolumeView(viewModel: viewModel)
+            } else {
+                VolumeSliderView(volume: speaker.volumeLevel,
+                                 onCommit: { viewModel.setVolume($0) })
+            }
         }
         .padding()
         .background(Color.white.opacity(0.08))
@@ -117,6 +121,51 @@ private struct TransportControlsView: View {
         case .off: "Av"
         case .all: "Alla"
         case .one: "En"
+        }
+    }
+}
+
+/// The group-volume banner shown when the active speaker is synced with others.
+/// The top slider sets every grouped speaker at once; the chevron expands an
+/// individual volume slider per speaker so the balance can be fine-tuned.
+private struct GroupVolumeView: View {
+    @ObservedObject var viewModel: MusicViewModel
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 10) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                } label: {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.white.opacity(0.7))
+                        .frame(width: 16)
+                }
+                .accessibilityLabel(isExpanded ? "Dölj enskilda volymer" : "Visa enskilda volymer")
+
+                VolumeSliderView(volume: viewModel.groupVolume,
+                                 onCommit: { viewModel.setGroupVolume($0) })
+                    .accessibilityLabel("Gruppvolym")
+            }
+
+            if isExpanded {
+                VStack(spacing: 10) {
+                    ForEach(viewModel.groupedSpeakers, id: \.entityId) { speaker in
+                        HStack(spacing: 10) {
+                            Text(speaker.friendlyName)
+                                .font(.subheadline)
+                                .lineLimit(1)
+                                .frame(width: 88, alignment: .leading)
+                            VolumeSliderView(volume: speaker.volumeLevel,
+                                             onCommit: { viewModel.setVolume($0, for: speaker.entityId) })
+                                .accessibilityLabel("Volym \(speaker.friendlyName)")
+                        }
+                    }
+                }
+                .padding(.leading, 26)
+            }
         }
     }
 }

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -11,45 +11,80 @@ import SwiftUI
 /// available speakers can be toggled into or out of its group.
 struct SpeakerGroupingView: View {
     @ObservedObject var viewModel: MusicViewModel
+    @State private var isExpanded = false
 
     private var otherSpeakers: [MediaPlayerEntity] {
         viewModel.availableSpeakers.filter { $0.entityId != viewModel.activeSpeakerID }
     }
 
+    /// Names of the speakers grouped with the active one, used for the collapsed
+    /// summary line.
+    private var groupedNames: [String] {
+        otherSpeakers.filter { viewModel.isGrouped($0.entityId) }.map(\.friendlyName)
+    }
+
+    private var summary: String {
+        groupedNames.isEmpty ? "Inga grupperade" : groupedNames.joined(separator: ", ")
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Gruppera högtalare")
-                .font(.headline)
-            ForEach(otherSpeakers, id: \.entityId) { speaker in
-                let grouped = viewModel.isGrouped(speaker.entityId)
-                VStack(spacing: 8) {
-                    Button {
-                        viewModel.toggleGroupMember(speaker.entityId)
-                    } label: {
-                        HStack {
-                            Image(systemName: grouped ? "checkmark.circle.fill" : "circle")
-                                .foregroundStyle(grouped ? .yellow : .white.opacity(0.6))
-                            Text(speaker.friendlyName)
-                            if speaker.isPlaying {
-                                Image(systemName: "speaker.wave.2.fill")
-                                    .font(.caption)
-                                    .foregroundStyle(.green)
-                                    .accessibilityLabel("Spelar nu")
-                            }
-                            Spacer()
+        VStack(alignment: .leading, spacing: 12) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+            } label: {
+                HStack(alignment: .firstTextBaseline) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Gruppera högtalare")
+                            .font(.headline)
+                        if !isExpanded {
+                            Text(summary)
+                                .font(.subheadline)
+                                .foregroundStyle(.white.opacity(0.6))
+                                .lineLimit(1)
                         }
                     }
-                    .accessibilityLabel("\(grouped ? "Ta bort" : "Lägg till") \(speaker.friendlyName) i gruppen")
-                    .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
-
-                    VolumeSliderView(volume: speaker.volumeLevel,
-                                     onCommit: { viewModel.setVolume($0, for: speaker.entityId) })
-                        .accessibilityLabel("Volym \(speaker.friendlyName)")
+                    Spacer()
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .foregroundStyle(.white.opacity(0.7))
                 }
-                .padding(.vertical, 8)
-                .padding(.horizontal, 12)
-                .background(grouped ? Color.yellow.opacity(0.12) : Color.white.opacity(0.06))
-                .cornerRadius(10)
+                .foregroundStyle(.white)
+                .contentShape(Rectangle())
+            }
+            .accessibilityLabel("Gruppera högtalare")
+            .accessibilityValue(isExpanded ? "Expanderad" : "Hopfälld. \(summary)")
+
+            if isExpanded {
+                ForEach(otherSpeakers, id: \.entityId) { speaker in
+                    let grouped = viewModel.isGrouped(speaker.entityId)
+                    VStack(spacing: 8) {
+                        Button {
+                            viewModel.toggleGroupMember(speaker.entityId)
+                        } label: {
+                            HStack {
+                                Image(systemName: grouped ? "checkmark.circle.fill" : "circle")
+                                    .foregroundStyle(grouped ? .yellow : .white.opacity(0.6))
+                                Text(speaker.friendlyName)
+                                if speaker.isPlaying {
+                                    Image(systemName: "speaker.wave.2.fill")
+                                        .font(.caption)
+                                        .foregroundStyle(.green)
+                                        .accessibilityLabel("Spelar nu")
+                                }
+                                Spacer()
+                            }
+                        }
+                        .accessibilityLabel("\(grouped ? "Ta bort" : "Lägg till") \(speaker.friendlyName) i gruppen")
+                        .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
+
+                        VolumeSliderView(volume: speaker.volumeLevel,
+                                         onCommit: { viewModel.setVolume($0, for: speaker.entityId) })
+                            .accessibilityLabel("Volym \(speaker.friendlyName)")
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 12)
+                    .background(grouped ? Color.yellow.opacity(0.12) : Color.white.opacity(0.06))
+                    .cornerRadius(10)
+                }
             }
         }
         .padding()

--- a/IntelliNestTests/MusicModelTests.swift
+++ b/IntelliNestTests/MusicModelTests.swift
@@ -307,9 +307,11 @@ final class MusicModelTests: XCTestCase {
 
         XCTAssertFalse(success)
     }
+}
 
-    // MARK: - Playlist browse
+// MARK: - Playlist browse
 
+extension MusicModelTests {
     func testPlaylistBrowseResponseDecodesTracksAndDropsInvalid() throws {
         let json = """
         {"media_player.kitchen":{"title":"Sommar","media_class":"playlist","children":[

--- a/IntelliNestTests/MusicViewModelGroupingTests.swift
+++ b/IntelliNestTests/MusicViewModelGroupingTests.swift
@@ -1,0 +1,279 @@
+@testable import IntelliNest
+import XCTest
+
+// MARK: - Grouping & live updates
+
+@MainActor
+extension MusicViewModelTests {
+    func testJoinAddsSpeakerToGroup() async {
+        viewModel.selectSpeaker(.mediaPlayerLivingRoom)
+        let expectation = XCTestExpectation(description: "POST join")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/media_player/join") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/join")
+        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerKitchen))
+        viewModel.toggleGroupMember(.mediaPlayerKitchen)
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
+    func testUnjoinRemovesSpeakerFromGroup() async {
+        // Living room is leader with Kitchen already grouped in.
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "playing",
+                                      friendlyName: "Vardagsrummet",
+                                      groupMembers: [EntityId.mediaPlayerKitchen.rawValue]))
+        for entityID in MusicViewModel.speakerIDs where entityID != .mediaPlayerLivingRoom {
+            stubSpeaker(entityID, data: speakerJSON(entityID: entityID, state: "idle", friendlyName: entityID.rawValue))
+        }
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerLivingRoom)
+        XCTAssertTrue(viewModel.isGrouped(.mediaPlayerKitchen))
+
+        let expectation = XCTestExpectation(description: "POST unjoin")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/media_player/unjoin") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/unjoin")
+        viewModel.toggleGroupMember(.mediaPlayerKitchen)
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
+    func testGroupingNoOpForActiveSpeakerItself() {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerKitchen))
+        // Toggling the leader against itself must do nothing (no crash).
+        viewModel.toggleGroupMember(.mediaPlayerKitchen)
+    }
+
+    // MARK: - Live updates
+
+    func testReloadKeepsOtherSpeakersWhenOneFailsToDecode() async {
+        // Kitchen returns a body that cannot decode into MediaPlayerEntity, hitting
+        // reload()'s per-speaker catch; the other speakers must still load.
+        stubAllSpeakers(playing: .mediaPlayerLivingRoom)
+        let badResponse = HTTPURLResponse(url: speakerURL(.mediaPlayerKitchen),
+                                          statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: speakerURL(.mediaPlayerKitchen),
+                                data: Data("not json".utf8), response: badResponse, error: nil)
+        await viewModel.reload()
+
+        // Kitchen keeps its initial loading entity; the playing speaker still resolves.
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "Loading")
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerLivingRoom)
+    }
+
+    func testReloadReflectsExternalChanges() async {
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+
+        // Someone changes volume + track elsewhere.
+        stubSpeaker(.mediaPlayerKitchen,
+                    data: speakerJSON(entityID: .mediaPlayerKitchen,
+                                      state: "playing",
+                                      friendlyName: "Kitchen",
+                                      volume: 0.9,
+                                      title: trackName,
+                                      artist: trackArtist))
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.volumeLevel, 0.9)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.mediaTitle, trackName)
+    }
+
+    // MARK: - Playlists
+
+    private var playlistItem: MusicSearchItem {
+        MusicSearchItem(uri: "spotify://playlist/p1", name: "Sommar", mediaType: .playlist, imageURL: nil, artist: nil)
+    }
+
+    private func browseURL() -> URL {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/services/media_player/browse_media"
+        components.queryItems = [URLQueryItem(name: "return_response", value: "true")]
+        return components.url!
+    }
+
+    private func stubBrowse(json: String, statusCode: Int = 200) {
+        let url = browseURL()
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(json.utf8), response: response, error: nil)
+    }
+
+    func testOpenPlaylistDrillsInAndLoadsTracks() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubBrowse(json: "{\"service_response\":{\"media_player.kitchen\":{\"children\":" +
+            "[{\"title\":\"Song A\",\"media_content_id\":\"spotify://track/a\"}]}}}")
+        await viewModel.openPlaylist(playlistItem)
+        XCTAssertEqual(viewModel.openedPlaylist, playlistItem)
+        XCTAssertEqual(viewModel.playlistTracks.count, 1)
+        XCTAssertEqual(viewModel.playlistTracks.first?.uri, "spotify://track/a")
+        XCTAssertFalse(viewModel.isLoadingPlaylist)
+    }
+
+    func testOpenPlaylistFailureShowsBanner() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubBrowse(json: "boom", statusCode: 500)
+        await viewModel.openPlaylist(playlistItem)
+        XCTAssertTrue(viewModel.playlistTracks.isEmpty)
+        XCTAssertTrue(bannerTitles.contains("Kunde inte öppna spellistan"))
+        XCTAssertFalse(viewModel.isLoadingPlaylist)
+    }
+
+    func testPlayPlaylistStartsPlaybackAndClosesSheet() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        viewModel.isShowingSearchResults = true
+        viewModel.openedPlaylist = playlistItem
+        stubPlayMedia(statusCode: 200)
+        await viewModel.playPlaylist(playlistItem)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+        XCTAssertFalse(viewModel.isShowingSearchResults)
+        XCTAssertNil(viewModel.openedPlaylist)
+    }
+
+    func testPlayTrackInPlaylistPlaysTrackThenClosesSheet() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        viewModel.isShowingSearchResults = true
+        viewModel.openedPlaylist = playlistItem
+        stubPlayMedia(statusCode: 200)
+        let track = MusicPlaylistTrack(uri: "spotify://track/a", title: "Song A", imageURL: nil)
+        await viewModel.playTrackInPlaylist(track, from: playlistItem)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.mediaTitle, "Song A")
+        XCTAssertFalse(viewModel.isShowingSearchResults)
+        XCTAssertNil(viewModel.openedPlaylist)
+    }
+
+    func testCloseSearchResultsResetsState() {
+        viewModel.isShowingSearchResults = true
+        viewModel.openedPlaylist = playlistItem
+        viewModel.closeSearchResults()
+        XCTAssertFalse(viewModel.isShowingSearchResults)
+        XCTAssertNil(viewModel.openedPlaylist)
+    }
+
+    func testSearchClearsOpenedPlaylist() async {
+        viewModel.openedPlaylist = playlistItem
+        stubSearch(json: "{\"tracks\":[{\"uri\":\"spotify://track/a\",\"name\":\"Song A\"}]}")
+        viewModel.searchText = "song"
+        await viewModel.search()
+        XCTAssertNil(viewModel.openedPlaylist)
+        XCTAssertTrue(viewModel.isShowingSearchResults)
+    }
+
+    // MARK: - Group volume
+
+    /// Reloads with Kitchen as group leader synced to Playroom and Matbord-ute,
+    /// each at a distinct volume, and returns the active speaker.
+    private func reloadGroupedKitchenLeader() async {
+        let leaderMembers = [EntityId.mediaPlayerKitchen.rawValue,
+                             EntityId.mediaPlayerPlayroom.rawValue,
+                             EntityId.mediaPlayerOutdoorTable.rawValue]
+        stubSpeaker(.mediaPlayerKitchen,
+                    data: speakerJSON(entityID: .mediaPlayerKitchen, state: "playing",
+                                      friendlyName: "Köket", volume: 0.06, groupMembers: leaderMembers))
+        stubSpeaker(.mediaPlayerPlayroom,
+                    data: speakerJSON(entityID: .mediaPlayerPlayroom, state: "playing",
+                                      friendlyName: "Lekrummet", volume: 0.12, groupMembers: leaderMembers))
+        stubSpeaker(.mediaPlayerOutdoorTable,
+                    data: speakerJSON(entityID: .mediaPlayerOutdoorTable, state: "playing",
+                                      friendlyName: "Matbord-ute", volume: 0.18, groupMembers: leaderMembers))
+        for entityID in [EntityId.mediaPlayerGuestRoom, .mediaPlayerLivingRoom, .mediaPlayerSpa] {
+            stubSpeaker(entityID, data: speakerJSON(entityID: entityID, state: "idle",
+                                                    friendlyName: entityID.rawValue, volume: 0.3))
+        }
+        await viewModel.reload()
+    }
+
+    func testGroupedSpeakersAndAverageVolume() async {
+        await reloadGroupedKitchenLeader()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerKitchen)
+        XCTAssertTrue(viewModel.isGroupActive)
+        XCTAssertEqual(viewModel.groupedSpeakers.map(\.entityId),
+                       [.mediaPlayerKitchen, .mediaPlayerPlayroom, .mediaPlayerOutdoorTable])
+        // Average of 0.06, 0.12, 0.18.
+        XCTAssertEqual(viewModel.groupVolume, 0.12, accuracy: 0.0001)
+    }
+
+    func testUngroupedSpeakerIsNotGroupActive() async {
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        XCTAssertFalse(viewModel.isGroupActive)
+        XCTAssertEqual(viewModel.groupedSpeakers.map(\.entityId), [.mediaPlayerKitchen])
+        XCTAssertEqual(viewModel.groupVolume, viewModel.activeSpeaker?.volumeLevel)
+    }
+
+    func testSetGroupVolumeUpdatesEveryGroupedSpeakerOnly() async {
+        await reloadGroupedKitchenLeader()
+        stubPostService(path: "/api/services/media_player/volume_set")
+        viewModel.setGroupVolume(0.5)
+        // Every grouped speaker is set to the new level…
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.volumeLevel, 0.5)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerPlayroom]?.volumeLevel, 0.5)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerOutdoorTable]?.volumeLevel, 0.5)
+        // …while an ungrouped speaker keeps its own volume.
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerSpa]?.volumeLevel, 0.3)
+    }
+
+    // MARK: - Favourite playlists
+
+    private func favoritesURL() -> URL {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/services/music_assistant/get_library"
+        components.queryItems = [URLQueryItem(name: "return_response", value: "true")]
+        return components.url!
+    }
+
+    private func stubFavorites(json: String, statusCode: Int = 200) {
+        let url = favoritesURL()
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(json.utf8), response: response, error: nil)
+    }
+
+    func testFavoriteAndRecentPlaylistsLoadOnReload() async {
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        // Both favourites and recents POST to get_library (filters live in the
+        // body, not the URL), so the same stub serves both.
+        stubFavorites(json: "{\"service_response\":{\"items\":[" +
+            "{\"uri\":\"spotify://playlist/1\",\"name\":\"Bastumusik\"}," +
+            "{\"uri\":\"spotify://playlist/2\",\"name\":\"Träning\"}]}}")
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.favoritePlaylists.map(\.name), ["Bastumusik", "Träning"])
+        XCTAssertEqual(viewModel.recentlyPlayedPlaylists.map(\.name), ["Bastumusik", "Träning"])
+        XCTAssertTrue(viewModel.favoritePlaylists.allSatisfy { $0.mediaType == .playlist })
+    }
+
+    func testPlayPlaylistRefreshesRecents() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        viewModel.isShowingSearchResults = true
+        stubPlayMedia(statusCode: 200)
+        stubFavorites(json: "{\"service_response\":{\"items\":[" +
+            "{\"uri\":\"spotify://playlist/1\",\"name\":\"Bastumusik\"}]}}")
+        let playlist = MusicSearchItem(uri: "spotify://playlist/1", name: "Bastumusik",
+                                       mediaType: .playlist, imageURL: nil, artist: nil)
+        await viewModel.playPlaylist(playlist)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
+        // Playing closes the sheet and the post-play refresh repopulated recents.
+        XCTAssertFalse(viewModel.isShowingSearchResults)
+        XCTAssertEqual(viewModel.recentlyPlayedPlaylists.map(\.name), ["Bastumusik"])
+    }
+
+    func testBrowseLibraryPlaylistOpensSheetAndLoadsTracks() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubBrowse(json: "{\"service_response\":{\"media_player.kitchen\":{\"children\":" +
+            "[{\"title\":\"Song A\",\"media_content_id\":\"spotify://track/a\"}]}}}")
+        let favorite = MusicSearchItem(uri: "spotify://playlist/p1", name: "Bastumusik",
+                                       mediaType: .playlist, imageURL: nil, artist: nil)
+        await viewModel.browseLibraryPlaylist(favorite)
+        XCTAssertEqual(viewModel.browsingLibraryPlaylist, favorite)
+        XCTAssertEqual(viewModel.playlistTracks.first?.uri, "spotify://track/a")
+        // Closing clears the browse sheet.
+        viewModel.closeSearchResults()
+        XCTAssertNil(viewModel.browsingLibraryPlaylist)
+    }
+}

--- a/IntelliNestTests/MusicViewModelTests.swift
+++ b/IntelliNestTests/MusicViewModelTests.swift
@@ -40,21 +40,21 @@ class MusicViewModelTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func speakerURL(_ entityID: EntityId) -> URL {
+    func speakerURL(_ entityID: EntityId) -> URL {
         var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
         components.path = "/api/states/\(entityID.rawValue)"
         return components.url!
     }
 
-    private func speakerJSON(entityID: EntityId,
-                             state: String,
-                             friendlyName: String,
-                             volume: Double = 0.3,
-                             title: String? = nil,
-                             artist: String? = nil,
-                             groupMembers: [String] = [],
-                             shuffle: Bool = false,
-                             repeatMode: String = "off") -> Data {
+    func speakerJSON(entityID: EntityId,
+                     state: String,
+                     friendlyName: String,
+                     volume: Double = 0.3,
+                     title: String? = nil,
+                     artist: String? = nil,
+                     groupMembers: [String] = [],
+                     shuffle: Bool = false,
+                     repeatMode: String = "off") -> Data {
         var attributes: [String: Any] = [
             "friendly_name": friendlyName,
             "volume_level": volume,
@@ -67,12 +67,12 @@ class MusicViewModelTests: XCTestCase {
         return makeEntityJSON(entityId: entityID.rawValue, state: state, attributes: attributes)
     }
 
-    private func stubSpeaker(_ entityID: EntityId, data: Data) {
+    func stubSpeaker(_ entityID: EntityId, data: Data) {
         let response = HTTPURLResponse(url: speakerURL(entityID), statusCode: 200, httpVersion: nil, headerFields: nil)!
         URLProtocolStub.setStub(for: speakerURL(entityID), data: data, response: response, error: nil)
     }
 
-    private func stubAllSpeakers(playing: EntityId? = nil, unavailable: Set<EntityId> = []) {
+    func stubAllSpeakers(playing: EntityId? = nil, unavailable: Set<EntityId> = []) {
         for entityID in MusicViewModel.speakerIDs {
             let state: String = if unavailable.contains(entityID) {
                 "unavailable"
@@ -87,14 +87,14 @@ class MusicViewModelTests: XCTestCase {
         }
     }
 
-    private func searchURL() -> URL {
+    func searchURL() -> URL {
         var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
         components.path = "/api/services/music_assistant/search"
         components.queryItems = [URLQueryItem(name: "return_response", value: "true")]
         return components.url!
     }
 
-    private func stubSearch(json: String, statusCode: Int = 200) {
+    func stubSearch(json: String, statusCode: Int = 200) {
         let url = searchURL()
         let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
         URLProtocolStub.setStub(for: url, data: Data(json.utf8), response: response, error: nil)
@@ -214,10 +214,15 @@ class MusicViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasNoResults)
         XCTAssertFalse(viewModel.isShowingSearchResults)
     }
+}
 
+// MARK: - Playback, transport & volume
+
+@MainActor
+extension MusicViewModelTests {
     // MARK: - Play
 
-    private func stubPlayMedia(statusCode: Int) {
+    func stubPlayMedia(statusCode: Int) {
         var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
         components.path = "/api/services/music_assistant/play_media"
         let url = components.url!
@@ -380,177 +385,11 @@ class MusicViewModelTests: XCTestCase {
 
     // MARK: - Helpers
 
-    fileprivate func stubPostService(path: String) {
+    func stubPostService(path: String) {
         var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
         components.path = path
         let url = components.url!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
         URLProtocolStub.setStub(for: url, data: Data(), response: response, error: nil)
-    }
-}
-
-// MARK: - Grouping & live updates
-
-@MainActor
-extension MusicViewModelTests {
-    func testJoinAddsSpeakerToGroup() async {
-        viewModel.selectSpeaker(.mediaPlayerLivingRoom)
-        let expectation = XCTestExpectation(description: "POST join")
-        URLProtocolStub.observerRequests { request in
-            if request.httpMethod == "POST", request.url?.path.contains("/media_player/join") == true {
-                expectation.fulfill()
-            }
-        }
-        stubPostService(path: "/api/services/media_player/join")
-        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerKitchen))
-        viewModel.toggleGroupMember(.mediaPlayerKitchen)
-        await fulfillment(of: [expectation], timeout: 2.0)
-    }
-
-    func testUnjoinRemovesSpeakerFromGroup() async {
-        // Living room is leader with Kitchen already grouped in.
-        stubSpeaker(.mediaPlayerLivingRoom,
-                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
-                                      state: "playing",
-                                      friendlyName: "Vardagsrummet",
-                                      groupMembers: [EntityId.mediaPlayerKitchen.rawValue]))
-        for entityID in MusicViewModel.speakerIDs where entityID != .mediaPlayerLivingRoom {
-            stubSpeaker(entityID, data: speakerJSON(entityID: entityID, state: "idle", friendlyName: entityID.rawValue))
-        }
-        await viewModel.reload()
-        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerLivingRoom)
-        XCTAssertTrue(viewModel.isGrouped(.mediaPlayerKitchen))
-
-        let expectation = XCTestExpectation(description: "POST unjoin")
-        URLProtocolStub.observerRequests { request in
-            if request.httpMethod == "POST", request.url?.path.contains("/media_player/unjoin") == true {
-                expectation.fulfill()
-            }
-        }
-        stubPostService(path: "/api/services/media_player/unjoin")
-        viewModel.toggleGroupMember(.mediaPlayerKitchen)
-        await fulfillment(of: [expectation], timeout: 2.0)
-    }
-
-    func testGroupingNoOpForActiveSpeakerItself() {
-        viewModel.selectSpeaker(.mediaPlayerKitchen)
-        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerKitchen))
-        // Toggling the leader against itself must do nothing (no crash).
-        viewModel.toggleGroupMember(.mediaPlayerKitchen)
-    }
-
-    // MARK: - Live updates
-
-    func testReloadKeepsOtherSpeakersWhenOneFailsToDecode() async {
-        // Kitchen returns a body that cannot decode into MediaPlayerEntity, hitting
-        // reload()'s per-speaker catch; the other speakers must still load.
-        stubAllSpeakers(playing: .mediaPlayerLivingRoom)
-        let badResponse = HTTPURLResponse(url: speakerURL(.mediaPlayerKitchen),
-                                          statusCode: 200, httpVersion: nil, headerFields: nil)!
-        URLProtocolStub.setStub(for: speakerURL(.mediaPlayerKitchen),
-                                data: Data("not json".utf8), response: badResponse, error: nil)
-        await viewModel.reload()
-
-        // Kitchen keeps its initial loading entity; the playing speaker still resolves.
-        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "Loading")
-        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerLivingRoom)
-    }
-
-    func testReloadReflectsExternalChanges() async {
-        stubAllSpeakers(playing: .mediaPlayerKitchen)
-        await viewModel.reload()
-        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
-
-        // Someone changes volume + track elsewhere.
-        stubSpeaker(.mediaPlayerKitchen,
-                    data: speakerJSON(entityID: .mediaPlayerKitchen,
-                                      state: "playing",
-                                      friendlyName: "Kitchen",
-                                      volume: 0.9,
-                                      title: trackName,
-                                      artist: trackArtist))
-        await viewModel.reload()
-        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.volumeLevel, 0.9)
-        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.mediaTitle, trackName)
-    }
-
-    // MARK: - Playlists
-
-    private var playlistItem: MusicSearchItem {
-        MusicSearchItem(uri: "spotify://playlist/p1", name: "Sommar", mediaType: .playlist, imageURL: nil, artist: nil)
-    }
-
-    private func browseURL() -> URL {
-        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
-        components.path = "/api/services/media_player/browse_media"
-        components.queryItems = [URLQueryItem(name: "return_response", value: "true")]
-        return components.url!
-    }
-
-    private func stubBrowse(json: String, statusCode: Int = 200) {
-        let url = browseURL()
-        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
-        URLProtocolStub.setStub(for: url, data: Data(json.utf8), response: response, error: nil)
-    }
-
-    func testOpenPlaylistDrillsInAndLoadsTracks() async {
-        viewModel.selectSpeaker(.mediaPlayerKitchen)
-        stubBrowse(json: "{\"service_response\":{\"media_player.kitchen\":{\"children\":" +
-            "[{\"title\":\"Song A\",\"media_content_id\":\"spotify://track/a\"}]}}}")
-        await viewModel.openPlaylist(playlistItem)
-        XCTAssertEqual(viewModel.openedPlaylist, playlistItem)
-        XCTAssertEqual(viewModel.playlistTracks.count, 1)
-        XCTAssertEqual(viewModel.playlistTracks.first?.uri, "spotify://track/a")
-        XCTAssertFalse(viewModel.isLoadingPlaylist)
-    }
-
-    func testOpenPlaylistFailureShowsBanner() async {
-        viewModel.selectSpeaker(.mediaPlayerKitchen)
-        stubBrowse(json: "boom", statusCode: 500)
-        await viewModel.openPlaylist(playlistItem)
-        XCTAssertTrue(viewModel.playlistTracks.isEmpty)
-        XCTAssertTrue(bannerTitles.contains("Kunde inte öppna spellistan"))
-        XCTAssertFalse(viewModel.isLoadingPlaylist)
-    }
-
-    func testPlayPlaylistStartsPlaybackAndClosesSheet() async {
-        viewModel.selectSpeaker(.mediaPlayerKitchen)
-        viewModel.isShowingSearchResults = true
-        viewModel.openedPlaylist = playlistItem
-        stubPlayMedia(statusCode: 200)
-        await viewModel.playPlaylist(playlistItem)
-        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
-        XCTAssertFalse(viewModel.isShowingSearchResults)
-        XCTAssertNil(viewModel.openedPlaylist)
-    }
-
-    func testPlayTrackInPlaylistPlaysTrackThenClosesSheet() async {
-        viewModel.selectSpeaker(.mediaPlayerKitchen)
-        viewModel.isShowingSearchResults = true
-        viewModel.openedPlaylist = playlistItem
-        stubPlayMedia(statusCode: 200)
-        let track = MusicPlaylistTrack(uri: "spotify://track/a", title: "Song A", imageURL: nil)
-        await viewModel.playTrackInPlaylist(track, from: playlistItem)
-        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
-        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.mediaTitle, "Song A")
-        XCTAssertFalse(viewModel.isShowingSearchResults)
-        XCTAssertNil(viewModel.openedPlaylist)
-    }
-
-    func testCloseSearchResultsResetsState() {
-        viewModel.isShowingSearchResults = true
-        viewModel.openedPlaylist = playlistItem
-        viewModel.closeSearchResults()
-        XCTAssertFalse(viewModel.isShowingSearchResults)
-        XCTAssertNil(viewModel.openedPlaylist)
-    }
-
-    func testSearchClearsOpenedPlaylist() async {
-        viewModel.openedPlaylist = playlistItem
-        stubSearch(json: "{\"tracks\":[{\"uri\":\"spotify://track/a\",\"name\":\"Song A\"}]}")
-        viewModel.searchText = "song"
-        await viewModel.search()
-        XCTAssertNil(viewModel.openedPlaylist)
-        XCTAssertTrue(viewModel.isShowingSearchResults)
     }
 }


### PR DESCRIPTION
## Music enhancements

- **Group-volume banner** — when the active speaker is grouped, one slider controls every grouped speaker (chevron expands to per-speaker sliders); falls back to a single slider when ungrouped.
- **Collapsible "Gruppera högtalare"** — collapsed by default with a summary of who's grouped; expands inline (pushing content down) to the checkbox + per-speaker-volume list.
- **"Senast spelade" + "Favoriter"** — recently-played and favourite playlists from Music Assistant `get_library` (`order_by: last_played_desc` / `favorite: true`). Whole row navigates into the playlist detail (Spotify-style); playback lives in the detail.
- **Editable search bar in the results sheet** — re-search without dismissing the popup.

## Housekeeping
- Split `MusicViewModel` (→ `MusicViewModel+Playback.swift`) and the music tests (→ `MusicViewModelGroupingTests.swift`); moved `RestAPIService` update overloads and a `MusicModelTests` section into same-file extensions — clears all SwiftLint length warnings.
- Excluded `.claude` skill assets from linting; set the empty `NSLocationAlwaysUsageDescription`.
- Build number bumped to 93.

Pure-refactor portions verified behaviour-preserving: full suite (413 tests) passes, clean build is warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library playlists (favorites and recently played) now available for browsing and playback
  * Group volume control for synchronized multi-speaker volume management
  * Enhanced playback controls (play/pause, next/previous, shuffle, repeat cycling)

* **UI Improvements**
  * Improved speaker grouping interface with expandable state display
  * Dedicated library playlist sections in music view
  * Group volume display and per-speaker controls in now playing interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->