### PR TITLE
Refreshed Spotify favourites from the account on each view open

### DIFF
--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -39,12 +39,25 @@ extension MusicViewModel {
         guard spotify.isAuthorized, !hasLoadedSpotifyPlaylists else {
             return
         }
+        await refreshSpotifyPlaylists()
+    }
+
+    /// Re-fetches the Spotify account's playlists, bypassing the load latch.
+    /// Spotify is the source of truth for the library, so the favourites refresh
+    /// each time the music view appears in case the playlists changed elsewhere
+    /// (e.g. edited in the Spotify app or on another device). An empty result is
+    /// kept off the list rather than clearing it, since `accountPlaylists` also
+    /// returns empty on a failed/logged-out fetch.
+    func refreshSpotifyPlaylists() async {
+        guard spotify.isAuthorized else {
+            return
+        }
         let playlists = await spotify.accountPlaylists()
         guard playlists.isNotEmpty else {
             return
         }
-        hasLoadedSpotifyPlaylists = true
         favoritePlaylists = playlists
+        hasLoadedSpotifyPlaylists = true
     }
 
     /// Re-fetches the recently-played list after a playlist launch so the new
@@ -238,8 +251,7 @@ extension MusicViewModel {
         if success {
             // The account's playlist set just changed — refresh the favourites
             // section so it reflects the save/remove.
-            hasLoadedSpotifyPlaylists = false
-            await loadSpotifyPlaylistsIfNeeded()
+            await refreshSpotifyPlaylists()
         } else {
             setSaved(wasSaved, for: playlist)
             setErrorBannerText("Kunde inte uppdatera favorit", "Det gick inte att ändra favoritmarkeringen på Spotify")

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -35,6 +35,9 @@ struct MusicView: View {
         }
         .padding(.horizontal)
         .foregroundStyle(.white)
+        // Spotify is the source of truth — refresh the account's playlists each
+        // time the view appears rather than trusting the once-per-session cache.
+        .task { await viewModel.refreshSpotifyPlaylists() }
         .sheet(isPresented: $viewModel.isShowingSearchResults) {
             MusicSearchResultsView(viewModel: viewModel)
         }

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -172,6 +172,32 @@ extension MusicViewModelTests {
         XCTAssertEqual(stub.accountPlaylistsCallCount, 0)
     }
 
+    func testRefreshSpotifyPlaylistsReflectsLatestLibrary() async {
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: [
+            MusicSearchItem(uri: "spotify://playlist/a", name: "En", mediaType: .playlist, imageURL: nil, artist: nil)
+        ])
+        let model = makeViewModel(spotify: stub)
+        await model.refreshSpotifyPlaylists()
+        XCTAssertEqual(model.favoritePlaylists.map(\.name), ["En"])
+        // The library changes on Spotify; a refresh reflects it (no stale cache),
+        // even though the list was already loaded once.
+        stub.accountPlaylistItems = [
+            MusicSearchItem(uri: "spotify://playlist/b", name: "Två", mediaType: .playlist, imageURL: nil, artist: nil)
+        ]
+        await model.refreshSpotifyPlaylists()
+        XCTAssertEqual(model.favoritePlaylists.map(\.name), ["Två"])
+    }
+
+    func testRefreshSpotifyPlaylistsSkippedWhenLoggedOut() async {
+        let item = MusicSearchItem(uri: "spotify://playlist/a", name: "En",
+                                   mediaType: .playlist, imageURL: nil, artist: nil)
+        let stub = StubSpotifyPlaylistService(authorized: false, accountPlaylistItems: [item])
+        let model = makeViewModel(spotify: stub)
+        await model.refreshSpotifyPlaylists()
+        XCTAssertTrue(model.favoritePlaylists.isEmpty)
+        XCTAssertEqual(stub.accountPlaylistsCallCount, 0)
+    }
+
     func testToggleRefreshesAccountPlaylists() async {
         let item = MusicSearchItem(uri: "spotify://playlist/x", name: "Ny",
                                    mediaType: .playlist, imageURL: nil, artist: nil)


### PR DESCRIPTION
## Why

Spotify is the source of truth for the music library; Music Assistant is only for convenience and playback. The "Favoriter" section was loaded once per session and latched, so it could go stale if the account's playlists changed elsewhere (edited in the Spotify app or on another device).

## What

- Added `MusicViewModel.refreshSpotifyPlaylists()` — re-fetches `/me/playlists` bypassing the load latch, and updates the favourites list.
- `MusicView` calls it on `.task` (each time the view appears), so opening Music always reflects the current Spotify library.
- A successful favourite toggle now also calls it (replacing the reset-flag + reload dance).
- An empty result is kept off the list rather than clearing it, since `accountPlaylists` also returns empty on a failed/logged-out fetch.

Refresh granularity is per view-open (not the 5s reload loop), to stay well within Spotify's "no excessive calls" terms.

## Tests

Added: refresh reflects the latest library even after an initial load; refresh is skipped (no call) when logged out. Full suite green; SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)