### PR TITLE
Derived Music Assistant socket host from the Home Assistant URL

### DIFF
--- a/IntelliNest/Utils/Constants/GlobalConstants.swift
+++ b/IntelliNest/Utils/Constants/GlobalConstants.swift
@@ -64,14 +64,22 @@ enum GlobalConstants {
 
     /// Music Assistant server WebSocket URL, used only for the queue commands
     /// Home Assistant exposes no REST service for: reading the full upcoming list
-    /// and removing a queue item. Defaults to the internal host on Music
-    /// Assistant's default port; override with the `MUSIC_ASSISTANT_WS_URL`
+    /// and removing a queue item. Override with the `MUSIC_ASSISTANT_WS_URL`
     /// xcconfig key if the server runs elsewhere. Queue editing therefore works
     /// on the home network only (the MA server is not exposed externally).
     static var musicAssistantWebSocketURLString: String {
         if let override = Bundle.main.object(forInfoDictionaryKey: "MUSIC_ASSISTANT_WS_URL") as? String,
            override.isNotEmpty {
             return override
+        }
+        // The Music Assistant add-on runs on the same host as Home Assistant and
+        // exposes its WebSocket API on port 8095, so derive the host from the
+        // known internal HA URL — it then tracks the HA host automatically with no
+        // hardcoded IP. The add-on's internal hostname (e.g.
+        // "<slug>-music-assistant") only resolves inside Home Assistant's Docker
+        // network, not from the device, so the host IP is reused instead.
+        if let host = URLComponents(string: baseInternalUrlString)?.host {
+            return "ws://\(host):8095/ws"
         }
         return "ws://192.168.1.205:8095/ws"
     }


### PR DESCRIPTION
The queue WebSocket URL was hardcoded to `ws://192.168.1.205:8095/ws`. Derive the host from the existing internal Home Assistant URL (`baseInternalUrlString`) instead, so the Music Assistant socket tracks the HA host automatically with no hardcoded IP.

The Music Assistant add-on runs on the same host as Home Assistant and exposes its WebSocket API on port 8095, so reusing the HA host + 8095 is correct. The add-on's internal hostname (e.g. `d5369777-music-assistant`) only resolves inside Home Assistant's Docker network — not from an iOS device — so the host IP is reused rather than that hostname. `MUSIC_ASSISTANT_WS_URL` still overrides if the server runs elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Music Assistant WebSocket connectivity with more reliable host detection and enhanced fallback mechanisms for better connection stability across different network environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->