### PR TITLE
Resolved Spotify star on Music Assistant playlists and gated it on login

### DIFF
--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -210,10 +210,12 @@ extension MusicViewModel {
 
     // MARK: - Spotify favourite
 
-    /// Whether the playlist can be saved to Spotify, i.e. it is a Spotify-provider
-    /// playlist. Local/other-provider playlists have no Spotify library to save to.
+    /// Whether to show the favourite star for this playlist. Only true when logged
+    /// in (so the star never appears unless tapping it actually saves) and the
+    /// playlist resolves to a Spotify id — directly or via the account match.
+    /// Built-ins, non-account playlists, and the logged-out state get no star.
     func isSpotifyPlaylist(_ playlist: MusicSearchItem) -> Bool {
-        spotifyPlaylistID(for: playlist) != nil
+        isSpotifyAuthorized && spotifyPlaylistID(for: playlist) != nil
     }
 
     /// Whether the playlist is currently marked saved (drives the filled star).
@@ -221,15 +223,32 @@ extension MusicViewModel {
         savedPlaylistURIs.contains(playlist.uri)
     }
 
-    /// Extracts the id from a `spotify://playlist/<id>` uri, or nil when the
-    /// playlist isn't a Spotify one.
+    /// Resolves the Spotify playlist id for a playlist. A `spotify://playlist/<id>`
+    /// uri gives it directly. Music Assistant library items instead use opaque
+    /// `library://playlist/<n>` uris with no Spotify id, so they're matched by name
+    /// against the logged-in account's playlists (Spotify is the source of truth,
+    /// and an MA Spotify-library playlist is by definition one of those). Returns
+    /// nil for non-Spotify playlists (MA built-ins, or anything not in the account).
     private func spotifyPlaylistID(for playlist: MusicSearchItem) -> String? {
+        if let id = directSpotifyPlaylistID(from: playlist.uri) {
+            return id
+        }
+        let name = normalizedName(playlist.name)
+        let match = favoritePlaylists.first { normalizedName($0.name) == name }
+        return match.flatMap { directSpotifyPlaylistID(from: $0.uri) }
+    }
+
+    private func directSpotifyPlaylistID(from uri: String) -> String? {
         let prefix = "spotify://playlist/"
-        guard playlist.uri.hasPrefix(prefix) else {
+        guard uri.hasPrefix(prefix) else {
             return nil
         }
-        let id = String(playlist.uri.dropFirst(prefix.count))
+        let id = String(uri.dropFirst(prefix.count))
         return id.isNotEmpty ? id : nil
+    }
+
+    private func normalizedName(_ name: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
     /// Reads the live Spotify saved-state when the playlist detail appears, so the

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -82,12 +82,47 @@ extension MusicViewModelTests {
                        spotify: spotify)
     }
 
-    func testIsSpotifyPlaylistDistinguishesProvider() {
+    func testIsSpotifyPlaylistRequiresLoginAndResolvableUri() {
         let spotifyItem = spotifyPlaylist()
         let localItem = MusicSearchItem(uri: "library://playlist/3", name: "Lokal",
                                         mediaType: .playlist, imageURL: nil, artist: nil)
-        XCTAssertTrue(viewModel.isSpotifyPlaylist(spotifyItem))
-        XCTAssertFalse(viewModel.isSpotifyPlaylist(localItem))
+        // Logged in: star shows for a Spotify uri, not for an unmatched library item.
+        let loggedIn = makeViewModel(spotify: StubSpotifyPlaylistService(authorized: true))
+        XCTAssertTrue(loggedIn.isSpotifyPlaylist(spotifyItem))
+        XCTAssertFalse(loggedIn.isSpotifyPlaylist(localItem))
+        // Logged out: no star at all, even on a Spotify playlist — tapping it
+        // couldn't save without logging in first.
+        let loggedOut = makeViewModel(spotify: StubSpotifyPlaylistService(authorized: false))
+        XCTAssertFalse(loggedOut.isSpotifyPlaylist(spotifyItem))
+    }
+
+    func testLibraryPlaylistResolvesToSpotifyByName() async {
+        // The huset account has this playlist (with its real Spotify id); Music
+        // Assistant exposes the same playlist as an opaque library:// item.
+        let account = [MusicSearchItem(uri: "spotify://playlist/realid42",
+                                       name: "Barnlåtar 🐵 musik för barn",
+                                       mediaType: .playlist, imageURL: nil, artist: nil)]
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: account)
+        let model = makeViewModel(spotify: stub)
+        await model.refreshSpotifyPlaylists()
+        let libraryItem = MusicSearchItem(uri: "library://playlist/12",
+                                          name: "Barnlåtar 🐵 musik för barn  ",
+                                          mediaType: .playlist, imageURL: nil, artist: nil)
+        XCTAssertTrue(model.isSpotifyPlaylist(libraryItem))
+        await model.toggleSpotifySaved(libraryItem)
+        // It resolved to a Spotify id, so the save went through.
+        XCTAssertEqual(stub.saveCallCount, 1)
+    }
+
+    func testLibraryBuiltinPlaylistHasNoStar() async {
+        let account = [MusicSearchItem(uri: "spotify://playlist/realid42", name: "Barnlåtar",
+                                       mediaType: .playlist, imageURL: nil, artist: nil)]
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: account)
+        let model = makeViewModel(spotify: stub)
+        await model.refreshSpotifyPlaylists()
+        let builtin = MusicSearchItem(uri: "library://playlist/3", name: "Random Album (from library)",
+                                      mediaType: .playlist, imageURL: nil, artist: nil)
+        XCTAssertFalse(model.isSpotifyPlaylist(builtin))
     }
 
     func testLoadSavedStateReflectsLibrary() async {


### PR DESCRIPTION
## Why

Two issues with the favourite star:
1. On "Senast spelade" (Music Assistant) playlists the star never appeared, because MA exposes them as opaque `library://playlist/<n>` uris with no Spotify id — even when they really are huset Spotify playlists.
2. A star could appear while logged out, where tapping it couldn't actually save.

Confirmed from a live `get_library` response: items carry `library://` uris and **no `provider_mappings`**; Spotify ones are only distinguishable by their `scdn.co` image.

## What

- **Name resolution:** `spotifyPlaylistID(for:)` now resolves a `library://` playlist by matching its name against the logged-in account's `/me/playlists` (which carry the real `spotify://playlist/<id>`). Direct `spotify://` uris still resolve instantly. So MA Spotify playlists get the star; built-ins ("Random Album", "All favorited tracks") and anything not in the account don't.
- **"Don't show stars that don't work":** the star is now gated on being logged in (`isSpotifyAuthorized`). Logged out → no stars anywhere (the warning triangle drives login). Logged in → a star appears only where the save/unsave genuinely works.

## Tests

Added: library item resolves to Spotify by name (+ save goes through); built-in stays star-less; star requires both login and a resolvable uri (logged-out Spotify playlist shows none). Updated the old provider-distinction test. Full suite green; SwiftLint clean.

## Limitations

Resolution is by normalized name, so two playlists with identical names are an edge case. "Liked Songs" is a collection (not a playlist), so it correctly stays star-less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)