### PR TITLE
Fixed regrouping speakers already paired in another group

### DIFF
--- a/IntelliNest/Services/RestAPIService+Music.swift
+++ b/IntelliNest/Services/RestAPIService+Music.swift
@@ -170,20 +170,30 @@ extension RestAPIService {
     /// failure; a failed pre-unjoin aborts before the join is attempted.
     @discardableResult
     func joinSpeakers(leaderID: EntityId, memberIDs: [EntityId], unjoinFirst: Bool = false, reloadTimes: Int = 3) async -> Bool {
+        // Track whether any state actually changed so a rejected op doesn't churn
+        // reloads, while a partial failure (a pre-unjoin succeeded, then the join
+        // failed) still refreshes the speaker that did leave its old group.
+        var didMutate = false
         if unjoinFirst {
             for memberID in memberIDs {
                 var unjoinJSON = [JSONKey: Any]()
                 unjoinJSON[.entityID] = memberID.rawValue
                 guard await sendMusicPostExpectingSuccess(domain: .mediaPlayer, action: .unjoin, json: unjoinJSON) else {
+                    if didMutate {
+                        triggerRepeatReload(times: reloadTimes)
+                    }
                     return false
                 }
+                didMutate = true
             }
         }
         var json = [JSONKey: Any]()
         json[.entityID] = leaderID.rawValue
         json[.groupMembers] = memberIDs.map(\.rawValue)
         let success = await sendMusicPostExpectingSuccess(domain: .mediaPlayer, action: .join, json: json)
-        triggerRepeatReload(times: reloadTimes)
+        if success || didMutate {
+            triggerRepeatReload(times: reloadTimes)
+        }
         return success
     }
 
@@ -194,7 +204,9 @@ extension RestAPIService {
         var json = [JSONKey: Any]()
         json[.entityID] = memberID.rawValue
         let success = await sendMusicPostExpectingSuccess(domain: .mediaPlayer, action: .unjoin, json: json)
-        triggerRepeatReload(times: reloadTimes)
+        if success {
+            triggerRepeatReload(times: reloadTimes)
+        }
         return success
     }
 

--- a/IntelliNest/Services/RestAPIService+Music.swift
+++ b/IntelliNest/Services/RestAPIService+Music.swift
@@ -162,25 +162,40 @@ extension RestAPIService {
                reloadTimes: reloadTimes)
     }
 
-    /// Adds `memberIDs` into the group led by `leaderID`.
-    func joinSpeakers(leaderID: EntityId, memberIDs: [EntityId], reloadTimes: Int = 3) {
-        Task {
-            var json = [JSONKey: Any]()
-            json[.entityID] = leaderID.rawValue
-            json[.groupMembers] = memberIDs.map(\.rawValue)
-            await sendPostRequest(json: json, domain: .mediaPlayer, action: .join)
-            triggerRepeatReload(times: reloadTimes)
+    /// Adds `memberIDs` into the group led by `leaderID`. When `unjoinFirst` is
+    /// set, each member is unjoined from its current group before the join —
+    /// Music Assistant accepts a bare `join` on an already-synced player but
+    /// silently keeps it in its old group, so re-homing needs the unjoin first.
+    /// Returns whether the group change succeeded so the caller can surface a
+    /// failure; a failed pre-unjoin aborts before the join is attempted.
+    @discardableResult
+    func joinSpeakers(leaderID: EntityId, memberIDs: [EntityId], unjoinFirst: Bool = false, reloadTimes: Int = 3) async -> Bool {
+        if unjoinFirst {
+            for memberID in memberIDs {
+                var unjoinJSON = [JSONKey: Any]()
+                unjoinJSON[.entityID] = memberID.rawValue
+                guard await sendMusicPostExpectingSuccess(domain: .mediaPlayer, action: .unjoin, json: unjoinJSON) else {
+                    return false
+                }
+            }
         }
+        var json = [JSONKey: Any]()
+        json[.entityID] = leaderID.rawValue
+        json[.groupMembers] = memberIDs.map(\.rawValue)
+        let success = await sendMusicPostExpectingSuccess(domain: .mediaPlayer, action: .join, json: json)
+        triggerRepeatReload(times: reloadTimes)
+        return success
     }
 
-    /// Removes `memberID` from whatever group it is currently in.
-    func unjoinSpeaker(memberID: EntityId, reloadTimes: Int = 3) {
-        Task {
-            var json = [JSONKey: Any]()
-            json[.entityID] = memberID.rawValue
-            await sendPostRequest(json: json, domain: .mediaPlayer, action: .unjoin)
-            triggerRepeatReload(times: reloadTimes)
-        }
+    /// Removes `memberID` from whatever group it is currently in. Returns whether
+    /// the unjoin succeeded so the caller can surface a failure.
+    @discardableResult
+    func unjoinSpeaker(memberID: EntityId, reloadTimes: Int = 3) async -> Bool {
+        var json = [JSONKey: Any]()
+        json[.entityID] = memberID.rawValue
+        let success = await sendMusicPostExpectingSuccess(domain: .mediaPlayer, action: .unjoin, json: json)
+        triggerRepeatReload(times: reloadTimes)
+        return success
     }
 
     private func sendMusicPostExpectingSuccess(domain: Domain, action: Action, json: [JSONKey: Any]) async -> Bool {

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -243,15 +243,32 @@ class MusicViewModel: ObservableObject, Reloadable {
     }
 
     /// Toggles `speakerID` into or out of the active speaker's group. The active
-    /// speaker stays the group leader (the `join` sync source).
-    func toggleGroupMember(_ speakerID: EntityId) {
+    /// speaker stays the group leader (the `join` sync source). Surfaces an error
+    /// banner when Home Assistant rejects the group change, so a failed sync no
+    /// longer looks like a silent no-op.
+    func toggleGroupMember(_ speakerID: EntityId) async {
         guard let activeSpeakerID, speakerID != activeSpeakerID else {
             return
         }
+        let speakerName = speakers[speakerID]?.friendlyName ?? speakerID.rawValue
         if isGrouped(speakerID) {
-            restAPIService.unjoinSpeaker(memberID: speakerID)
+            let success = await restAPIService.unjoinSpeaker(memberID: speakerID)
+            if !success {
+                setErrorBannerText("Kunde inte dela upp högtalare", "Det gick inte att ta bort \(speakerName) från gruppen")
+            }
         } else {
-            restAPIService.joinSpeakers(leaderID: activeSpeakerID, memberIDs: [speakerID])
+            // A speaker already synced into a different group (e.g. Spa paired with
+            // Matbord-ute) can't be moved by a plain join, so unjoin it from its
+            // current group first. groupMembers > 1 means it is grouped with someone
+            // other than the active leader, since the grouped-with-leader case is the
+            // unjoin branch above.
+            let isInOtherGroup = (speakers[speakerID]?.groupMembers.count ?? 0) > 1
+            let success = await restAPIService.joinSpeakers(leaderID: activeSpeakerID,
+                                                            memberIDs: [speakerID],
+                                                            unjoinFirst: isInOtherGroup)
+            if !success {
+                setErrorBannerText("Kunde inte gruppera högtalare", "Det gick inte att lägga till \(speakerName) i gruppen")
+            }
         }
     }
 }

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -58,7 +58,7 @@ struct SpeakerGroupingView: View {
                     let grouped = viewModel.isGrouped(speaker.entityId)
                     VStack(spacing: 8) {
                         Button {
-                            viewModel.toggleGroupMember(speaker.entityId)
+                            Task { await viewModel.toggleGroupMember(speaker.entityId) }
                         } label: {
                             HStack {
                                 Image(systemName: grouped ? "checkmark.circle.fill" : "circle")

--- a/IntelliNestTests/MusicViewModelGroupingTests.swift
+++ b/IntelliNestTests/MusicViewModelGroupingTests.swift
@@ -15,7 +15,7 @@ extension MusicViewModelTests {
         }
         stubPostService(path: "/api/services/media_player/join")
         XCTAssertFalse(viewModel.isGrouped(.mediaPlayerKitchen))
-        viewModel.toggleGroupMember(.mediaPlayerKitchen)
+        await viewModel.toggleGroupMember(.mediaPlayerKitchen)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
 
@@ -40,15 +40,106 @@ extension MusicViewModelTests {
             }
         }
         stubPostService(path: "/api/services/media_player/unjoin")
-        viewModel.toggleGroupMember(.mediaPlayerKitchen)
+        await viewModel.toggleGroupMember(.mediaPlayerKitchen)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
 
-    func testGroupingNoOpForActiveSpeakerItself() {
+    func testJoinUnjoinsSpeakerFromItsOldGroupFirst() async {
+        // Kitchen is the active, ungrouped leader. Spa and Matbord-ute are already
+        // synced together in their own group, so tapping Spa must unjoin it from
+        // that group before joining Kitchen — a bare join would silently no-op.
+        let spaGroup = [EntityId.mediaPlayerSpa.rawValue, EntityId.mediaPlayerOutdoorTable.rawValue]
+        stubSpeaker(.mediaPlayerKitchen,
+                    data: speakerJSON(entityID: .mediaPlayerKitchen, state: "playing", friendlyName: "Köket"))
+        stubSpeaker(.mediaPlayerSpa,
+                    data: speakerJSON(entityID: .mediaPlayerSpa, state: "idle", friendlyName: "Spa", groupMembers: spaGroup))
+        stubSpeaker(.mediaPlayerOutdoorTable,
+                    data: speakerJSON(entityID: .mediaPlayerOutdoorTable, state: "idle",
+                                      friendlyName: "Matbord-ute", groupMembers: spaGroup))
+        for entityID in [EntityId.mediaPlayerGuestRoom, .mediaPlayerPlayroom, .mediaPlayerLivingRoom] {
+            stubSpeaker(entityID, data: speakerJSON(entityID: entityID, state: "idle", friendlyName: entityID.rawValue))
+        }
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerKitchen)
+        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerSpa))
+
+        let orderLock = NSLock()
+        var requestOrder: [String] = []
+        URLProtocolStub.observerRequests { request in
+            guard request.httpMethod == "POST", let path = request.url?.path else {
+                return
+            }
+            if path.contains("/media_player/unjoin") {
+                orderLock.lock(); requestOrder.append("unjoin"); orderLock.unlock()
+            } else if path.contains("/media_player/join") {
+                orderLock.lock(); requestOrder.append("join"); orderLock.unlock()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/unjoin")
+        stubPostService(path: "/api/services/media_player/join")
+
+        await viewModel.toggleGroupMember(.mediaPlayerSpa)
+        orderLock.lock(); let recordedOrder = requestOrder; orderLock.unlock()
+        XCTAssertEqual(recordedOrder, ["unjoin", "join"])
+    }
+
+    func testJoinDoesNotUnjoinAFreeSpeaker() async {
+        // Kitchen active, Spa ungrouped. Tapping Spa joins it directly — no unjoin.
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerSpa))
+
+        let orderLock = NSLock()
+        var requestOrder: [String] = []
+        URLProtocolStub.observerRequests { request in
+            guard request.httpMethod == "POST", let path = request.url?.path else {
+                return
+            }
+            if path.contains("/media_player/unjoin") {
+                orderLock.lock(); requestOrder.append("unjoin"); orderLock.unlock()
+            } else if path.contains("/media_player/join") {
+                orderLock.lock(); requestOrder.append("join"); orderLock.unlock()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/unjoin")
+        stubPostService(path: "/api/services/media_player/join")
+
+        await viewModel.toggleGroupMember(.mediaPlayerSpa)
+        orderLock.lock(); let recordedOrder = requestOrder; orderLock.unlock()
+        XCTAssertEqual(recordedOrder, ["join"])
+    }
+
+    func testJoinFailureShowsBanner() async {
+        // Kitchen active, Spa ungrouped, but the join is rejected by Home Assistant.
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        stubPostService(path: "/api/services/media_player/join", statusCode: 500)
+        await viewModel.toggleGroupMember(.mediaPlayerSpa)
+        XCTAssertTrue(bannerTitles.contains("Kunde inte gruppera högtalare"))
+    }
+
+    func testUnjoinFailureShowsBanner() async {
+        // Living room leader with Kitchen grouped in; the unjoin is rejected.
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "playing",
+                                      friendlyName: "Vardagsrummet",
+                                      groupMembers: [EntityId.mediaPlayerKitchen.rawValue]))
+        for entityID in MusicViewModel.speakerIDs where entityID != .mediaPlayerLivingRoom {
+            stubSpeaker(entityID, data: speakerJSON(entityID: entityID, state: "idle", friendlyName: entityID.rawValue))
+        }
+        await viewModel.reload()
+        XCTAssertTrue(viewModel.isGrouped(.mediaPlayerKitchen))
+        stubPostService(path: "/api/services/media_player/unjoin", statusCode: 500)
+        await viewModel.toggleGroupMember(.mediaPlayerKitchen)
+        XCTAssertTrue(bannerTitles.contains("Kunde inte dela upp högtalare"))
+    }
+
+    func testGroupingNoOpForActiveSpeakerItself() async {
         viewModel.selectSpeaker(.mediaPlayerKitchen)
         XCTAssertFalse(viewModel.isGrouped(.mediaPlayerKitchen))
         // Toggling the leader against itself must do nothing (no crash).
-        viewModel.toggleGroupMember(.mediaPlayerKitchen)
+        await viewModel.toggleGroupMember(.mediaPlayerKitchen)
     }
 
     // MARK: - Live updates

--- a/IntelliNestTests/MusicViewModelTests.swift
+++ b/IntelliNestTests/MusicViewModelTests.swift
@@ -385,11 +385,11 @@ extension MusicViewModelTests {
 
     // MARK: - Helpers
 
-    func stubPostService(path: String) {
+    func stubPostService(path: String, statusCode: Int = 200) {
         var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
         components.path = path
         let url = components.url!
-        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
         URLProtocolStub.setStub(for: url, data: Data(), response: response, error: nil)
     }
 }


### PR DESCRIPTION
## Why

Tapping a speaker in **Gruppera högtalare** (e.g. Spa or Matbord-ute) sometimes did nothing. The cause: those two were already
synced together in their own group. Music Assistant accepts a bare `media_player.join` on an already-grouped player but silently
keeps it in its old group, so the join was a no-op. The app made it worse two ways:

- `isGrouped(_:)` only checks the **active** speaker's members, so a speaker grouped with someone *else* looked ungrouped and got
  the no-op `join`.
- `joinSpeakers`/`unjoinSpeaker` ignored the response, so even a genuinely rejected group change looked like a silent no-op.

## What changed

- **Unjoin-first re-homing** — when the tapped speaker is already in another group (`groupMembers.count > 1`), it is unjoined from
  its current group before joining the active leader. A failed pre-unjoin aborts before the join is attempted.
- **Error surfacing** — `joinSpeakers`/`unjoinSpeaker` now run through the success-checking request path and return whether the
  change succeeded. `toggleGroupMember` awaits the result and raises an error banner on failure
  (`Kunde inte gruppera högtalare` / `Kunde inte dela upp högtalare`) instead of failing silently.

## Tests

Added to `MusicViewModelGroupingTests`:
- `testJoinUnjoinsSpeakerFromItsOldGroupFirst` — asserts request order is exactly `["unjoin", "join"]`.
- `testJoinDoesNotUnjoinAFreeSpeaker` — an ungrouped speaker joins directly, no stray unjoin.
- `testJoinFailureShowsBanner` / `testUnjoinFailureShowsBanner` — rejected group changes raise the banner.

Full `MusicViewModelTests` suite passes; SwiftFormat and SwiftLint clean.

## Note

Assumes Music Assistant processes the sequential unjoin→join cleanly without a delay between them — couldn't verify timing
without hardware. If a race shows up on a real device, the follow-up would be a small settle between the two calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for speaker grouping operations with proper success/failure detection and user feedback.

* **Tests**
  * Enhanced test coverage for speaker grouping scenarios, including failure cases and error reporting validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->