### PR TITLE
Added Spotify login prompt and fixed playlist title truncation

### DIFF
--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -192,6 +192,22 @@ extension MusicViewModel {
         browsingLibraryPlaylist = nil
     }
 
+    // MARK: - Spotify login
+
+    /// Runs the Spotify login from the login prompt. On success, marks the session
+    /// authorized (hides the warning triangle) and loads the account's playlists
+    /// into the favourites section.
+    func connectSpotify() async {
+        do {
+            try await spotify.authorize()
+            isSpotifyAuthorized = true
+            await refreshSpotifyPlaylists()
+        } catch {
+            Log.error("Spotify login failed: \(error)")
+            setErrorBannerText("Spotify-inloggning misslyckades", "Kunde inte logga in på Spotify")
+        }
+    }
+
     // MARK: - Spotify favourite
 
     /// Whether the playlist can be saved to Spotify, i.e. it is a Spotify-provider
@@ -236,6 +252,7 @@ extension MusicViewModel {
         if !spotify.isAuthorized {
             do {
                 try await spotify.authorize()
+                isSpotifyAuthorized = true
             } catch {
                 Log.error("Spotify authorization failed: \(error)")
                 setErrorBannerText("Spotify-inloggning misslyckades", "Kunde inte logga in på Spotify")

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -45,6 +45,9 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// URIs of playlists currently saved in the user's Spotify library, driving the
     /// star toggle in the playlist detail view. Populated on demand per playlist.
     @Published var savedPlaylistURIs: Set<String> = []
+    /// Whether the user is logged into Spotify. Drives the login warning triangle
+    /// and its prompt — shown only while logged out.
+    @Published var isSpotifyAuthorized = false
 
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false
@@ -85,6 +88,7 @@ class MusicViewModel: ObservableObject, Reloadable {
         self.restAPIService = restAPIService
         self.setErrorBannerText = setErrorBannerText
         self.spotify = spotify
+        isSpotifyAuthorized = spotify.isAuthorized
         var initialSpeakers: [EntityId: MediaPlayerEntity] = [:]
         for speakerID in Self.speakerIDs {
             initialSpeakers[speakerID] = MediaPlayerEntity(entityId: speakerID)

--- a/IntelliNest/Views/Music/MusicSearchResultsView.swift
+++ b/IntelliNest/Views/Music/MusicSearchResultsView.swift
@@ -129,12 +129,9 @@ struct MusicPlaylistView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task { await viewModel.loadSavedState(for: playlist) }
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Text(playlist.name)
-                    .font(.headline)
-                    .foregroundStyle(.white)
-                    .lineLimit(1)
-            }
+            // No principal title here on purpose — the full playlist name is shown
+            // large in the header below, so a cramped, truncated nav-bar copy adds
+            // nothing. Keep only the favourite star.
             ToolbarItem(placement: .topBarTrailing) {
                 if viewModel.isSpotifyPlaylist(playlist) {
                     favoriteButton

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -9,11 +9,17 @@ import SwiftUI
 
 struct MusicView: View {
     @ObservedObject var viewModel: MusicViewModel
+    @State private var isShowingSpotifyLogin = false
 
     var body: some View {
         VStack(spacing: 16) {
-            MusicSearchBar(searchText: $viewModel.searchText,
-                           onSubmit: { Task { await viewModel.search() } })
+            HStack(spacing: 8) {
+                MusicSearchBar(searchText: $viewModel.searchText,
+                               onSubmit: { Task { await viewModel.search() } })
+                if !viewModel.isSpotifyAuthorized {
+                    spotifyLoginTriangle
+                }
+            }
 
             ScrollView {
                 VStack(spacing: 16) {
@@ -50,6 +56,80 @@ struct MusicView: View {
                                 .foregroundStyle(.white)
                         }
                     }
+            }
+        }
+        .sheet(isPresented: $isShowingSpotifyLogin) {
+            SpotifyLoginPromptView(viewModel: viewModel)
+        }
+    }
+
+    /// A discrete warning triangle shown next to the search bar while logged out
+    /// of Spotify. Tapping opens the dismissable login prompt.
+    private var spotifyLoginTriangle: some View {
+        Button {
+            isShowingSpotifyLogin = true
+        } label: {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.title3)
+                .foregroundStyle(.yellow)
+                .frame(width: 36, height: 36)
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel("Anslut Spotify")
+    }
+}
+
+/// A dismissable modal that explains why Spotify is needed and starts the login.
+/// Dismissable by swipe, the drag indicator, or "Senare"; logging in successfully
+/// also dismisses it.
+private struct SpotifyLoginPromptView: View {
+    @ObservedObject var viewModel: MusicViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var isLoggingIn = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.largeTitle)
+                .foregroundStyle(.yellow)
+            Text("Anslut Spotify")
+                .font(.title2.bold())
+            Text("Logga in på Spotify för att se dina spellistor under Favoriter och spara favoriter.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.white.opacity(0.8))
+            Button(action: logIn) {
+                HStack(spacing: 8) {
+                    if isLoggingIn {
+                        ProgressView().tint(.black)
+                    }
+                    Text("Logga in på Spotify")
+                }
+                .font(.headline)
+                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity)
+                .background(Color.white)
+                .foregroundStyle(.black)
+                .clipShape(Capsule())
+            }
+            .disabled(isLoggingIn)
+            Button("Senare") { dismiss() }
+                .foregroundStyle(.white.opacity(0.7))
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .backgroundModifier()
+        .foregroundStyle(.white)
+        .presentationDetents([.height(320)])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func logIn() {
+        Task {
+            isLoggingIn = true
+            await viewModel.connectSpotify()
+            isLoggingIn = false
+            if viewModel.isSpotifyAuthorized {
+                dismiss()
             }
         }
     }

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -172,6 +172,30 @@ extension MusicViewModelTests {
         XCTAssertEqual(stub.accountPlaylistsCallCount, 0)
     }
 
+    func testIsSpotifyAuthorizedReflectsServiceAtInit() {
+        XCTAssertTrue(makeViewModel(spotify: StubSpotifyPlaylistService(authorized: true)).isSpotifyAuthorized)
+        XCTAssertFalse(makeViewModel(spotify: StubSpotifyPlaylistService(authorized: false)).isSpotifyAuthorized)
+    }
+
+    func testConnectSpotifyLogsInAndLoadsPlaylists() async {
+        let item = MusicSearchItem(uri: "spotify://playlist/a", name: "Morgon",
+                                   mediaType: .playlist, imageURL: nil, artist: nil)
+        let stub = StubSpotifyPlaylistService(authorized: false, accountPlaylistItems: [item])
+        let model = makeViewModel(spotify: stub)
+        await model.connectSpotify()
+        XCTAssertTrue(model.isSpotifyAuthorized)
+        XCTAssertEqual(stub.authorizeCallCount, 1)
+        XCTAssertEqual(model.favoritePlaylists.map(\.name), ["Morgon"])
+    }
+
+    func testConnectSpotifyFailureBannersAndStaysLoggedOut() async {
+        let stub = StubSpotifyPlaylistService(authorized: false, authorizeThrows: true)
+        let model = makeViewModel(spotify: stub)
+        await model.connectSpotify()
+        XCTAssertFalse(model.isSpotifyAuthorized)
+        XCTAssertTrue(bannerTitles.contains("Spotify-inloggning misslyckades"))
+    }
+
     func testRefreshSpotifyPlaylistsReflectsLatestLibrary() async {
         let stub = StubSpotifyPlaylistService(accountPlaylistItems: [
             MusicSearchItem(uri: "spotify://playlist/a", name: "En", mediaType: .playlist, imageURL: nil, artist: nil)


### PR DESCRIPTION
## Why

There was no way to log into Spotify except by tapping a favourite star — but the star only shows on Spotify-sourced playlists, which don't appear until you're logged in. Chicken-and-egg: you couldn't reach login, so "Favoriter" stayed empty. Also, the playlist detail's nav-bar title truncated.

## What

- **Warning triangle** (`exclamationmark.triangle.fill`, discrete, next to the search bar) shown only while logged out of Spotify. Tapping it opens a **dismissable login modal**.
- **`SpotifyLoginPromptView`** — a dismissable sheet (drag indicator + "Senare" + swipe) explaining why Spotify is needed, with a "Logga in på Spotify" button that runs the login. Logging in successfully dismisses it and hides the triangle; the favourites section then loads.
- `MusicViewModel.isSpotifyAuthorized` (drives the triangle) + `connectSpotify()` (login → load account playlists).
- **Title truncation fix:** removed the cramped, truncated principal nav-bar title in `MusicPlaylistView` — the full name is already shown large in the header. Kept the favourite star.

## Tests

Added: `isSpotifyAuthorized` reflects the service at init; `connectSpotify` logs in + loads playlists; login failure banners and stays logged out. Full suite green; SwiftLint clean.

## Note

No render screenshots — the new UI is a modal sheet + a nav-bar/toolbar element, neither of which `ImageRenderer` can draw faithfully. Visible on the next TestFlight build.

## Follow-up (separate)

Star on Music-Assistant-sourced playlists ("Senast spelade") — you asked to resolve those to their Spotify ID so the star works there too. That needs the real MA `get_library` JSON shape to map the ID; I'll do it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Spotify login prompt modal explaining integration requirements
  * Visual indicator appears when Spotify authorization is needed
  * Modal automatically dismisses on successful login

* **Bug Fixes**
  * Fixed authorization state not updating in all authorization flows

* **Tests**
  * Expanded Spotify authorization and login flow test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->