### PR TITLE
Added music queue, song favourites and playlist editing

### DIFF
--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -51,19 +51,28 @@
 		F62750B32A066B4500C1253F /* URLProtocolStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62750B22A066B4500C1253F /* URLProtocolStub.swift */; };
 		EE0000010000000000000001 /* MediaPlayerEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000010000000000000001 /* MediaPlayerEntity.swift */; };
 		EE0000020000000000000002 /* MusicSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000020000000000000002 /* MusicSearchResult.swift */; };
+		FE0000000000000000000001 /* MusicQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000001 /* MusicQueue.swift */; };
 		EE0000030000000000000003 /* RestAPIService+Music.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000030000000000000003 /* RestAPIService+Music.swift */; };
 		EE0000130000000000000020 /* SpotifyAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000130000000000000020 /* SpotifyAuthService.swift */; };
 		EE0000140000000000000021 /* SpotifyApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000140000000000000021 /* SpotifyApiService.swift */; };
+		FE0000000000000000000002 /* MusicAssistantSocketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000002 /* MusicAssistantSocketService.swift */; };
 		EE0000150000000000000022 /* SpotifyApiServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000150000000000000022 /* SpotifyApiServiceTests.swift */; };
 		EE0000160000000000000023 /* MusicViewModelSpotifyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000160000000000000023 /* MusicViewModelSpotifyTests.swift */; };
+		FE0000000000000000000009 /* MusicViewModelSongFavoriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000009 /* MusicViewModelSongFavoriteTests.swift */; };
+		FE0000000000000000000008 /* MusicViewModelQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000008 /* MusicViewModelQueueTests.swift */; };
+		FE0000000000000000000007 /* MusicQueueModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000007 /* MusicQueueModelTests.swift */; };
 		EE0000040000000000000004 /* MusicViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000040000000000000004 /* MusicViewModel.swift */; };
 		EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00000400000000000000F1 /* MusicViewModel+Playback.swift */; };
+		FE0000000000000000000004 /* MusicViewModel+Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000004 /* MusicViewModel+Queue.swift */; };
+		FE0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift */; };
 		EE0000050000000000000005 /* MusicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000050000000000000005 /* MusicView.swift */; };
 		EE0000060000000000000006 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000060000000000000006 /* NowPlayingView.swift */; };
 		EE0000070000000000000007 /* AlbumArtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000070000000000000007 /* AlbumArtView.swift */; };
 		EE0000080000000000000008 /* SpeakerPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000080000000000000008 /* SpeakerPickerView.swift */; };
 		EE0000090000000000000009 /* SpeakerGroupingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000090000000000000009 /* SpeakerGroupingView.swift */; };
 		EE000010000000000000000A /* MusicSearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF000010000000000000000A /* MusicSearchResultsView.swift */; };
+		FE0000000000000000000006 /* QueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000006 /* QueueView.swift */; };
+		FE0000000000000000000005 /* MusicTrackControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000005 /* MusicTrackControls.swift */; };
 		EE000011000000000000000B /* MusicViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF000011000000000000000B /* MusicViewModelTests.swift */; };
 		EE00001100000000000000C1 /* MusicViewModelGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00001100000000000000C1 /* MusicViewModelGroupingTests.swift */; };
 		EE000012000000000000000C /* MusicModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF000012000000000000000C /* MusicModelTests.swift */; };
@@ -270,19 +279,28 @@
 		F62CD2DF286D950A00462092 /* LightEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightEntity.swift; sourceTree = "<group>"; };
 		EF0000010000000000000001 /* MediaPlayerEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerEntity.swift; sourceTree = "<group>"; };
 		EF0000020000000000000002 /* MusicSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSearchResult.swift; sourceTree = "<group>"; };
+		FD0000000000000000000001 /* MusicQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicQueue.swift; sourceTree = "<group>"; };
 		EF0000030000000000000003 /* RestAPIService+Music.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestAPIService+Music.swift"; sourceTree = "<group>"; };
 		EF0000130000000000000020 /* SpotifyAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAuthService.swift; sourceTree = "<group>"; };
 		EF0000140000000000000021 /* SpotifyApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyApiService.swift; sourceTree = "<group>"; };
+		FD0000000000000000000002 /* MusicAssistantSocketService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicAssistantSocketService.swift; sourceTree = "<group>"; };
 		EF0000150000000000000022 /* SpotifyApiServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyApiServiceTests.swift; sourceTree = "<group>"; };
 		EF0000160000000000000023 /* MusicViewModelSpotifyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelSpotifyTests.swift; sourceTree = "<group>"; };
+		FD0000000000000000000009 /* MusicViewModelSongFavoriteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelSongFavoriteTests.swift; sourceTree = "<group>"; };
+		FD0000000000000000000008 /* MusicViewModelQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelQueueTests.swift; sourceTree = "<group>"; };
+		FD0000000000000000000007 /* MusicQueueModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicQueueModelTests.swift; sourceTree = "<group>"; };
 		EF0000040000000000000004 /* MusicViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModel.swift; sourceTree = "<group>"; };
 		EF00000400000000000000F1 /* MusicViewModel+Playback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Playback.swift"; sourceTree = "<group>"; };
+		FD0000000000000000000004 /* MusicViewModel+Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Queue.swift"; sourceTree = "<group>"; };
+		FD0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+SpotifyTracks.swift"; sourceTree = "<group>"; };
 		EF0000050000000000000005 /* MusicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicView.swift; sourceTree = "<group>"; };
 		EF0000060000000000000006 /* NowPlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingView.swift; sourceTree = "<group>"; };
 		EF0000070000000000000007 /* AlbumArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumArtView.swift; sourceTree = "<group>"; };
 		EF0000080000000000000008 /* SpeakerPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerPickerView.swift; sourceTree = "<group>"; };
 		EF0000090000000000000009 /* SpeakerGroupingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerGroupingView.swift; sourceTree = "<group>"; };
 		EF000010000000000000000A /* MusicSearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSearchResultsView.swift; sourceTree = "<group>"; };
+		FD0000000000000000000006 /* QueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueView.swift; sourceTree = "<group>"; };
+		FD0000000000000000000005 /* MusicTrackControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicTrackControls.swift; sourceTree = "<group>"; };
 		EF000011000000000000000B /* MusicViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelTests.swift; sourceTree = "<group>"; };
 		EF00001100000000000000C1 /* MusicViewModelGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelGroupingTests.swift; sourceTree = "<group>"; };
 		EF000012000000000000000C /* MusicModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicModelTests.swift; sourceTree = "<group>"; };
@@ -481,6 +499,7 @@
 				B126D511CCFBA5E7EF7F80F9 /* HomeLocationEntity.swift */,
 				EF0000010000000000000001 /* MediaPlayerEntity.swift */,
 				EF0000020000000000000002 /* MusicSearchResult.swift */,
+				FD0000000000000000000001 /* MusicQueue.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -521,6 +540,7 @@
 				EF0000030000000000000003 /* RestAPIService+Music.swift */,
 				EF0000130000000000000020 /* SpotifyAuthService.swift */,
 				EF0000140000000000000021 /* SpotifyApiService.swift */,
+				FD0000000000000000000002 /* MusicAssistantSocketService.swift */,
 				F6FDBE2C2A1A2F970081BC3D /* URLRequestBuilder.swift */,
 				F60345CB27A93BD700212D04 /* URLCreator.swift */,
 				F64D2693283E8FAB0073A7BF /* NetworkTask.swift */,
@@ -568,6 +588,9 @@
 				EF000012000000000000000C /* MusicModelTests.swift */,
 				EF0000150000000000000022 /* SpotifyApiServiceTests.swift */,
 				EF0000160000000000000023 /* MusicViewModelSpotifyTests.swift */,
+				FD0000000000000000000009 /* MusicViewModelSongFavoriteTests.swift */,
+				FD0000000000000000000008 /* MusicViewModelQueueTests.swift */,
+				FD0000000000000000000007 /* MusicQueueModelTests.swift */,
 			);
 			path = IntelliNestTests;
 			sourceTree = "<group>";
@@ -598,6 +621,8 @@
 				D89BCA06BE3A45F2A8E3DAE4 /* LynkViewModelHelpers.swift */,
 				EF0000040000000000000004 /* MusicViewModel.swift */,
 				EF00000400000000000000F1 /* MusicViewModel+Playback.swift */,
+				FD0000000000000000000004 /* MusicViewModel+Queue.swift */,
+				FD0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -687,6 +712,8 @@
 				EF0000080000000000000008 /* SpeakerPickerView.swift */,
 				EF0000090000000000000009 /* SpeakerGroupingView.swift */,
 				EF000010000000000000000A /* MusicSearchResultsView.swift */,
+				FD0000000000000000000006 /* QueueView.swift */,
+				FD0000000000000000000005 /* MusicTrackControls.swift */,
 			);
 			path = Music;
 			sourceTree = "<group>";
@@ -1193,17 +1220,23 @@
 				F62CD2E328770D5500462092 /* LightsViewModel.swift in Sources */,
 				EE0000010000000000000001 /* MediaPlayerEntity.swift in Sources */,
 				EE0000020000000000000002 /* MusicSearchResult.swift in Sources */,
+				FE0000000000000000000001 /* MusicQueue.swift in Sources */,
 				EE0000030000000000000003 /* RestAPIService+Music.swift in Sources */,
 				EE0000130000000000000020 /* SpotifyAuthService.swift in Sources */,
 				EE0000140000000000000021 /* SpotifyApiService.swift in Sources */,
+				FE0000000000000000000002 /* MusicAssistantSocketService.swift in Sources */,
 				EE0000040000000000000004 /* MusicViewModel.swift in Sources */,
 				EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */,
+				FE0000000000000000000004 /* MusicViewModel+Queue.swift in Sources */,
+				FE0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift in Sources */,
 				EE0000050000000000000005 /* MusicView.swift in Sources */,
 				EE0000060000000000000006 /* NowPlayingView.swift in Sources */,
 				EE0000070000000000000007 /* AlbumArtView.swift in Sources */,
 				EE0000080000000000000008 /* SpeakerPickerView.swift in Sources */,
 				EE0000090000000000000009 /* SpeakerGroupingView.swift in Sources */,
 				EE000010000000000000000A /* MusicSearchResultsView.swift in Sources */,
+				FE0000000000000000000006 /* QueueView.swift in Sources */,
+				FE0000000000000000000005 /* MusicTrackControls.swift in Sources */,
 				CD215FD8D5AD91EE27DAAB00 /* FuelView.swift in Sources */,
 				3D1653ABAE6D49DB4CCAC158 /* PurifierView.swift in Sources */,
 				65450E96A215D8CB2443B2D6 /* INText.swift in Sources */,
@@ -1235,6 +1268,9 @@
 				EE000012000000000000000C /* MusicModelTests.swift in Sources */,
 				EE0000150000000000000022 /* SpotifyApiServiceTests.swift in Sources */,
 				EE0000160000000000000023 /* MusicViewModelSpotifyTests.swift in Sources */,
+				FE0000000000000000000009 /* MusicViewModelSongFavoriteTests.swift in Sources */,
+				FE0000000000000000000008 /* MusicViewModelQueueTests.swift in Sources */,
+				FE0000000000000000000007 /* MusicQueueModelTests.swift in Sources */,
 			BB0000003000000000000003 /* LightsViewModelTests.swift in Sources */,
 			BB0000007000000000000007 /* LockableTests.swift in Sources */,
 			AA0000001000000000000001 /* NordPoolEntityTests.swift in Sources */,

--- a/IntelliNest/Model/MusicQueue.swift
+++ b/IntelliNest/Model/MusicQueue.swift
@@ -1,0 +1,152 @@
+//
+//  MusicQueue.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-11.
+//
+
+import Foundation
+
+/// A single entry in a Music Assistant player queue. `queueItemID` is the stable
+/// id the queue-delete command targets (distinct from the track `uri`, since the
+/// same track can sit in the queue more than once).
+struct MusicQueueItem: Identifiable, Equatable {
+    let queueItemID: String
+    let uri: String?
+    let title: String
+    let artist: String?
+    let imageURL: String?
+
+    var id: String { queueItemID }
+}
+
+/// The state the Queue screen renders: the queue's id (needed for the delete
+/// command), the track playing now, and the upcoming tracks.
+struct MusicQueue: Equatable {
+    let queueID: String?
+    let currentItem: MusicQueueItem?
+    let upcomingItems: [MusicQueueItem]
+
+    static let empty = MusicQueue(queueID: nil, currentItem: nil, upcomingItems: [])
+}
+
+/// Decodes a Music Assistant `QueueItem`, as returned both by the Home Assistant
+/// `music_assistant.get_queue` service (for the current item) and the Music
+/// Assistant WebSocket `player_queues/items` command (for the upcoming list).
+/// The display fields come from the nested `media_item` when present, falling
+/// back to the queue item's own `name`.
+struct MusicQueueItemDTO: Decodable {
+    let queueItemID: String
+    let name: String?
+    let mediaItem: MediaItemDTO?
+    let image: ImageDTO?
+
+    private enum CodingKeys: String, CodingKey {
+        case queueItemID = "queue_item_id"
+        case name
+        case mediaItem = "media_item"
+        case image
+    }
+
+    struct MediaItemDTO: Decodable {
+        let uri: String?
+        let name: String?
+        let artists: [ArtistDTO]?
+        let image: ImageDTO?
+        let metadata: MetadataDTO?
+
+        struct MetadataDTO: Decodable {
+            let images: [ImageDTO]?
+        }
+    }
+
+    struct ArtistDTO: Decodable {
+        let name: String?
+    }
+
+    /// A Music Assistant image reference. Only a remotely-reachable `path` (an
+    /// absolute URL) is usable directly; local provider images would need the MA
+    /// image proxy, so those are dropped to nil rather than shown broken.
+    struct ImageDTO: Decodable {
+        let path: String?
+
+        var usableURL: String? {
+            guard let path, path.hasPrefix("http") else {
+                return nil
+            }
+            return path
+        }
+    }
+
+    /// Maps the decoded DTO to a `MusicQueueItem`, or nil when it has no stable
+    /// id to target for removal.
+    var queueItem: MusicQueueItem? {
+        guard queueItemID.isNotEmpty else {
+            return nil
+        }
+        let title = mediaItem?.name ?? name ?? "Okänd låt"
+        let imageURL = mediaItem?.image?.usableURL
+            ?? mediaItem?.metadata?.images?.compactMap(\.usableURL).first
+            ?? image?.usableURL
+        return MusicQueueItem(queueItemID: queueItemID,
+                              uri: mediaItem?.uri,
+                              title: title,
+                              artist: mediaItem?.artists?.first?.name,
+                              imageURL: imageURL)
+    }
+}
+
+/// The Music Assistant queue object as serialized by `get_queue` /
+/// `player_queues`. Only the fields the Queue screen needs are decoded.
+struct MusicQueueDTO: Decodable {
+    let queueID: String?
+    let currentItem: MusicQueueItemDTO?
+
+    private enum CodingKeys: String, CodingKey {
+        case queueID = "queue_id"
+        case currentItem = "current_item"
+    }
+}
+
+enum MusicGetQueueParser {
+    /// Parses the `music_assistant.get_queue` `return_response` body into the
+    /// queue id and current item. Home Assistant wraps service results under
+    /// `service_response`, and the queue then sits either directly under it or
+    /// keyed by the entity id (as `browse_media` does). Both shapes are handled,
+    /// and a body in any unexpected shape yields an empty queue rather than
+    /// throwing — the Queue screen falls back to session state when this is empty.
+    static func parse(_ data: Data) -> (queueID: String?, currentItem: MusicQueueItem?) {
+        let decoder = JSONDecoder()
+        for candidate in candidateObjects(in: data) {
+            guard let dto = try? decoder.decode(MusicQueueDTO.self, from: candidate), dto.queueID != nil else {
+                continue
+            }
+            return (dto.queueID, dto.currentItem?.queueItem)
+        }
+        return (nil, nil)
+    }
+
+    /// Returns every JSON object worth trying to decode as a queue: the body
+    /// itself, the contents of a `service_response` wrapper, and the first value
+    /// of an entity-keyed dictionary at either level.
+    private static func candidateObjects(in data: Data) -> [Data] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [data]
+        }
+        var objects: [[String: Any]] = [root]
+        if let serviceResponse = root["service_response"] as? [String: Any] {
+            objects.append(serviceResponse)
+        }
+        // Unwrap one level of entity-id keying (e.g. {"media_player.kitchen": {…}})
+        // for each level above. Collect into a separate list so the unwrapped
+        // entries are themselves considered (a doubly-keyed shape resolves too).
+        var unwrapped: [[String: Any]] = []
+        for object in objects where object["queue_id"] == nil {
+            if let nested = object.values.first as? [String: Any] {
+                unwrapped.append(nested)
+            }
+        }
+        objects.append(contentsOf: unwrapped)
+        return objects.compactMap { try? JSONSerialization.data(withJSONObject: $0) }
+    }
+}

--- a/IntelliNest/Navigation/Navigator.swift
+++ b/IntelliNest/Navigation/Navigator.swift
@@ -103,7 +103,8 @@ class Navigator: ObservableObject {
                                              setErrorBannerText: { [weak self] title, message in
                                                  self?.setErrorBannerText(title: title, message: message)
                                              },
-                                             spotify: spotifyApiService)
+                                             spotify: spotifyApiService,
+                                             queueSocket: MusicAssistantSocketService())
 
     init() {
         WidgetCenter.shared.reloadAllTimelines()

--- a/IntelliNest/Services/MusicAssistantSocketService.swift
+++ b/IntelliNest/Services/MusicAssistantSocketService.swift
@@ -1,0 +1,149 @@
+//
+//  MusicAssistantSocketService.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-11.
+//
+
+import Foundation
+
+/// The Music Assistant queue commands Home Assistant exposes no REST service for:
+/// reading the full ordered queue and removing an item. Hidden behind a protocol
+/// so `MusicViewModel` can be tested with a stub and so the queue degrades
+/// cleanly (empty list, failed delete) when the Music Assistant server can't be
+/// reached — e.g. when away from the home network.
+protocol MusicAssistantQueueSocket: Sendable {
+    /// The full ordered queue (current track included), or empty on any failure.
+    func queueItems(queueID: String) async -> [MusicQueueItem]
+    /// Removes the item from the queue. Returns whether the command succeeded.
+    func deleteItem(queueID: String, itemID: String) async -> Bool
+}
+
+/// Talks to the Music Assistant server's WebSocket API. Each call opens a short
+/// connection, sends one command, waits for the reply with the matching
+/// `message_id`, and closes — no long-lived socket, since the queue screen polls
+/// infrequently. The server pushes a `server_info` frame and event frames that
+/// carry no matching id; those are skipped while waiting for the reply.
+final class MusicAssistantSocketService: MusicAssistantQueueSocket {
+    private let urlString: String
+    private let session: URLSession
+    private let timeout: TimeInterval
+
+    init(urlString: String = GlobalConstants.musicAssistantWebSocketURLString,
+         session: URLSession = .shared,
+         timeout: TimeInterval = 5) {
+        self.urlString = urlString
+        self.session = session
+        self.timeout = timeout
+    }
+
+    func queueItems(queueID: String) async -> [MusicQueueItem] {
+        guard let result = await send(command: "player_queues/items",
+                                      args: ["queue_id": queueID, "limit": 500, "offset": 0]) else {
+            return []
+        }
+        guard let items = try? JSONDecoder().decode([MusicQueueItemDTO].self, from: result) else {
+            return []
+        }
+        return items.compactMap(\.queueItem)
+    }
+
+    func deleteItem(queueID: String, itemID: String) async -> Bool {
+        await send(command: "player_queues/delete_item",
+                   args: ["queue_id": queueID, "item_id_or_index": itemID]) != nil
+    }
+
+    // MARK: - WebSocket plumbing
+
+    /// Opens a socket, sends one command, and returns the `result` payload of the
+    /// reply with the matching `message_id`. Returns nil on any error, timeout, or
+    /// error reply, so callers degrade gracefully.
+    private func send(command: String, args: [String: Any]) async -> Data? {
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+        let task = session.webSocketTask(with: url)
+        task.resume()
+        defer { task.cancel(with: .normalClosure, reason: nil) }
+
+        let messageID = "1"
+        let payload: [String: Any] = ["command": command, "message_id": messageID, "args": args]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        do {
+            return try await withTimeout(timeout) {
+                try await task.send(.string(json))
+                return try await Self.awaitReply(on: task, messageID: messageID)
+            }
+        } catch {
+            Log.error("Music Assistant socket command \(command) failed: \(error)")
+            return nil
+        }
+    }
+
+    /// Reads frames until one carries the matching `message_id`, returning its
+    /// `result` payload (or nil for an error reply). Skips `server_info` and event
+    /// frames. Bounded so a chatty server can't loop forever.
+    private static func awaitReply(on task: URLSessionWebSocketTask, messageID: String) async throws -> Data? {
+        for _ in 0 ..< 50 {
+            let message = try await task.receive()
+            let frame: Data? = switch message {
+            case let .string(text): Data(text.utf8)
+            case let .data(data): data
+            @unknown default: nil
+            }
+            guard let frame,
+                  let object = try? JSONSerialization.jsonObject(with: frame) as? [String: Any],
+                  let replyID = replyMessageID(object), replyID == messageID else {
+                continue
+            }
+            guard object["error_code"] == nil, let result = object["result"] else {
+                return nil
+            }
+            return try? JSONSerialization.data(withJSONObject: result)
+        }
+        return nil
+    }
+
+    /// Reads the reply's `message_id` as a string regardless of whether the
+    /// server encodes it as a string or a number — Music Assistant conventionally
+    /// echoes an integer id, so matching only `String` would never match.
+    private static func replyMessageID(_ object: [String: Any]) -> String? {
+        if let stringID = object["message_id"] as? String {
+            return stringID
+        }
+        if let intID = object["message_id"] as? Int {
+            return String(intID)
+        }
+        return nil
+    }
+
+    /// Races `operation` against a deadline so a stalled socket can't hang the
+    /// queue screen. The losing child is cancelled.
+    private func withTimeout<T: Sendable>(_ seconds: TimeInterval,
+                                          _ operation: @escaping @Sendable () async throws -> T) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try await Task.sleep(seconds: seconds)
+                throw CancellationError()
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw CancellationError()
+            }
+            return result
+        }
+    }
+}
+
+/// Stand-in used in SwiftUI previews and tests that don't exercise the queue
+/// socket. Reports an empty queue and a failed delete, so the Queue screen falls
+/// back to its session state without any network access.
+struct DisabledMusicAssistantQueueSocket: MusicAssistantQueueSocket {
+    func queueItems(queueID _: String) async -> [MusicQueueItem] { [] }
+    func deleteItem(queueID _: String, itemID _: String) async -> Bool { false }
+}

--- a/IntelliNest/Services/RestAPIService+Music.swift
+++ b/IntelliNest/Services/RestAPIService+Music.swift
@@ -73,6 +73,20 @@ extension RestAPIService {
         return try decoder.decode(MusicPlaylistBrowseResponse.self, from: data).tracks
     }
 
+    /// Reads the active queue for `entityID` via `music_assistant.get_queue`
+    /// (`?return_response`). Returns the queue id (needed to target the WebSocket
+    /// delete command) and the current item ("Spelas nu"). The upcoming list is
+    /// fetched separately over the Music Assistant WebSocket, since `get_queue`
+    /// only carries the current/next item, not the full list.
+    func getQueue(on entityID: EntityId) async throws -> (queueID: String?, currentItem: MusicQueueItem?) {
+        let path = "/api/services/\(Domain.musicAssistant.rawValue)/\(Action.getQueue.rawValue)"
+        var json = [JSONKey: Any]()
+        json[.entityID] = entityID.rawValue
+
+        let data = try await postExpectingResponseData(path: path, json: json)
+        return MusicGetQueueParser.parse(data)
+    }
+
     /// POSTs a service call with `?return_response` and returns the response
     /// body, retrying against the external URL when the internal one fails.
     /// Used by the music services that read data back (search, browse).

--- a/IntelliNest/Services/SpotifyApiService.swift
+++ b/IntelliNest/Services/SpotifyApiService.swift
@@ -18,12 +18,25 @@ protocol SpotifyPlaylistService {
     func authorize() async throws
     /// The playlists in the signed-in account's library (owned + followed).
     func accountPlaylists() async -> [MusicSearchItem]
+    /// The Spotify ids of the playlists the user can edit (owned or collaborative).
+    /// Used to gate the add-to-playlist picker and the remove-from-playlist action.
+    func editablePlaylistIDs() async -> Set<String>
     /// Whether the playlist is currently in the user's Spotify library.
     func isPlaylistSaved(playlistID: String) async -> Bool
     /// Adds the playlist to the user's Spotify library. Returns success.
     func savePlaylist(playlistID: String) async -> Bool
     /// Removes the playlist from the user's Spotify library. Returns success.
     func removePlaylist(playlistID: String) async -> Bool
+    /// The subset of `trackIDs` that are in the user's Liked Songs.
+    func savedSongIDs(trackIDs: [String]) async -> Set<String>
+    /// Adds the track to the user's Liked Songs. Returns success.
+    func saveSong(trackID: String) async -> Bool
+    /// Removes the track from the user's Liked Songs. Returns success.
+    func removeSong(trackID: String) async -> Bool
+    /// Adds the track to the given playlist. Returns success.
+    func addTrack(playlistID: String, trackID: String) async -> Bool
+    /// Removes every occurrence of the track from the given playlist. Returns success.
+    func removeTrack(playlistID: String, trackID: String) async -> Bool
 }
 
 /// Talks to the Spotify Web API to save/unsave (follow/unfollow) playlists in the
@@ -94,6 +107,103 @@ final class SpotifyApiService: SpotifyPlaylistService {
         await followRequest(playlistID: playlistID, method: "DELETE", body: nil)
     }
 
+    func editablePlaylistIDs() async -> Set<String> {
+        do {
+            let userID = try await currentUserID()
+            let request = try await authorizedRequest(path: "/me/playlists",
+                                                      method: "GET",
+                                                      queryItems: [URLQueryItem(name: "limit", value: "50")])
+            let (data, response) = try await session.data(for: request)
+            guard isSuccess(response) else {
+                return []
+            }
+            let page = try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data)
+            return page.editableIDs(currentUserID: userID)
+        } catch {
+            Log.error("Spotify editablePlaylistIDs failed: \(error)")
+            return []
+        }
+    }
+
+    // MARK: - Liked Songs
+
+    func savedSongIDs(trackIDs: [String]) async -> Set<String> {
+        guard trackIDs.isNotEmpty else {
+            return []
+        }
+        do {
+            // `/me/tracks/contains` takes up to 50 ids and returns a bool array in
+            // the same order; zip it back to the saved subset.
+            let request = try await authorizedRequest(path: "/me/tracks/contains",
+                                                      method: "GET",
+                                                      queryItems: [URLQueryItem(name: "ids", value: trackIDs.joined(separator: ","))])
+            let (data, response) = try await session.data(for: request)
+            guard isSuccess(response) else {
+                return []
+            }
+            let flags = try JSONDecoder().decode([Bool].self, from: data)
+            let saved = zip(trackIDs, flags).compactMap { trackID, isSaved in isSaved ? trackID : nil }
+            return Set(saved)
+        } catch {
+            Log.error("Spotify savedSongIDs failed: \(error)")
+            return []
+        }
+    }
+
+    func saveSong(trackID: String) async -> Bool {
+        await libraryTracksRequest(method: "PUT", trackID: trackID)
+    }
+
+    func removeSong(trackID: String) async -> Bool {
+        await libraryTracksRequest(method: "DELETE", trackID: trackID)
+    }
+
+    private func libraryTracksRequest(method: String, trackID: String) async -> Bool {
+        do {
+            var request = try await authorizedRequest(path: "/me/tracks", method: method)
+            request.httpBody = try JSONSerialization.data(withJSONObject: ["ids": [trackID]])
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let (_, response) = try await session.data(for: request)
+            return isSuccess(response)
+        } catch {
+            Log.error("Spotify library tracks request (\(method)) failed: \(error)")
+            return false
+        }
+    }
+
+    // MARK: - Playlist tracks
+
+    func addTrack(playlistID: String, trackID: String) async -> Bool {
+        await playlistTracksRequest(method: "POST",
+                                    playlistID: playlistID,
+                                    body: ["uris": [Self.trackURI(trackID)]])
+    }
+
+    func removeTrack(playlistID: String, trackID: String) async -> Bool {
+        await playlistTracksRequest(method: "DELETE",
+                                    playlistID: playlistID,
+                                    body: ["tracks": [["uri": Self.trackURI(trackID)]]])
+    }
+
+    private func playlistTracksRequest(method: String, playlistID: String, body: [String: Any]) async -> Bool {
+        do {
+            var request = try await authorizedRequest(path: "/playlists/\(playlistID)/tracks", method: method)
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let (_, response) = try await session.data(for: request)
+            return isSuccess(response)
+        } catch {
+            Log.error("Spotify playlist tracks request (\(method)) failed: \(error)")
+            return false
+        }
+    }
+
+    /// Spotify's track endpoints want the `spotify:track:<id>` URI form, not the
+    /// `spotify://track/<id>` form Music Assistant uses.
+    private static func trackURI(_ trackID: String) -> String {
+        "spotify:track:\(trackID)"
+    }
+
     private func followRequest(playlistID: String, method: String, body: Data?) async -> Bool {
         do {
             var request = try await authorizedRequest(path: "/playlists/\(playlistID)/followers", method: method)
@@ -156,6 +266,12 @@ private struct SpotifyPlaylistPage: Decodable {
     var playlists: [MusicSearchItem] {
         items.compactMap(\.searchItem)
     }
+
+    /// The ids of playlists the signed-in user may edit: ones they own, plus any
+    /// collaborative playlist regardless of owner.
+    func editableIDs(currentUserID: String) -> Set<String> {
+        Set(items.compactMap { $0.editableID(currentUserID: currentUserID) })
+    }
 }
 
 private struct SpotifyPlaylistItem: Decodable {
@@ -163,6 +279,7 @@ private struct SpotifyPlaylistItem: Decodable {
     let name: String?
     let images: [SpotifyImage]?
     let owner: SpotifyOwner?
+    let collaborative: Bool?
 
     var searchItem: MusicSearchItem? {
         guard let id, let name, name.isNotEmpty else {
@@ -174,6 +291,14 @@ private struct SpotifyPlaylistItem: Decodable {
                                imageURL: images?.first?.url,
                                artist: owner?.displayName)
     }
+
+    func editableID(currentUserID: String) -> String? {
+        guard let id else {
+            return nil
+        }
+        let owned = owner?.id == currentUserID
+        return owned || collaborative == true ? id : nil
+    }
 }
 
 private struct SpotifyImage: Decodable {
@@ -181,9 +306,11 @@ private struct SpotifyImage: Decodable {
 }
 
 private struct SpotifyOwner: Decodable {
+    let id: String?
     let displayName: String?
 
     enum CodingKeys: String, CodingKey {
+        case id
         case displayName = "display_name"
     }
 }
@@ -196,7 +323,13 @@ struct DisabledSpotifyPlaylistService: SpotifyPlaylistService {
     var isAuthorized: Bool { false }
     func authorize() async throws {}
     func accountPlaylists() async -> [MusicSearchItem] { [] }
+    func editablePlaylistIDs() async -> Set<String> { [] }
     func isPlaylistSaved(playlistID _: String) async -> Bool { false }
     func savePlaylist(playlistID _: String) async -> Bool { false }
     func removePlaylist(playlistID _: String) async -> Bool { false }
+    func savedSongIDs(trackIDs _: [String]) async -> Set<String> { [] }
+    func saveSong(trackID _: String) async -> Bool { false }
+    func removeSong(trackID _: String) async -> Bool { false }
+    func addTrack(playlistID _: String, trackID _: String) async -> Bool { false }
+    func removeTrack(playlistID _: String, trackID _: String) async -> Bool { false }
 }

--- a/IntelliNest/Services/SpotifyAuthService.swift
+++ b/IntelliNest/Services/SpotifyAuthService.swift
@@ -42,9 +42,12 @@ final class SpotifyAuthService: NSObject, SpotifyTokenProviding {
     /// Must exactly match a Redirect URI registered in the Spotify app dashboard.
     private let redirectURI = "intellinest://spotify-callback"
     private let callbackScheme = "intellinest"
-    /// `playlist-read-private` to read follow state, the two `modify` scopes to
-    /// add/remove a playlist from the user's library.
-    private let scopes = "playlist-read-private playlist-modify-public playlist-modify-private"
+    /// `playlist-read-private` to read follow state, the two playlist `modify`
+    /// scopes to add/remove a playlist from the user's library and to edit a
+    /// playlist's tracks, and the two `user-library` scopes to read and toggle
+    /// Liked Songs.
+    private let scopes = "playlist-read-private playlist-modify-public playlist-modify-private "
+        + "user-library-read user-library-modify"
     private let authorizeEndpoint = "https://accounts.spotify.com/authorize"
     private let tokenEndpoint = "https://accounts.spotify.com/api/token"
 

--- a/IntelliNest/Utils/Constants/Actions.swift
+++ b/IntelliNest/Utils/Constants/Actions.swift
@@ -55,4 +55,5 @@ enum Action: String, Codable {
     case unjoin
     case browseMedia = "browse_media"
     case getLibrary = "get_library"
+    case getQueue = "get_queue"
 }

--- a/IntelliNest/Utils/Constants/GlobalConstants.swift
+++ b/IntelliNest/Utils/Constants/GlobalConstants.swift
@@ -61,6 +61,21 @@ enum GlobalConstants {
     }
 
     static let musicAssistantConfigEntryID = "01JZ57QTQPB79NSC7GJ2VQPA8V"
+
+    /// Music Assistant server WebSocket URL, used only for the queue commands
+    /// Home Assistant exposes no REST service for: reading the full upcoming list
+    /// and removing a queue item. Defaults to the internal host on Music
+    /// Assistant's default port; override with the `MUSIC_ASSISTANT_WS_URL`
+    /// xcconfig key if the server runs elsewhere. Queue editing therefore works
+    /// on the home network only (the MA server is not exposed externally).
+    static var musicAssistantWebSocketURLString: String {
+        if let override = Bundle.main.object(forInfoDictionaryKey: "MUSIC_ASSISTANT_WS_URL") as? String,
+           override.isNotEmpty {
+            return override
+        }
+        return "ws://192.168.1.205:8095/ws"
+    }
+
     static let baseInternalUrlString = "http://192.168.1.205:8123/"
     static let githubFakeUrlString = "https://192.218.223.123/"
     static var shouldUseLocalSSID: Bool {

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -58,6 +58,7 @@ extension MusicViewModel {
         }
         favoritePlaylists = playlists
         hasLoadedSpotifyPlaylists = true
+        editablePlaylistSpotifyIDs = await spotify.editablePlaylistIDs()
     }
 
     /// Re-fetches the recently-played list after a playlist launch so the new
@@ -90,6 +91,9 @@ extension MusicViewModel {
 
     func play(item: MusicSearchItem) async {
         if await startPlayback(uri: item.uri, mediaType: item.mediaType, title: item.name, artist: item.artist) {
+            // A single search result isn't played from a playlist, so the
+            // now-playing card has no playlist to jump to.
+            nowPlayingSourcePlaylist = nil
             closeSearchResults()
         }
     }
@@ -133,7 +137,7 @@ extension MusicViewModel {
 
     /// Loads a playlist's tracks into `playlistTracks`, toggling the loading
     /// flag. Shared by the search-sheet drill-in and the main-view browse sheet.
-    private func loadPlaylistTracks(_ playlist: MusicSearchItem) async {
+    func loadPlaylistTracks(_ playlist: MusicSearchItem) async {
         playlistTracks = []
         isLoadingPlaylist = true
         let browseSpeaker = activeSpeakerID ?? availableSpeakers.first?.entityId
@@ -151,6 +155,7 @@ extension MusicViewModel {
     /// Plays the whole playlist from the start on the active speaker.
     func playPlaylist(_ playlist: MusicSearchItem) async {
         if await startPlayback(uri: playlist.uri, mediaType: .playlist, title: playlist.name, artist: nil) {
+            nowPlayingSourcePlaylist = playlist
             closeSearchResults()
             await refreshRecentlyPlayed()
         }
@@ -163,6 +168,7 @@ extension MusicViewModel {
         guard await startPlayback(uri: playlist.uri, mediaType: .playlist, title: playlist.name, artist: nil) else {
             return
         }
+        nowPlayingSourcePlaylist = playlist
         if let activeSpeaker, let targetID = playbackTargetID {
             speakers[activeSpeaker.entityId]?.shuffle = true
             restAPIService.setShuffle(entityID: targetID, shuffle: true)
@@ -177,11 +183,21 @@ extension MusicViewModel {
         guard await startPlayback(uri: track.uri, mediaType: .track, title: track.title, artist: nil) else {
             return
         }
+        nowPlayingSourcePlaylist = playlist
         if let targetID = playbackTargetID {
             await restAPIService.playMedia(on: targetID, mediaID: playlist.uri, mediaType: .playlist, enqueue: "add")
         }
         closeSearchResults()
         await refreshRecentlyPlayed()
+    }
+
+    /// Opens the playlist the current track is playing from, reusing the main
+    /// view's browse sheet. No-op when the source playlist is unknown.
+    func openNowPlayingPlaylist() async {
+        guard let playlist = nowPlayingSourcePlaylist else {
+            return
+        }
+        await browseLibraryPlaylist(playlist)
     }
 
     /// Dismisses any playlist presentation: the search-results sheet, its
@@ -229,7 +245,7 @@ extension MusicViewModel {
     /// against the logged-in account's playlists (Spotify is the source of truth,
     /// and an MA Spotify-library playlist is by definition one of those). Returns
     /// nil for non-Spotify playlists (MA built-ins, or anything not in the account).
-    private func spotifyPlaylistID(for playlist: MusicSearchItem) -> String? {
+    func spotifyPlaylistID(for playlist: MusicSearchItem) -> String? {
         if let id = directSpotifyPlaylistID(from: playlist.uri) {
             return id
         }
@@ -294,7 +310,7 @@ extension MusicViewModel {
         }
     }
 
-    private func setSaved(_ saved: Bool, for playlist: MusicSearchItem) {
+    func setSaved(_ saved: Bool, for playlist: MusicSearchItem) {
         if saved {
             savedPlaylistURIs.insert(playlist.uri)
         } else {

--- a/IntelliNest/ViewModels/MusicViewModel+Queue.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Queue.swift
@@ -1,0 +1,156 @@
+//
+//  MusicViewModel+Queue.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-11.
+//
+
+import Foundation
+
+/// The play queue for the active speaker's group leader. Reads run over two
+/// transports: `music_assistant.get_queue` (REST) for the queue id and the
+/// current track, and the Music Assistant WebSocket for the full upcoming list
+/// and per-item removal — the two commands Home Assistant exposes no REST
+/// service for. When the socket can't be reached the screen degrades to the
+/// current track plus whatever the app enqueued this session.
+extension MusicViewModel {
+    /// The speaker whose queue is shown and acted on: the active speaker's group
+    /// leader (a synced follower's queue mirrors the leader's).
+    var queueTargetID: EntityId? {
+        activeSpeaker?.playbackTargetID ?? activeSpeakerID
+    }
+
+    /// Opens the Queue sheet and loads its contents.
+    func openQueue() async {
+        isShowingQueue = true
+        await loadQueue()
+    }
+
+    /// Refreshes the queue from the reload loop, but only while the sheet is open,
+    /// so "Spelas nu" and "Näst på tur" stay current without extra work otherwise.
+    func refreshQueueIfShowing() async {
+        guard isShowingQueue else {
+            return
+        }
+        await loadQueue()
+    }
+
+    /// Loads the current track and upcoming tracks for the active speaker's queue.
+    func loadQueue() async {
+        guard let targetID = queueTargetID else {
+            queue = .empty
+            return
+        }
+        isLoadingQueue = true
+        defer { isLoadingQueue = false }
+
+        let queueID: String?
+        let restCurrent: MusicQueueItem?
+        do {
+            (queueID, restCurrent) = try await restAPIService.getQueue(on: targetID)
+        } catch {
+            Log.error("Failed to read queue: \(error)")
+            (queueID, restCurrent) = (nil, nil)
+        }
+
+        let currentItem = restCurrent ?? currentItemFromSpeaker()
+        let upcoming = await upcomingItems(queueID: queueID, currentItem: currentItem)
+        queue = MusicQueue(queueID: queueID, currentItem: currentItem, upcomingItems: upcoming)
+    }
+
+    /// The upcoming tracks: the socket's full ordered list sliced to whatever
+    /// follows the current item, or the session-enqueued fallback when the socket
+    /// returns nothing (server unreachable, e.g. away from home).
+    private func upcomingItems(queueID: String?, currentItem: MusicQueueItem?) async -> [MusicQueueItem] {
+        guard let queueID else {
+            return sessionEnqueuedItems
+        }
+        let items = await queueSocket.queueItems(queueID: queueID)
+        guard items.isNotEmpty else {
+            return sessionEnqueuedItems
+        }
+        guard let currentItem,
+              let currentIndex = items.firstIndex(where: { $0.queueItemID == currentItem.queueItemID }) else {
+            // Current track not located in the list — show the whole list rather
+            // than nothing, minus any entry that is the current track by uri.
+            return items.filter { $0.uri == nil || $0.uri != currentItem?.uri }
+        }
+        return Array(items[(currentIndex + 1)...])
+    }
+
+    /// Builds a "Spelas nu" item from the speaker's now-playing metadata, used
+    /// when `get_queue` returns no current item.
+    private func currentItemFromSpeaker() -> MusicQueueItem? {
+        guard let speaker = activeSpeaker, let title = speaker.mediaTitle else {
+            return nil
+        }
+        return MusicQueueItem(queueItemID: speaker.mediaContentID ?? "current",
+                              uri: speaker.mediaContentID,
+                              title: title,
+                              artist: speaker.mediaArtist,
+                              imageURL: speaker.entityPicture)
+    }
+
+    // MARK: - Add
+
+    func addToQueue(_ track: MusicPlaylistTrack) async {
+        await addToQueue(uri: track.uri, title: track.title, artist: nil, imageURL: track.imageURL)
+    }
+
+    func addToQueue(_ item: MusicSearchItem) async {
+        await addToQueue(uri: item.uri, title: item.name, artist: item.artist, imageURL: item.imageURL)
+    }
+
+    /// Appends a track to the active speaker's queue. Optimistically adds it to
+    /// "Näst på tur" and the session fallback; banners on failure.
+    func addToQueue(uri: String, title: String, artist: String?, imageURL: String?) async {
+        guard let targetID = queueTargetID else {
+            setErrorBannerText("Ingen högtalare vald", "Välj en högtalare innan du lägger till i kön")
+            return
+        }
+        let success = await restAPIService.playMedia(on: targetID, mediaID: uri, mediaType: .track, enqueue: "add")
+        guard success else {
+            setErrorBannerText("Kunde inte lägga till i kön", "Det gick inte att lägga till låten i kön")
+            return
+        }
+        // A session-local id: these fallback rows have no server queue-item id,
+        // so they are removed locally only. A queue reload replaces them with the
+        // real items once the socket can read the live queue.
+        let sessionItem = MusicQueueItem(queueItemID: "session-\(uri)-\(sessionEnqueuedItems.count)",
+                                         uri: uri,
+                                         title: title,
+                                         artist: artist,
+                                         imageURL: imageURL)
+        sessionEnqueuedItems.append(sessionItem)
+        queue = MusicQueue(queueID: queue.queueID,
+                           currentItem: queue.currentItem,
+                           upcomingItems: queue.upcomingItems + [sessionItem])
+    }
+
+    // MARK: - Remove
+
+    /// Removes an upcoming track from the queue. Optimistically drops it, then
+    /// deletes it over the socket when it is a real (server-backed) queue item;
+    /// session-fallback rows have no server id and are removed locally only.
+    /// Reverts and banners if the socket delete fails.
+    func removeFromQueue(_ item: MusicQueueItem) async {
+        let previousUpcoming = queue.upcomingItems
+        let previousSession = sessionEnqueuedItems
+        let isSessionOnly = previousSession.contains { $0.id == item.id }
+
+        queue = MusicQueue(queueID: queue.queueID,
+                           currentItem: queue.currentItem,
+                           upcomingItems: previousUpcoming.filter { $0.id != item.id })
+        sessionEnqueuedItems.removeAll { $0.id == item.id }
+
+        guard let queueID = queue.queueID, !isSessionOnly else {
+            return
+        }
+        let success = await queueSocket.deleteItem(queueID: queueID, itemID: item.queueItemID)
+        if !success {
+            queue = MusicQueue(queueID: queue.queueID, currentItem: queue.currentItem, upcomingItems: previousUpcoming)
+            sessionEnqueuedItems = previousSession
+            setErrorBannerText("Kunde inte ta bort från kön", "Det gick inte att ta bort låten från kön")
+        }
+    }
+}

--- a/IntelliNest/ViewModels/MusicViewModel+SpotifyTracks.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+SpotifyTracks.swift
@@ -1,0 +1,204 @@
+//
+//  MusicViewModel+SpotifyTracks.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-11.
+//
+
+import Foundation
+
+/// Song-level Spotify actions: liking/unliking tracks and adding/removing them
+/// from the account's editable playlists. Spotify is the source of truth for all
+/// of these; Music Assistant only plays the result. A track is actionable only
+/// when it resolves to a `spotify://track/<id>` uri — Music Assistant items from
+/// other providers expose no Spotify id, so their controls are hidden.
+extension MusicViewModel {
+    // MARK: - Liked Songs
+
+    /// Whether to show the song-favourite star for `uri`: logged in and the track
+    /// resolves to a Spotify id (so tapping it can actually like the song).
+    func canFavoriteSong(uri: String?) -> Bool {
+        guard let uri else {
+            return false
+        }
+        return isSpotifyAuthorized && spotifyTrackID(from: uri) != nil
+    }
+
+    /// Whether the track is currently in the user's Liked Songs (drives the star).
+    func isSongSaved(uri: String) -> Bool {
+        savedSongURIs.contains(uri)
+    }
+
+    /// Loads the live Liked-Songs state for the resolvable tracks among `uris`, so
+    /// each star reflects reality when its view appears. Silent for non-Spotify
+    /// tracks or while logged out.
+    func loadSavedSongStates(uris: [String]) async {
+        guard spotify.isAuthorized else {
+            return
+        }
+        let resolvable = uris.filter { spotifyTrackID(from: $0) != nil }
+        let trackIDs = resolvable.compactMap { spotifyTrackID(from: $0) }
+        guard trackIDs.isNotEmpty else {
+            return
+        }
+        let savedIDs = await spotify.savedSongIDs(trackIDs: trackIDs)
+        for uri in resolvable {
+            guard let trackID = spotifyTrackID(from: uri) else {
+                continue
+            }
+            setSongSaved(savedIDs.contains(trackID), uri: uri)
+        }
+    }
+
+    /// Toggles whether the track is in the user's Liked Songs. Logs in first when
+    /// needed, flips the star optimistically, then reverts and banners on failure.
+    func toggleSongSaved(uri: String) async {
+        guard let trackID = spotifyTrackID(from: uri) else {
+            return
+        }
+        guard await ensureSpotifyAuthorized() else {
+            return
+        }
+        let wasSaved = isSongSaved(uri: uri)
+        setSongSaved(!wasSaved, uri: uri)
+        let success = wasSaved
+            ? await spotify.removeSong(trackID: trackID)
+            : await spotify.saveSong(trackID: trackID)
+        if !success {
+            setSongSaved(wasSaved, uri: uri)
+            setErrorBannerText("Kunde inte uppdatera favorit", "Det gick inte att ändra favoritmarkeringen på Spotify")
+        }
+    }
+
+    private func setSongSaved(_ saved: Bool, uri: String) {
+        if saved {
+            savedSongURIs.insert(uri)
+        } else {
+            savedSongURIs.remove(uri)
+        }
+    }
+
+    // MARK: - Library row saved-state
+
+    /// Changes whenever the library lists change, so the view can reload the
+    /// row stars' saved-state without polling.
+    var librarySavedStateSignature: String {
+        (recentlyPlayedPlaylists.map(\.uri) + favoritePlaylists.map(\.uri)).joined(separator: "|")
+    }
+
+    /// Populates the saved-state for the library rows. Favourites are in the
+    /// Spotify library by definition, so they are marked saved without a call;
+    /// recently-played playlists are queried so their star reflects reality.
+    func loadLibrarySavedStates() async {
+        for playlist in favoritePlaylists {
+            setSaved(true, for: playlist)
+        }
+        for playlist in recentlyPlayedPlaylists {
+            await loadSavedState(for: playlist)
+        }
+    }
+
+    // MARK: - Playlist membership
+
+    /// The account playlists the user may add tracks to (owned or collaborative).
+    var editableAccountPlaylists: [MusicSearchItem] {
+        favoritePlaylists.filter { playlist in
+            guard let id = spotifyPlaylistID(for: playlist) else {
+                return false
+            }
+            return editablePlaylistSpotifyIDs.contains(id)
+        }
+    }
+
+    /// Whether the "Lägg till i spellista" action should be offered for `uri`:
+    /// logged in, the track resolves to a Spotify id, and there is at least one
+    /// editable playlist to add it to.
+    func canAddTrackToPlaylist(uri: String?) -> Bool {
+        guard let uri else {
+            return false
+        }
+        return isSpotifyAuthorized && spotifyTrackID(from: uri) != nil && editableAccountPlaylists.isNotEmpty
+    }
+
+    /// Whether the "Ta bort från spellistan" action should be offered: the
+    /// playlist is one the user can edit on Spotify.
+    func canEditPlaylist(_ playlist: MusicSearchItem) -> Bool {
+        guard isSpotifyAuthorized, let id = spotifyPlaylistID(for: playlist) else {
+            return false
+        }
+        return editablePlaylistSpotifyIDs.contains(id)
+    }
+
+    /// Adds the track to the chosen playlist via Spotify. Banners on failure and
+    /// leaves the playlist unchanged. When the target is the playlist currently
+    /// open, its track list is refreshed so the addition shows.
+    func addTrack(uri: String, toPlaylist playlist: MusicSearchItem) async {
+        guard let trackID = spotifyTrackID(from: uri), let playlistID = spotifyPlaylistID(for: playlist) else {
+            return
+        }
+        guard await ensureSpotifyAuthorized() else {
+            return
+        }
+        let success = await spotify.addTrack(playlistID: playlistID, trackID: trackID)
+        guard success else {
+            setErrorBannerText("Kunde inte lägga till i spellistan", "Det gick inte att lägga till låten på Spotify")
+            return
+        }
+        if let openPlaylist = currentlyOpenPlaylist, spotifyPlaylistID(for: openPlaylist) == playlistID {
+            await loadPlaylistTracks(openPlaylist)
+        }
+    }
+
+    /// Removes the track from the playlist via Spotify. Optimistically drops it
+    /// from the visible track list, reverting and bannering on failure.
+    func removeTrack(_ track: MusicPlaylistTrack, fromPlaylist playlist: MusicSearchItem) async {
+        guard let trackID = spotifyTrackID(from: track.uri), let playlistID = spotifyPlaylistID(for: playlist) else {
+            return
+        }
+        guard await ensureSpotifyAuthorized() else {
+            return
+        }
+        let previousTracks = playlistTracks
+        playlistTracks.removeAll { $0.uri == track.uri }
+        let success = await spotify.removeTrack(playlistID: playlistID, trackID: trackID)
+        if !success {
+            playlistTracks = previousTracks
+            setErrorBannerText("Kunde inte ta bort låten", "Det gick inte att ta bort låten från spellistan")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Logs in to Spotify when needed so a control tapped while logged out still
+    /// completes after login. Returns whether the session is authorized. Banners
+    /// and returns false when login fails or is cancelled.
+    func ensureSpotifyAuthorized() async -> Bool {
+        if spotify.isAuthorized {
+            return true
+        }
+        do {
+            try await spotify.authorize()
+            isSpotifyAuthorized = true
+            return true
+        } catch {
+            Log.error("Spotify authorization failed: \(error)")
+            setErrorBannerText("Spotify-inloggning misslyckades", "Kunde inte logga in på Spotify")
+            return false
+        }
+    }
+
+    /// The playlist whose detail is currently on screen (the search drill-in or
+    /// the main-view browse sheet), used to refresh after an add.
+    private var currentlyOpenPlaylist: MusicSearchItem? {
+        browsingLibraryPlaylist ?? openedPlaylist
+    }
+
+    func spotifyTrackID(from uri: String) -> String? {
+        let prefix = "spotify://track/"
+        guard uri.hasPrefix(prefix) else {
+            return nil
+        }
+        let trackID = String(uri.dropFirst(prefix.count))
+        return trackID.isNotEmpty ? trackID : nil
+    }
+}

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -48,6 +48,26 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// Whether the user is logged into Spotify. Drives the login warning triangle
     /// and its prompt — shown only while logged out.
     @Published var isSpotifyAuthorized = false
+    /// The playlist the current track is playing from, when playback was started
+    /// from a playlist within the app this session. Drives the now-playing card's
+    /// jump-to-playlist tap. Nil when the source is unknown (started elsewhere, a
+    /// single track played, or after relaunch), which hides the affordance.
+    @Published var nowPlayingSourcePlaylist: MusicSearchItem?
+    /// URIs of tracks currently in the user's Spotify Liked Songs, driving the
+    /// song favourite star wherever a track is shown. Loaded on demand per view.
+    @Published var savedSongURIs: Set<String> = []
+    /// Spotify ids of the account playlists the user can edit (owned or
+    /// collaborative). Gates the add-to-playlist picker and the remove action.
+    @Published var editablePlaylistSpotifyIDs: Set<String> = []
+    /// The queue shown on the Queue screen: the current track and the upcoming
+    /// tracks for the active speaker's group leader.
+    @Published var queue: MusicQueue = .empty
+    @Published var isLoadingQueue = false
+    /// Drives the Queue sheet presented from the now-playing area.
+    @Published var isShowingQueue = false
+    /// Tracks the app enqueued this session, newest last. Used as the "Näst på
+    /// tur" fallback when the live queue contents can't be read over the socket.
+    @Published var sessionEnqueuedItems: [MusicQueueItem] = []
 
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false
@@ -68,6 +88,10 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// Spotify library. Defaults to a disabled no-op so previews and non-Spotify
     /// tests need no setup.
     let spotify: SpotifyPlaylistService
+    /// Reads and edits the Music Assistant queue over its WebSocket (the commands
+    /// Home Assistant exposes no REST service for). Defaults to a disabled no-op
+    /// so previews and tests need no socket.
+    let queueSocket: MusicAssistantQueueSocket
 
     /// Speakers that are reachable right now (anything not `unavailable`),
     /// in the fixed display order.
@@ -84,10 +108,12 @@ class MusicViewModel: ObservableObject, Reloadable {
 
     init(restAPIService: RestAPIService,
          setErrorBannerText: @escaping StringStringClosure = { _, _ in },
-         spotify: SpotifyPlaylistService = DisabledSpotifyPlaylistService()) {
+         spotify: SpotifyPlaylistService = DisabledSpotifyPlaylistService(),
+         queueSocket: MusicAssistantQueueSocket = DisabledMusicAssistantQueueSocket()) {
         self.restAPIService = restAPIService
         self.setErrorBannerText = setErrorBannerText
         self.spotify = spotify
+        self.queueSocket = queueSocket
         isSpotifyAuthorized = spotify.isAuthorized
         var initialSpeakers: [EntityId: MediaPlayerEntity] = [:]
         for speakerID in Self.speakerIDs {
@@ -123,6 +149,7 @@ class MusicViewModel: ObservableObject, Reloadable {
             self.dropActiveSpeakerIfUnavailable()
         }
         await loadLibraryPlaylistsIfNeeded()
+        await refreshQueueIfShowing()
     }
 
     /// On the first reload after the view appears, default the active speaker to

--- a/IntelliNest/Views/Music/MusicSearchResultsView.swift
+++ b/IntelliNest/Views/Music/MusicSearchResultsView.swift
@@ -75,11 +75,11 @@ struct MusicSearchResultsView: View {
                     ForEach(section.items) { item in
                         if item.mediaType == .playlist {
                             // A playlist opens its track list instead of playing.
-                            MusicResultRow(item: item, trailingSystemImage: "chevron.right") {
+                            MusicResultRow(viewModel: viewModel, item: item, trailingSystemImage: "chevron.right") {
                                 Task { await viewModel.openPlaylist(item) }
                             }
                         } else {
-                            MusicResultRow(item: item) {
+                            MusicResultRow(viewModel: viewModel, item: item) {
                                 Task { await viewModel.play(item: item) }
                             }
                         }
@@ -204,36 +204,85 @@ struct MusicPlaylistView: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 8) {
                     ForEach(viewModel.playlistTracks) { track in
-                        Button {
-                            Task { await viewModel.playTrackInPlaylist(track, from: playlist) }
-                        } label: {
-                            HStack(spacing: 12) {
-                                AlbumArtView(urlString: track.imageURL, size: 44)
-                                Text(track.title)
-                                    .font(.body)
-                                    .lineLimit(1)
-                                Spacer()
-                                Image(systemName: "play.fill")
-                                    .foregroundStyle(.white.opacity(0.6))
-                            }
-                            .padding(.vertical, 4)
-                        }
-                        .foregroundStyle(.white)
-                        .accessibilityLabel("Spela \(track.title)")
+                        trackRow(track)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
+            // Reflect each track's Liked-Songs state when the list loads.
+            .task(id: viewModel.playlistTracks.map(\.uri).joined(separator: "|")) {
+                await viewModel.loadSavedSongStates(uris: viewModel.playlistTracks.map(\.uri))
+            }
+        }
+    }
+
+    /// A playlist track row: tapping plays it (then the rest of the playlist),
+    /// the trailing heart toggles Liked Songs, and a long-press exposes add to
+    /// queue / add to playlist / remove from this playlist.
+    private func trackRow(_ track: MusicPlaylistTrack) -> some View {
+        // Only an editable playlist offers "remove from this playlist".
+        var removeAction: MainActorVoidClosure?
+        if viewModel.canEditPlaylist(playlist) {
+            removeAction = { Task { await viewModel.removeTrack(track, fromPlaylist: playlist) } }
+        }
+        return HStack(spacing: 12) {
+            Button {
+                Task { await viewModel.playTrackInPlaylist(track, from: playlist) }
+            } label: {
+                HStack(spacing: 12) {
+                    AlbumArtView(urlString: track.imageURL, size: 44)
+                    Text(track.title)
+                        .font(.body)
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Spela \(track.title)")
+
+            if viewModel.canFavoriteSong(uri: track.uri) {
+                SongFavoriteButton(viewModel: viewModel, uri: track.uri)
+            } else {
+                Image(systemName: "play.fill")
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+        }
+        .padding(.vertical, 4)
+        .foregroundStyle(.white)
+        .contextMenu {
+            TrackActionButtons(viewModel: viewModel,
+                               uri: track.uri,
+                               title: track.title,
+                               imageURL: track.imageURL,
+                               onRemoveFromPlaylist: removeAction)
         }
     }
 }
 
 private struct MusicResultRow: View {
+    @ObservedObject var viewModel: MusicViewModel
     let item: MusicSearchItem
     var trailingSystemImage = "play.fill"
     let onTap: MainActorVoidClosure
 
     var body: some View {
+        // A track also offers add-to-queue / add-to-playlist via long-press; the
+        // other result types (album, artist, playlist) have no track actions.
+        if item.mediaType == .track {
+            rowButton.contextMenu {
+                TrackActionButtons(viewModel: viewModel,
+                                   uri: item.uri,
+                                   title: item.name,
+                                   artist: item.artist,
+                                   imageURL: item.imageURL)
+            }
+        } else {
+            rowButton
+        }
+    }
+
+    private var rowButton: some View {
         Button(action: onTap) {
             HStack(spacing: 12) {
                 AlbumArtView(urlString: item.imageURL, size: 44)

--- a/IntelliNest/Views/Music/MusicTrackControls.swift
+++ b/IntelliNest/Views/Music/MusicTrackControls.swift
@@ -1,0 +1,70 @@
+//
+//  MusicTrackControls.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-11.
+//
+
+import SwiftUI
+
+/// The Liked-Songs heart shown on a track row or now-playing. Filled green when
+/// the track is in the user's Spotify Liked Songs, outlined otherwise. Callers
+/// render it only for Spotify-resolvable tracks (`canFavoriteSong`).
+struct SongFavoriteButton: View {
+    @ObservedObject var viewModel: MusicViewModel
+    let uri: String
+
+    var body: some View {
+        let saved = viewModel.isSongSaved(uri: uri)
+        Button {
+            Task { await viewModel.toggleSongSaved(uri: uri) }
+        } label: {
+            Image(systemName: saved ? "heart.fill" : "heart")
+                .foregroundStyle(saved ? .green : .white.opacity(0.6))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(saved ? "Ta bort från gillade låtar" : "Spara i gillade låtar")
+    }
+}
+
+/// The track context-menu actions: add to the play queue, add to one of the
+/// user's editable playlists, and (in an editable playlist) remove from it. Each
+/// action is shown only when it can function. Designed to live inside a
+/// `.contextMenu { … }`.
+struct TrackActionButtons: View {
+    @ObservedObject var viewModel: MusicViewModel
+    let uri: String
+    let title: String
+    var artist: String?
+    var imageURL: String?
+    /// Set by an editable playlist's detail to offer "remove from this playlist".
+    var onRemoveFromPlaylist: MainActorVoidClosure?
+
+    var body: some View {
+        Button {
+            Task { await viewModel.addToQueue(uri: uri, title: title, artist: artist, imageURL: imageURL) }
+        } label: {
+            Label("Lägg till i kö", systemImage: "text.line.last.and.arrowtriangle.forward")
+        }
+
+        if viewModel.canAddTrackToPlaylist(uri: uri) {
+            Menu {
+                ForEach(viewModel.editableAccountPlaylists) { playlist in
+                    Button(playlist.name) {
+                        Task { await viewModel.addTrack(uri: uri, toPlaylist: playlist) }
+                    }
+                }
+            } label: {
+                Label("Lägg till i spellista", systemImage: "plus")
+            }
+        }
+
+        if let onRemoveFromPlaylist {
+            Button(role: .destructive) {
+                onRemoveFromPlaylist()
+            } label: {
+                Label("Ta bort från spellistan", systemImage: "minus.circle")
+            }
+        }
+    }
+}

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -44,8 +44,15 @@ struct MusicView: View {
         // Spotify is the source of truth — refresh the account's playlists each
         // time the view appears rather than trusting the once-per-session cache.
         .task { await viewModel.refreshSpotifyPlaylists() }
+        // Keep the library-row stars in sync as the favourite/recents lists load.
+        .task(id: viewModel.librarySavedStateSignature) {
+            await viewModel.loadLibrarySavedStates()
+        }
         .sheet(isPresented: $viewModel.isShowingSearchResults) {
             MusicSearchResultsView(viewModel: viewModel)
+        }
+        .sheet(isPresented: $viewModel.isShowingQueue) {
+            QueueView(viewModel: viewModel)
         }
         .sheet(item: $viewModel.browsingLibraryPlaylist) { playlist in
             NavigationStack {
@@ -170,6 +177,7 @@ struct LibraryPlaylistsSection: View {
                     .font(.headline)
                 ForEach(playlists) { playlist in
                     LibraryPlaylistRow(
+                        viewModel: viewModel,
                         playlist: playlist,
                         onOpen: { Task { await viewModel.browseLibraryPlaylist(playlist) } }
                     )
@@ -183,30 +191,54 @@ struct LibraryPlaylistsSection: View {
     }
 }
 
-/// A single playlist row. The whole row navigates into the playlist detail
-/// (Spotify-style), where playback lives — so the trailing chevron honestly
-/// signals "tapping the row opens it". The detail's play button starts it.
+/// A single playlist row. Tapping the row opens the playlist detail
+/// (Spotify-style), where playback lives. Spotify-resolvable playlists also show
+/// a favourite star — filled for ones already in the library (the "Favoriter"
+/// rows are always filled; tapping un-favorites), empty and tappable-to-save for
+/// a recently-played playlist that isn't saved yet. Non-Spotify rows keep the
+/// plain chevron.
 private struct LibraryPlaylistRow: View {
+    @ObservedObject var viewModel: MusicViewModel
     let playlist: MusicSearchItem
     let onOpen: MainActorVoidClosure
 
     var body: some View {
-        Button(action: onOpen) {
-            HStack(spacing: 12) {
-                AlbumArtView(urlString: playlist.imageURL, size: 48)
-                Text(playlist.name)
-                    .font(.body)
-                    .lineLimit(1)
-                Spacer(minLength: 8)
+        HStack(spacing: 12) {
+            Button(action: onOpen) {
+                HStack(spacing: 12) {
+                    AlbumArtView(urlString: playlist.imageURL, size: 48)
+                    Text(playlist.name)
+                        .font(.body)
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(playlist.name)
+            .accessibilityHint("Öppna spellistan")
+
+            if viewModel.isSpotifyPlaylist(playlist) {
+                favoriteStar
+            } else {
                 Image(systemName: "chevron.right")
                     .font(.footnote.weight(.semibold))
                     .foregroundStyle(.white.opacity(0.4))
             }
-            .contentShape(Rectangle())
         }
         .foregroundStyle(.white)
-        .accessibilityLabel(playlist.name)
-        .accessibilityHint("Öppna spellistan")
+    }
+
+    private var favoriteStar: some View {
+        let saved = viewModel.isSaved(playlist)
+        return Button {
+            Task { await viewModel.toggleSpotifySaved(playlist) }
+        } label: {
+            Image(systemName: saved ? "star.fill" : "star")
+                .foregroundStyle(saved ? .yellow : .white.opacity(0.6))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(saved ? "Ta bort \(playlist.name) från Spotify-favoriter" : "Lägg till \(playlist.name) i Spotify-favoriter")
     }
 }
 

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -22,29 +22,26 @@ struct NowPlayingView: View {
                     .lineLimit(1)
                 Spacer()
                 Button {
+                    Task { await viewModel.openQueue() }
+                } label: {
+                    Image(systemName: "list.bullet")
+                }
+                .accessibilityLabel("Visa kö")
+                Button {
                     viewModel.activeSpeakerID = nil
                 } label: {
                     Image(systemName: "hifispeaker.2.fill")
                 }
                 .accessibilityLabel("Byt högtalare")
             }
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("Vald högtalare: \(speaker.friendlyName)")
 
             HStack(spacing: 12) {
-                AlbumArtView(urlString: speaker.entityPicture, size: 64)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(speaker.mediaTitle ?? "Inget spelas")
-                        .font(.headline)
-                        .lineLimit(1)
-                    if let artist = speaker.mediaArtist {
-                        Text(artist)
-                            .font(.subheadline)
-                            .foregroundStyle(.white.opacity(0.7))
-                            .lineLimit(1)
-                    }
+                nowPlayingMetadata
+                Spacer(minLength: 8)
+                if let uri = speaker.mediaContentID, viewModel.canFavoriteSong(uri: uri) {
+                    SongFavoriteButton(viewModel: viewModel, uri: uri)
+                        .font(.title3)
                 }
-                Spacer()
             }
 
             TransportControlsView(speaker: speaker, viewModel: viewModel)
@@ -63,6 +60,52 @@ struct NowPlayingView: View {
             RoundedRectangle(cornerRadius: 16)
                 .stroke(Color.yellow.opacity(0.7), lineWidth: 2)
         )
+        // Keep the now-playing Liked-Songs heart in sync with the live track.
+        .task(id: speaker.mediaContentID) {
+            await viewModel.loadSavedSongStates(uris: [speaker.mediaContentID].compactMap { $0 })
+        }
+    }
+
+    /// The album art and track metadata. Tapping it opens the playlist the track
+    /// is playing from, when that source is known; otherwise it is inert (no
+    /// dead-end). The transport and volume controls below stay separate, so the
+    /// jump tap never swallows a play/pause or volume change.
+    @ViewBuilder private var nowPlayingMetadata: some View {
+        if viewModel.nowPlayingSourcePlaylist != nil {
+            Button {
+                Task { await viewModel.openNowPlayingPlaylist() }
+            } label: {
+                metadataLabel
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint("Öppna spellistan som spelas")
+        } else {
+            metadataLabel
+        }
+    }
+
+    private var metadataLabel: some View {
+        HStack(spacing: 12) {
+            AlbumArtView(urlString: speaker.entityPicture, size: 64)
+            VStack(alignment: .leading, spacing: 2) {
+                if let source = viewModel.nowPlayingSourcePlaylist {
+                    Text("Spelas från \(source.name)")
+                        .font(.caption2)
+                        .foregroundStyle(.yellow.opacity(0.8))
+                        .lineLimit(1)
+                }
+                Text(speaker.mediaTitle ?? "Inget spelas")
+                    .font(.headline)
+                    .lineLimit(1)
+                if let artist = speaker.mediaArtist {
+                    Text(artist)
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.7))
+                        .lineLimit(1)
+                }
+            }
+        }
+        .contentShape(Rectangle())
     }
 }
 

--- a/IntelliNest/Views/Music/QueueView.swift
+++ b/IntelliNest/Views/Music/QueueView.swift
@@ -1,0 +1,137 @@
+//
+//  QueueView.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-11.
+//
+
+import SwiftUI
+
+/// The play queue for the active speaker, presented as a sheet from the
+/// now-playing area. Shows the current track ("Spelas nu") and the upcoming
+/// tracks ("Näst på tur"); upcoming tracks can be swiped away. Each Spotify
+/// track carries the Liked-Songs heart.
+struct QueueView: View {
+    @ObservedObject var viewModel: MusicViewModel
+
+    var body: some View {
+        NavigationStack {
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .backgroundModifier()
+                .foregroundStyle(.white)
+                .navigationTitle("Kö")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Stäng") { viewModel.isShowingQueue = false }
+                            .foregroundStyle(.white)
+                    }
+                }
+        }
+        .task { await viewModel.loadQueue() }
+    }
+
+    @ViewBuilder private var content: some View {
+        if viewModel.isLoadingQueue, viewModel.queue == .empty {
+            ProgressView()
+                .tint(.white)
+                .padding(.top, 60)
+        } else if isQueueEmpty {
+            emptyState
+        } else {
+            queueList
+        }
+    }
+
+    private var isQueueEmpty: Bool {
+        viewModel.queue.currentItem == nil && viewModel.queue.upcomingItems.isEmpty
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "music.note.list")
+                .font(.largeTitle)
+                .foregroundStyle(.white.opacity(0.4))
+            Text("Inget spelas")
+                .foregroundStyle(.white.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var queueList: some View {
+        List {
+            Section {
+                if let current = viewModel.queue.currentItem {
+                    QueueRow(viewModel: viewModel, item: current)
+                } else {
+                    Text("Inget spelas")
+                        .foregroundStyle(.white.opacity(0.6))
+                        .listRowBackground(Color.clear)
+                }
+            } header: {
+                sectionHeader("Spelas nu")
+            }
+
+            Section {
+                if viewModel.queue.upcomingItems.isEmpty {
+                    Text("Inga kommande låtar")
+                        .foregroundStyle(.white.opacity(0.6))
+                        .listRowBackground(Color.clear)
+                } else {
+                    ForEach(viewModel.queue.upcomingItems) { item in
+                        QueueRow(viewModel: viewModel, item: item)
+                            .listRowBackground(Color.clear)
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    Task { await viewModel.removeFromQueue(item) }
+                                } label: {
+                                    Label("Ta bort", systemImage: "trash")
+                                }
+                            }
+                    }
+                }
+            } header: {
+                sectionHeader("Näst på tur")
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.headline)
+            .foregroundStyle(.white)
+    }
+}
+
+/// One queue row: album art, title, artist, and the Liked-Songs heart for
+/// Spotify tracks.
+private struct QueueRow: View {
+    @ObservedObject var viewModel: MusicViewModel
+    let item: MusicQueueItem
+
+    var body: some View {
+        HStack(spacing: 12) {
+            AlbumArtView(urlString: item.imageURL, size: 44)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .font(.body)
+                    .lineLimit(1)
+                if let artist = item.artist {
+                    Text(artist)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.6))
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            if let uri = item.uri, viewModel.canFavoriteSong(uri: uri) {
+                SongFavoriteButton(viewModel: viewModel, uri: uri)
+            }
+        }
+        .listRowBackground(Color.clear)
+        .foregroundStyle(.white)
+    }
+}

--- a/IntelliNestTests/MusicQueueModelTests.swift
+++ b/IntelliNestTests/MusicQueueModelTests.swift
@@ -1,0 +1,67 @@
+@testable import IntelliNest
+import XCTest
+
+/// Decoding coverage for the Music Assistant queue payloads: the `get_queue`
+/// REST body (which carries the queue id and current item) and the queue-item
+/// shape shared with the WebSocket `player_queues/items` list.
+final class MusicQueueModelTests: XCTestCase {
+    func testGetQueueParsesServiceResponseEnvelope() {
+        let json = """
+        {"service_response":{"queue_id":"kitchen","current_item":{"queue_item_id":"item-1",
+        "media_item":{"uri":"spotify://track/abc","name":"Röda sten","artists":[{"name":"Albin Lee Meldau"}]}}}}
+        """
+        let result = MusicGetQueueParser.parse(Data(json.utf8))
+        XCTAssertEqual(result.queueID, "kitchen")
+        XCTAssertEqual(result.currentItem?.queueItemID, "item-1")
+        XCTAssertEqual(result.currentItem?.title, "Röda sten")
+        XCTAssertEqual(result.currentItem?.artist, "Albin Lee Meldau")
+        XCTAssertEqual(result.currentItem?.uri, "spotify://track/abc")
+    }
+
+    func testGetQueueParsesEntityKeyedShape() {
+        let json = """
+        {"service_response":{"media_player.kitchen":{"queue_id":"kitchen","current_item":{"queue_item_id":"item-9",
+        "name":"Fallback Name"}}}}
+        """
+        let result = MusicGetQueueParser.parse(Data(json.utf8))
+        XCTAssertEqual(result.queueID, "kitchen")
+        XCTAssertEqual(result.currentItem?.queueItemID, "item-9")
+        // No media_item, so the queue item's own name is used.
+        XCTAssertEqual(result.currentItem?.title, "Fallback Name")
+    }
+
+    func testGetQueueParsesDirectShape() {
+        let json = #"{"queue_id":"spa","current_item":{"queue_item_id":"i1","media_item":{"name":"Låt"}}}"#
+        let result = MusicGetQueueParser.parse(Data(json.utf8))
+        XCTAssertEqual(result.queueID, "spa")
+        XCTAssertEqual(result.currentItem?.title, "Låt")
+    }
+
+    func testGetQueueReturnsEmptyForUnexpectedBody() {
+        let result = MusicGetQueueParser.parse(Data("not json".utf8))
+        XCTAssertNil(result.queueID)
+        XCTAssertNil(result.currentItem)
+    }
+
+    func testQueueItemDropsNonHttpImage() {
+        let json = """
+        {"queue_item_id":"i1","media_item":{"uri":"spotify://track/x","name":"X",
+        "metadata":{"images":[{"path":"local/file.png"},{"path":"https://img/cover.jpg"}]}}}
+        """
+        let dto = try? JSONDecoder().decode(MusicQueueItemDTO.self, from: Data(json.utf8))
+        // The first remotely-reachable (http) image wins; the local path is skipped.
+        XCTAssertEqual(dto?.queueItem?.imageURL, "https://img/cover.jpg")
+    }
+
+    func testQueueItemListDecodesForWebSocketItems() {
+        let json = """
+        [{"queue_item_id":"a","media_item":{"uri":"spotify://track/1","name":"One"}},
+         {"queue_item_id":"b","media_item":{"uri":"spotify://track/2","name":"Two","artists":[{"name":"Band"}]}}]
+        """
+        let items = try? JSONDecoder().decode([MusicQueueItemDTO].self, from: Data(json.utf8))
+        let mapped = items?.compactMap(\.queueItem)
+        XCTAssertEqual(mapped?.map(\.queueItemID), ["a", "b"])
+        XCTAssertEqual(mapped?.last?.title, "Two")
+        XCTAssertEqual(mapped?.last?.artist, "Band")
+    }
+}

--- a/IntelliNestTests/MusicViewModelQueueTests.swift
+++ b/IntelliNestTests/MusicViewModelQueueTests.swift
@@ -1,0 +1,163 @@
+@testable import IntelliNest
+import XCTest
+
+/// Records queue-socket calls so the view model's read/add/remove queue logic
+/// can be tested without the Music Assistant WebSocket.
+actor StubMusicAssistantQueueSocket: MusicAssistantQueueSocket {
+    var items: [MusicQueueItem]
+    var deleteSucceeds: Bool
+    private(set) var deletedItemIDs: [String] = []
+
+    init(items: [MusicQueueItem] = [], deleteSucceeds: Bool = true) {
+        self.items = items
+        self.deleteSucceeds = deleteSucceeds
+    }
+
+    func queueItems(queueID _: String) async -> [MusicQueueItem] { items }
+
+    func deleteItem(queueID _: String, itemID: String) async -> Bool {
+        deletedItemIDs.append(itemID)
+        return deleteSucceeds
+    }
+}
+
+@MainActor
+extension MusicViewModelTests {
+    func makeViewModel(socket: MusicAssistantQueueSocket) -> MusicViewModel {
+        makeViewModel(spotify: StubSpotifyPlaylistService(authorized: false), socket: socket)
+    }
+
+    func makeViewModel(spotify: SpotifyPlaylistService, socket: MusicAssistantQueueSocket) -> MusicViewModel {
+        MusicViewModel(restAPIService: restAPIService,
+                       setErrorBannerText: { [weak self] title, _ in self?.bannerTitles.append(title) },
+                       spotify: spotify,
+                       queueSocket: socket)
+    }
+
+    func stubGetQueue(json: String, statusCode: Int = 200) {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/services/music_assistant/get_queue"
+        components.queryItems = [URLQueryItem(name: "return_response", value: "true")]
+        let url = components.url!
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(json.utf8), response: response, error: nil)
+    }
+
+    private func queueItem(_ id: String, uri: String? = nil, title: String = "Song") -> MusicQueueItem {
+        MusicQueueItem(queueItemID: id, uri: uri, title: title, artist: nil, imageURL: nil)
+    }
+
+    private var getQueueJSON: String {
+        // queue_id present plus a current item; the socket supplies the full list.
+        #"{"service_response":{"queue_id":"kitchen","current_item":{"queue_item_id":"cur","media_item":{"name":"Now"}}}}"#
+    }
+
+    // MARK: - Load
+
+    func testLoadQueueSlicesUpcomingAfterCurrent() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubGetQueue(json: getQueueJSON)
+        let socket = StubMusicAssistantQueueSocket(items: [
+            queueItem("cur", title: "Now"),
+            queueItem("next1", title: "Next One"),
+            queueItem("next2", title: "Next Two")
+        ])
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.loadQueue()
+        XCTAssertEqual(model.queue.queueID, "kitchen")
+        XCTAssertEqual(model.queue.currentItem?.queueItemID, "cur")
+        XCTAssertEqual(model.queue.upcomingItems.map(\.queueItemID), ["next1", "next2"])
+    }
+
+    func testLoadQueueFallsBackToSessionItemsWhenSocketEmpty() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubGetQueue(json: getQueueJSON)
+        stubPlayMedia(statusCode: 200)
+        let model = makeViewModel(socket: StubMusicAssistantQueueSocket(items: []))
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.addToQueue(uri: "spotify://track/x", title: "Enqueued", artist: nil, imageURL: nil)
+        await model.loadQueue()
+        // Socket returns nothing, so the session-enqueued track is the fallback.
+        XCTAssertEqual(model.queue.upcomingItems.map(\.title), ["Enqueued"])
+    }
+
+    // MARK: - Add
+
+    func testAddToQueueAppendsOptimisticallyOnSuccess() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubPlayMedia(statusCode: 200)
+        let model = makeViewModel(socket: StubMusicAssistantQueueSocket())
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.addToQueue(uri: "spotify://track/x", title: "Enqueued", artist: "A", imageURL: nil)
+        XCTAssertEqual(model.sessionEnqueuedItems.map(\.title), ["Enqueued"])
+        XCTAssertEqual(model.queue.upcomingItems.map(\.title), ["Enqueued"])
+        XCTAssertTrue(bannerTitles.isEmpty)
+    }
+
+    func testAddToQueueBannersOnFailure() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubPlayMedia(statusCode: 500)
+        let model = makeViewModel(socket: StubMusicAssistantQueueSocket())
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.addToQueue(uri: "spotify://track/x", title: "Enqueued", artist: nil, imageURL: nil)
+        XCTAssertTrue(model.sessionEnqueuedItems.isEmpty)
+        XCTAssertTrue(bannerTitles.contains("Kunde inte lägga till i kön"))
+    }
+
+    func testAddToQueueWithoutSpeakerBanners() async {
+        let model = makeViewModel(socket: StubMusicAssistantQueueSocket())
+        await model.addToQueue(uri: "spotify://track/x", title: "X", artist: nil, imageURL: nil)
+        XCTAssertTrue(bannerTitles.contains("Ingen högtalare vald"))
+    }
+
+    // MARK: - Remove
+
+    func testRemoveRealQueueItemCallsSocketAndDropsRow() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubGetQueue(json: getQueueJSON)
+        let socket = StubMusicAssistantQueueSocket(items: [
+            queueItem("cur", title: "Now"),
+            queueItem("next1", title: "Next One")
+        ])
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.loadQueue()
+        let target = model.queue.upcomingItems[0]
+        await model.removeFromQueue(target)
+        XCTAssertTrue(model.queue.upcomingItems.isEmpty)
+        let deleted = await socket.deletedItemIDs
+        XCTAssertEqual(deleted, ["next1"])
+    }
+
+    func testRemoveRealQueueItemRevertsAndBannersOnFailure() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubGetQueue(json: getQueueJSON)
+        let socket = StubMusicAssistantQueueSocket(items: [
+            queueItem("cur", title: "Now"),
+            queueItem("next1", title: "Next One")
+        ], deleteSucceeds: false)
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.loadQueue()
+        let target = model.queue.upcomingItems[0]
+        await model.removeFromQueue(target)
+        XCTAssertEqual(model.queue.upcomingItems.map(\.queueItemID), ["next1"])
+        XCTAssertTrue(bannerTitles.contains("Kunde inte ta bort från kön"))
+    }
+
+    func testRemoveSessionItemIsLocalOnlyNoSocketCall() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubPlayMedia(statusCode: 200)
+        let socket = StubMusicAssistantQueueSocket(items: [])
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.addToQueue(uri: "spotify://track/x", title: "Enqueued", artist: nil, imageURL: nil)
+        let sessionItem = model.queue.upcomingItems[0]
+        await model.removeFromQueue(sessionItem)
+        XCTAssertTrue(model.queue.upcomingItems.isEmpty)
+        XCTAssertTrue(model.sessionEnqueuedItems.isEmpty)
+        let deleted = await socket.deletedItemIDs
+        XCTAssertTrue(deleted.isEmpty)
+    }
+}

--- a/IntelliNestTests/MusicViewModelSongFavoriteTests.swift
+++ b/IntelliNestTests/MusicViewModelSongFavoriteTests.swift
@@ -1,0 +1,173 @@
+@testable import IntelliNest
+import XCTest
+
+/// Song-level Spotify behaviour on the music view model: liking/unliking tracks,
+/// adding and removing playlist tracks, and tracking the now-playing source
+/// playlist for the jump-to-playlist control. Reuses `MusicViewModelTests`
+/// scaffolding (stubbed REST + speakers).
+@MainActor
+extension MusicViewModelTests {
+    private var spotifyTrackURI: String { trackURI }
+
+    private func playlistTrack(_ uri: String, title: String = "X") -> MusicPlaylistTrack {
+        MusicPlaylistTrack(uri: uri, title: title, imageURL: nil)
+    }
+
+    // MARK: - Liked Songs
+
+    func testCanFavoriteSongRequiresLoginAndSpotifyTrack() {
+        let loggedIn = makeViewModel(spotify: StubSpotifyPlaylistService(authorized: true))
+        XCTAssertTrue(loggedIn.canFavoriteSong(uri: spotifyTrackURI))
+        XCTAssertFalse(loggedIn.canFavoriteSong(uri: "library://track/4"))
+        XCTAssertFalse(loggedIn.canFavoriteSong(uri: nil))
+
+        let loggedOut = makeViewModel(spotify: StubSpotifyPlaylistService(authorized: false))
+        XCTAssertFalse(loggedOut.canFavoriteSong(uri: spotifyTrackURI))
+    }
+
+    func testLoadSavedSongStatesReflectsLibrary() async {
+        let trackID = "3SjXx3rbNGk8nCho8YEoz5"
+        let stub = StubSpotifyPlaylistService(savedSongTrackIDs: [trackID])
+        let model = makeViewModel(spotify: stub)
+        await model.loadSavedSongStates(uris: [spotifyTrackURI])
+        XCTAssertTrue(model.isSongSaved(uri: spotifyTrackURI))
+    }
+
+    func testToggleSongSavesThenRemoves() async {
+        let stub = StubSpotifyPlaylistService()
+        let model = makeViewModel(spotify: stub)
+        await model.toggleSongSaved(uri: spotifyTrackURI)
+        XCTAssertTrue(model.isSongSaved(uri: spotifyTrackURI))
+        XCTAssertEqual(stub.saveSongCallCount, 1)
+
+        await model.toggleSongSaved(uri: spotifyTrackURI)
+        XCTAssertFalse(model.isSongSaved(uri: spotifyTrackURI))
+        XCTAssertEqual(stub.removeSongCallCount, 1)
+    }
+
+    func testToggleSongFailureRevertsAndBanners() async {
+        let stub = StubSpotifyPlaylistService(operationSucceeds: false)
+        let model = makeViewModel(spotify: stub)
+        await model.toggleSongSaved(uri: spotifyTrackURI)
+        XCTAssertFalse(model.isSongSaved(uri: spotifyTrackURI))
+        XCTAssertTrue(bannerTitles.contains("Kunde inte uppdatera favorit"))
+    }
+
+    func testToggleSongLogsInWhenLoggedOut() async {
+        let stub = StubSpotifyPlaylistService(authorized: false)
+        let model = makeViewModel(spotify: stub)
+        await model.toggleSongSaved(uri: spotifyTrackURI)
+        XCTAssertEqual(stub.authorizeCallCount, 1)
+        XCTAssertTrue(model.isSongSaved(uri: spotifyTrackURI))
+    }
+
+    func testToggleSongIgnoresNonSpotifyTrack() async {
+        let stub = StubSpotifyPlaylistService()
+        let model = makeViewModel(spotify: stub)
+        await model.toggleSongSaved(uri: "library://track/9")
+        XCTAssertEqual(stub.saveSongCallCount, 0)
+        XCTAssertTrue(model.savedSongURIs.isEmpty)
+    }
+
+    // MARK: - Add to playlist
+
+    private func makeEditableModel() async -> (MusicViewModel, StubSpotifyPlaylistService) {
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: [spotifyPlaylist()],
+                                              editableIDs: [spotifyPlaylistID])
+        let model = makeViewModel(spotify: stub)
+        await model.refreshSpotifyPlaylists()
+        return (model, stub)
+    }
+
+    func testEditableAccountPlaylistsFiltersByEditableIDs() async {
+        let (model, _) = await makeEditableModel()
+        XCTAssertEqual(model.editableAccountPlaylists.map(\.name), ["Lugnt & Skönt"])
+    }
+
+    func testCanAddTrackRequiresEditablePlaylistAndSpotifyTrack() async {
+        let (model, _) = await makeEditableModel()
+        XCTAssertTrue(model.canAddTrackToPlaylist(uri: spotifyTrackURI))
+        XCTAssertFalse(model.canAddTrackToPlaylist(uri: "library://track/1"))
+    }
+
+    func testAddTrackToPlaylistCallsSpotify() async {
+        let (model, stub) = await makeEditableModel()
+        await model.addTrack(uri: spotifyTrackURI, toPlaylist: spotifyPlaylist())
+        XCTAssertEqual(stub.addedTracks.count, 1)
+        XCTAssertEqual(stub.addedTracks.first?.playlistID, spotifyPlaylistID)
+        XCTAssertEqual(stub.addedTracks.first?.trackID, "3SjXx3rbNGk8nCho8YEoz5")
+    }
+
+    func testAddTrackFailureBanners() async {
+        let stub = StubSpotifyPlaylistService(operationSucceeds: false,
+                                              accountPlaylistItems: [spotifyPlaylist()],
+                                              editableIDs: [spotifyPlaylistID])
+        let model = makeViewModel(spotify: stub)
+        await model.refreshSpotifyPlaylists()
+        await model.addTrack(uri: spotifyTrackURI, toPlaylist: spotifyPlaylist())
+        XCTAssertTrue(bannerTitles.contains("Kunde inte lägga till i spellistan"))
+    }
+
+    // MARK: - Remove from playlist
+
+    func testCanEditPlaylistReflectsEditableIDs() async {
+        let (model, _) = await makeEditableModel()
+        XCTAssertTrue(model.canEditPlaylist(spotifyPlaylist()))
+        let other = MusicSearchItem(uri: "spotify://playlist/other", name: "Annan",
+                                    mediaType: .playlist, imageURL: nil, artist: nil)
+        XCTAssertFalse(model.canEditPlaylist(other))
+    }
+
+    func testRemoveTrackFromPlaylistOptimisticallyDropsRow() async {
+        let (model, stub) = await makeEditableModel()
+        let track = playlistTrack(spotifyTrackURI)
+        model.playlistTracks = [track, playlistTrack("spotify://track/keep", title: "Keep")]
+        await model.removeTrack(track, fromPlaylist: spotifyPlaylist())
+        XCTAssertEqual(model.playlistTracks.map(\.title), ["Keep"])
+        XCTAssertEqual(stub.removedTracks.first?.trackID, "3SjXx3rbNGk8nCho8YEoz5")
+    }
+
+    func testRemoveTrackFailureRevertsList() async {
+        let stub = StubSpotifyPlaylistService(operationSucceeds: false,
+                                              accountPlaylistItems: [spotifyPlaylist()],
+                                              editableIDs: [spotifyPlaylistID])
+        let model = makeViewModel(spotify: stub)
+        await model.refreshSpotifyPlaylists()
+        let track = playlistTrack(spotifyTrackURI)
+        model.playlistTracks = [track]
+        await model.removeTrack(track, fromPlaylist: spotifyPlaylist())
+        XCTAssertEqual(model.playlistTracks.map(\.uri), [spotifyTrackURI])
+        XCTAssertTrue(bannerTitles.contains("Kunde inte ta bort låten"))
+    }
+
+    // MARK: - Jump to playing playlist
+
+    func testPlayPlaylistSetsNowPlayingSource() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubPlayMedia(statusCode: 200)
+        await viewModel.playPlaylist(spotifyPlaylist())
+        XCTAssertEqual(viewModel.nowPlayingSourcePlaylist?.uri, spotifyPlaylist().uri)
+    }
+
+    func testPlaySingleTrackClearsNowPlayingSource() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        viewModel.nowPlayingSourcePlaylist = spotifyPlaylist()
+        stubPlayMedia(statusCode: 200)
+        let item = MusicSearchItem(uri: spotifyTrackURI, name: "Track", mediaType: .track, imageURL: nil, artist: nil)
+        await viewModel.play(item: item)
+        XCTAssertNil(viewModel.nowPlayingSourcePlaylist)
+    }
+
+    func testOpenNowPlayingPlaylistOpensBrowseSheet() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        viewModel.nowPlayingSourcePlaylist = spotifyPlaylist()
+        await viewModel.openNowPlayingPlaylist()
+        XCTAssertEqual(viewModel.browsingLibraryPlaylist?.uri, spotifyPlaylist().uri)
+    }
+
+    func testOpenNowPlayingPlaylistNoOpWhenSourceUnknown() async {
+        viewModel.nowPlayingSourcePlaylist = nil
+        await viewModel.openNowPlayingPlaylist()
+        XCTAssertNil(viewModel.browsingLibraryPlaylist)
+    }
+}

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -11,21 +11,31 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
     var operationSucceeds: Bool
     var authorizeThrows: Bool
     var accountPlaylistItems: [MusicSearchItem]
+    var editableIDs: Set<String>
+    var savedSongTrackIDs: Set<String>
     private(set) var authorizeCallCount = 0
     private(set) var saveCallCount = 0
     private(set) var removeCallCount = 0
     private(set) var accountPlaylistsCallCount = 0
+    private(set) var saveSongCallCount = 0
+    private(set) var removeSongCallCount = 0
+    private(set) var addedTracks: [(playlistID: String, trackID: String)] = []
+    private(set) var removedTracks: [(playlistID: String, trackID: String)] = []
 
     init(authorized: Bool = true,
          savedIDs: Set<String> = [],
          operationSucceeds: Bool = true,
          authorizeThrows: Bool = false,
-         accountPlaylistItems: [MusicSearchItem] = []) {
+         accountPlaylistItems: [MusicSearchItem] = [],
+         editableIDs: Set<String> = [],
+         savedSongTrackIDs: Set<String> = []) {
         self.authorized = authorized
         self.savedIDs = savedIDs
         self.operationSucceeds = operationSucceeds
         self.authorizeThrows = authorizeThrows
         self.accountPlaylistItems = accountPlaylistItems
+        self.editableIDs = editableIDs
+        self.savedSongTrackIDs = savedSongTrackIDs
     }
 
     var isAuthorized: Bool { authorized }
@@ -41,6 +51,10 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
     func accountPlaylists() async -> [MusicSearchItem] {
         accountPlaylistsCallCount += 1
         return accountPlaylistItems
+    }
+
+    func editablePlaylistIDs() async -> Set<String> {
+        editableIDs
     }
 
     func isPlaylistSaved(playlistID: String) async -> Bool {
@@ -59,6 +73,40 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
         removeCallCount += 1
         if operationSucceeds {
             savedIDs.remove(playlistID)
+        }
+        return operationSucceeds
+    }
+
+    func savedSongIDs(trackIDs: [String]) async -> Set<String> {
+        savedSongTrackIDs.intersection(trackIDs)
+    }
+
+    func saveSong(trackID: String) async -> Bool {
+        saveSongCallCount += 1
+        if operationSucceeds {
+            savedSongTrackIDs.insert(trackID)
+        }
+        return operationSucceeds
+    }
+
+    func removeSong(trackID: String) async -> Bool {
+        removeSongCallCount += 1
+        if operationSucceeds {
+            savedSongTrackIDs.remove(trackID)
+        }
+        return operationSucceeds
+    }
+
+    func addTrack(playlistID: String, trackID: String) async -> Bool {
+        if operationSucceeds {
+            addedTracks.append((playlistID, trackID))
+        }
+        return operationSucceeds
+    }
+
+    func removeTrack(playlistID: String, trackID: String) async -> Bool {
+        if operationSucceeds {
+            removedTracks.append((playlistID, trackID))
         }
         return operationSucceeds
     }

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ IntelliNest is a native iOS application that leverages the power of the popular 
 ## Code statistics
 | Indicators                          | Now  | Desired |
 |-------------------------------------|------|---------|
-| Total LOC                           | 15657 | N/A |
-| Swift file count                    | 167 | N/A |
-| Average LOC per file                | 93 | <100 |
+| Total LOC                           | 18594 | N/A |
+| Swift file count                    | 182 | N/A |
+| Average LOC per file                | 102 | <100 |
 | TODO comment count                  | 0 | 0 |
 | FIX comment count                   | 0 | 0 |
 | unowned reference count             | 1 | 0 |
-| Commit count in main                | 141 | N/A |
-| Total deleted lines                 | 13876 | N/A |
-| Total added lines                   | 34206 | N/A |
+| Commit count in main                | 154 | N/A |
+| Total deleted lines                 | 15865 | N/A |
+| Total added lines                   | 36606 | N/A |
 
-Last Updated: 2026-06-10
+Last Updated: 2026-06-11
 ## Supported features
 ### Rest API and Websocket support
 Most views now use WebSocket instead of REST API for improved real-time updates.


### PR DESCRIPTION
## What

Spotify-inspired upgrades to the Musik view. Spotify stays the source of truth for the library/favourites; Music Assistant drives live playback/queue state on the home speakers.

- **Jump to playing playlist** — the now-playing card's art/metadata is tappable (with a "Spelas från …" caption) and opens the source playlist; shown only when the source is known, and kept separate from the transport/volume controls.
- **Queue** — a new Queue screen (Spelas nu / Näst på tur) opened from a queue icon. Reads `music_assistant.get_queue` (REST) for the current item + queue id and a **minimal revived MA WebSocket** (`player_queues/items` / `player_queues/delete_item`) for the full upcoming list and per-item removal. Add-to-queue and swipe-to-remove are optimistic with revert; degrades to now-playing + session-enqueued tracks when the socket is unreachable; group-leader aware; refreshes live while open.
- **Playlist favourites** — the star now appears on every Favoriter/Senast spelade row (filled vs. empty by real saved state), not just in the detail view.
- **Song favourites** — Spotify Liked-Songs heart on playlist track rows, queue rows, and Now Playing; reflects saved state on load.
- **Add/remove songs ↔ playlists** — long-press menu: add to queue, add to an editable Spotify playlist (picker), remove from this playlist; gated to owned/collaborative playlists only.
- Controls appear only where they can function (Spotify-resolvable track/playlist); logged-out taps trigger the existing Spotify login then complete; Swedish VoiceOver labels throughout.

## Notes

- New Spotify scopes `user-library-read` / `user-library-modify`.
- MA server WebSocket URL defaults to the internal host on MA's port, overridable via the `MUSIC_ASSISTANT_WS_URL` xcconfig key. Queue display + add work over REST regardless; only the full upcoming-list read and per-item remove use the socket (home network only).

## Tests

New XCTest coverage for the queue parser/DTOs, queue load/add/remove (stub socket), and song-favourite/playlist-edit/jump-source logic. Full music + Spotify suites green; SwiftFormat clean; SwiftLint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)