### PR TITLE
Fixed music starting on the wrong speaker when ungrouped

### DIFF
--- a/IntelliNest/Model/MediaPlayerEntity.swift
+++ b/IntelliNest/Model/MediaPlayerEntity.swift
@@ -44,8 +44,16 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
     /// speaker is synced into a group, Music Assistant only accepts transport
     /// and play commands on the group leader (the first group member); a
     /// follower rejects them. Falls back to this speaker when it is ungrouped.
+    ///
+    /// A well-formed Music Assistant group always lists this speaker among its
+    /// members. If `group_members` doesn't include it (a stale or malformed
+    /// list), play on this speaker rather than redirecting to a leader it isn't
+    /// actually grouped with — otherwise the music starts on the wrong speaker.
     var playbackTargetID: EntityId {
-        groupMembers.first ?? entityId
+        guard groupMembers.contains(entityId), let leader = groupMembers.first else {
+            return entityId
+        }
+        return leader
     }
 
     var isUnavailable: Bool {

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -88,6 +88,15 @@ extension MusicViewModel {
         return activeSpeaker.playbackTargetID
     }
 
+    /// Re-fetches the active speaker's state so playback routing reads its
+    /// current group membership rather than a value up to one reload cycle
+    /// stale. A failed fetch leaves the existing state in place.
+    private func refreshActiveSpeaker(_ speakerID: EntityId) async {
+        if let fresh = try? await restAPIService.reload(entityId: speakerID, entityType: MediaPlayerEntity.self) {
+            speakers[speakerID] = fresh
+        }
+    }
+
     func play(item: MusicSearchItem) async {
         if await startPlayback(uri: item.uri, mediaType: item.mediaType, title: item.name, artist: item.artist) {
             closeSearchResults()
@@ -103,7 +112,16 @@ extension MusicViewModel {
                                title: String?,
                                artist: String?,
                                enqueue: String = "replace") async -> Bool {
-        guard let activeSpeakerID, let targetID = playbackTargetID else {
+        guard let activeSpeakerID else {
+            setErrorBannerText("Ingen högtalare vald", "Välj en högtalare innan du spelar musik")
+            return false
+        }
+        // Group membership can change between the 5-second reloads (e.g. the
+        // speaker was just ungrouped). Refresh the active speaker before routing
+        // so playback isn't sent to a stale group leader it's no longer synced
+        // with — which would start the music on the wrong speaker.
+        await refreshActiveSpeaker(activeSpeakerID)
+        guard let targetID = playbackTargetID else {
             setErrorBannerText("Ingen högtalare vald", "Välj en högtalare innan du spelar musik")
             return false
         }

--- a/IntelliNestTests/MusicModelTests.swift
+++ b/IntelliNestTests/MusicModelTests.swift
@@ -125,6 +125,13 @@ final class MusicModelTests: XCTestCase {
         var leader = MediaPlayerEntity(entityId: .mediaPlayerGuestRoom)
         leader.groupMembers = [.mediaPlayerGuestRoom, .mediaPlayerPlayroom]
         XCTAssertEqual(leader.playbackTargetID, .mediaPlayerGuestRoom)
+
+        // A group_members list that doesn't include this speaker is stale or
+        // malformed; playback must stay on this speaker rather than redirect to
+        // a leader it isn't grouped with.
+        var stale = MediaPlayerEntity(entityId: .mediaPlayerOutdoorTable)
+        stale.groupMembers = [.mediaPlayerKitchen]
+        XCTAssertEqual(stale.playbackTargetID, .mediaPlayerOutdoorTable)
     }
 
     func testMediaPlayerSetNextUpdateTimeMovesIntoFuture() {

--- a/IntelliNestTests/MusicViewModelGroupingTests.swift
+++ b/IntelliNestTests/MusicViewModelGroupingTests.swift
@@ -227,6 +227,35 @@ extension MusicViewModelTests {
         XCTAssertNil(viewModel.openedPlaylist)
     }
 
+    func testPlayRefreshesGroupStateSoStaleLeaderIsNotTargeted() async {
+        // Per the last reload, Matbord-ute is grouped under Kitchen as leader, so
+        // its stale playback target is Kitchen.
+        let staleGroup = [EntityId.mediaPlayerKitchen.rawValue, EntityId.mediaPlayerOutdoorTable.rawValue]
+        stubSpeaker(.mediaPlayerOutdoorTable,
+                    data: speakerJSON(entityID: .mediaPlayerOutdoorTable, state: "playing",
+                                      friendlyName: "Matbord-ute", groupMembers: staleGroup))
+        for entityID in MusicViewModel.speakerIDs where entityID != .mediaPlayerOutdoorTable {
+            stubSpeaker(entityID, data: speakerJSON(entityID: entityID, state: "idle", friendlyName: entityID.rawValue))
+        }
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerOutdoorTable)
+        XCTAssertEqual(viewModel.activeSpeaker?.playbackTargetID, .mediaPlayerKitchen)
+
+        // The speakers were ungrouped since that reload; the fresh state is solo.
+        stubSpeaker(.mediaPlayerOutdoorTable,
+                    data: speakerJSON(entityID: .mediaPlayerOutdoorTable, state: "idle",
+                                      friendlyName: "Matbord-ute", groupMembers: []))
+        stubPlayMedia(statusCode: 200)
+        let item = MusicSearchItem(uri: "spotify://track/x", name: "Song A",
+                                   mediaType: .track, imageURL: nil, artist: nil)
+        await viewModel.play(item: item)
+
+        // Playback refreshed the active speaker first, so routing now lands on
+        // Matbord-ute itself rather than the stale Kitchen leader.
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerOutdoorTable]?.groupMembers, [])
+        XCTAssertEqual(viewModel.activeSpeaker?.playbackTargetID, .mediaPlayerOutdoorTable)
+    }
+
     func testPlayTrackInPlaylistPlaysTrackThenClosesSheet() async {
         viewModel.selectSpeaker(.mediaPlayerKitchen)
         viewModel.isShowingSearchResults = true


### PR DESCRIPTION
## Problem

Selecting a speaker (e.g. *Matbord-ute*) and pressing play could start the music on a **different** speaker (e.g. *Kitchen*) even though nothing was grouped.

## Cause

Playback is redirected to the group leader via `MediaPlayerEntity.playbackTargetID` (`group_members.first`), because Music Assistant rejects play/transport on a synced follower. But `group_members` only refreshes on the 5-second reload loop. When a speaker had been grouped under another (as leader) and was then ungrouped, the local `group_members` was still stale at play time, so the command was routed to the stale leader.

## Fix

- `MusicViewModel+Playback.startPlayback` now refreshes the active speaker's state immediately before routing, so playback uses current group membership instead of a value up to one reload cycle stale. A failed refresh falls back to existing state.
- `MediaPlayerEntity.playbackTargetID` now only redirects to a leader when `group_members` actually contains the speaker itself; a stale/malformed list plays on the speaker directly.

## Tests

- `testPlayRefreshesGroupStateSoStaleLeaderIsNotTargeted` reproduces the exact case: stale leader, ungroup happens, play lands on the selected speaker.
- Extended `testPlaybackTargetIDResolvesGroupLeader` with the stale-list guard.

`MusicViewModelTests` and `MusicModelTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)