### PR TITLE
Added personal-account Spotify playlist sections

### DIFF
--- a/IntelliNest/Services/SpotifyApiService.swift
+++ b/IntelliNest/Services/SpotifyApiService.swift
@@ -7,6 +7,24 @@
 
 import Foundation
 
+/// A known personal Spotify account whose public playlists are surfaced in the
+/// music view as its own titled section. Baked into the app (no in-app management);
+/// add another account by appending to `SpotifyPersonalAccount.configured`.
+struct SpotifyPersonalAccount: Identifiable, Equatable {
+    /// The Spotify user id (the `/users/{id}` path component).
+    let userID: String
+    /// The Swedish section title shown above this account's playlists.
+    let title: String
+
+    var id: String { userID }
+
+    /// The ordered list of personal accounts. Sections render in this order.
+    /// Only Tobias is configured now; Sarah is appended here once her id is known.
+    static let configured: [SpotifyPersonalAccount] = [
+        SpotifyPersonalAccount(userID: "tobiasc91", title: "Mina spellistor")
+    ]
+}
+
 /// The Spotify playlist operations the music UI needs. Hidden behind a protocol
 /// so `MusicViewModel` can be tested with a stub and so the feature degrades
 /// cleanly when no Spotify client is configured.
@@ -21,6 +39,9 @@ protocol SpotifyPlaylistService {
     /// The Spotify ids of the playlists the user can edit (owned or collaborative).
     /// Used to gate the add-to-playlist picker and the remove-from-playlist action.
     func editablePlaylistIDs() async -> Set<String>
+    /// The public playlists on another Spotify user's profile (created + followed).
+    /// Reuses the signed-in account's token; only public playlists are visible.
+    func userPlaylists(userID: String) async -> [MusicSearchItem]
     /// Whether the playlist is currently in the user's Spotify library.
     func isPlaylistSaved(playlistID: String) async -> Bool
     /// Adds the playlist to the user's Spotify library. Returns success.
@@ -77,6 +98,25 @@ final class SpotifyApiService: SpotifyPlaylistService {
             return try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data).playlists
         } catch {
             Log.error("Spotify accountPlaylists failed: \(error)")
+            return []
+        }
+    }
+
+    func userPlaylists(userID: String) async -> [MusicSearchItem] {
+        do {
+            // 50 is the API's per-page max. Matching accountPlaylists' single-page
+            // limit keeps this to one request; a personal profile rarely exceeds it
+            // and pagination is out of scope (see design.md).
+            let request = try await authorizedRequest(path: "/users/\(userID)/playlists",
+                                                      method: "GET",
+                                                      queryItems: [URLQueryItem(name: "limit", value: "50")])
+            let (data, response) = try await session.data(for: request)
+            guard isSuccess(response) else {
+                return []
+            }
+            return try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data).playlists
+        } catch {
+            Log.error("Spotify userPlaylists(\(userID)) failed: \(error)")
             return []
         }
     }
@@ -324,6 +364,7 @@ struct DisabledSpotifyPlaylistService: SpotifyPlaylistService {
     func authorize() async throws {}
     func accountPlaylists() async -> [MusicSearchItem] { [] }
     func editablePlaylistIDs() async -> Set<String> { [] }
+    func userPlaylists(userID _: String) async -> [MusicSearchItem] { [] }
     func isPlaylistSaved(playlistID _: String) async -> Bool { false }
     func savePlaylist(playlistID _: String) async -> Bool { false }
     func removePlaylist(playlistID _: String) async -> Bool { false }

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -20,6 +20,7 @@ extension MusicViewModel {
     func loadLibraryPlaylistsIfNeeded() async {
         await loadRecentlyPlayedIfNeeded()
         await loadSpotifyPlaylistsIfNeeded()
+        await refreshPersonalPlaylists()
     }
 
     /// Loads the recently-played playlists from Music Assistant once.
@@ -59,6 +60,27 @@ extension MusicViewModel {
         favoritePlaylists = playlists
         hasLoadedSpotifyPlaylists = true
         editablePlaylistSpotifyIDs = await spotify.editablePlaylistIDs()
+    }
+
+    /// Re-fetches each configured personal account's public playlists, reusing the
+    /// huset login, and rebuilds `personalPlaylistSections` in configured order.
+    /// Mirrors `refreshSpotifyPlaylists`: when logged out the sections are cleared,
+    /// and an account whose fetch returns nothing (empty profile or failed request)
+    /// is dropped so its section disappears — never shown as an empty header.
+    func refreshPersonalPlaylists() async {
+        guard spotify.isAuthorized else {
+            personalPlaylistSections = []
+            return
+        }
+        var sections: [PersonalPlaylistSection] = []
+        for account in personalAccounts {
+            let playlists = await spotify.userPlaylists(userID: account.userID)
+            guard playlists.isNotEmpty else {
+                continue
+            }
+            sections.append(PersonalPlaylistSection(account: account, playlists: playlists))
+        }
+        personalPlaylistSections = sections
     }
 
     /// Re-fetches the recently-played list after a playlist launch so the new
@@ -236,6 +258,7 @@ extension MusicViewModel {
             try await spotify.authorize()
             isSpotifyAuthorized = true
             await refreshSpotifyPlaylists()
+            await refreshPersonalPlaylists()
         } catch {
             Log.error("Spotify login failed: \(error)")
             setErrorBannerText("Spotify-inloggning misslyckades", "Kunde inte logga in på Spotify")

--- a/IntelliNest/ViewModels/MusicViewModel+SpotifyTracks.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+SpotifyTracks.swift
@@ -83,17 +83,23 @@ extension MusicViewModel {
     /// Changes whenever the library lists change, so the view can reload the
     /// row stars' saved-state without polling.
     var librarySavedStateSignature: String {
-        (recentlyPlayedPlaylists.map(\.uri) + favoritePlaylists.map(\.uri)).joined(separator: "|")
+        (recentlyPlayedPlaylists.map(\.uri)
+            + favoritePlaylists.map(\.uri)
+            + personalPlaylistSections.flatMap { $0.playlists.map(\.uri) }).joined(separator: "|")
     }
 
     /// Populates the saved-state for the library rows. Favourites are in the
     /// Spotify library by definition, so they are marked saved without a call;
-    /// recently-played playlists are queried so their star reflects reality.
+    /// recently-played and personal-account playlists are queried so their star
+    /// reflects reality even when they are not also favourites.
     func loadLibrarySavedStates() async {
         for playlist in favoritePlaylists {
             setSaved(true, for: playlist)
         }
         for playlist in recentlyPlayedPlaylists {
+            await loadSavedState(for: playlist)
+        }
+        for playlist in personalPlaylistSections.flatMap(\.playlists) {
             await loadSavedState(for: playlist)
         }
     }

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -7,6 +7,16 @@
 
 import Foundation
 
+/// A personal account's section of public playlists, ready to render. Carries the
+/// account (for title + stable identity) and the playlists fetched for it.
+struct PersonalPlaylistSection: Identifiable, Equatable {
+    let account: SpotifyPersonalAccount
+    let playlists: [MusicSearchItem]
+
+    var id: String { account.id }
+    var title: String { account.title }
+}
+
 @MainActor
 class MusicViewModel: ObservableObject, Reloadable {
     /// The six controllable Music Assistant speakers, in display order.
@@ -68,6 +78,10 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// Tracks the app enqueued this session, newest last. Used as the "Näst på
     /// tur" fallback when the live queue contents can't be read over the socket.
     @Published var sessionEnqueuedItems: [MusicQueueItem] = []
+    /// One section per configured personal account that currently has public
+    /// playlists, in configured order, rendered below "Favoriter". Accounts with
+    /// no playlists (empty/failed fetch, or logged out) are kept off the list.
+    @Published var personalPlaylistSections: [PersonalPlaylistSection] = []
 
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false
@@ -92,6 +106,10 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// Home Assistant exposes no REST service for). Defaults to a disabled no-op
     /// so previews and tests need no socket.
     let queueSocket: MusicAssistantQueueSocket
+    /// The personal accounts whose public playlists are surfaced as their own
+    /// sections. Injectable so tests can exercise multiple-account ordering and the
+    /// hide-when-empty rule without depending on the baked-in list.
+    let personalAccounts: [SpotifyPersonalAccount]
 
     /// Speakers that are reachable right now (anything not `unavailable`),
     /// in the fixed display order.
@@ -109,11 +127,13 @@ class MusicViewModel: ObservableObject, Reloadable {
     init(restAPIService: RestAPIService,
          setErrorBannerText: @escaping StringStringClosure = { _, _ in },
          spotify: SpotifyPlaylistService = DisabledSpotifyPlaylistService(),
-         queueSocket: MusicAssistantQueueSocket = DisabledMusicAssistantQueueSocket()) {
+         queueSocket: MusicAssistantQueueSocket = DisabledMusicAssistantQueueSocket(),
+         personalAccounts: [SpotifyPersonalAccount] = SpotifyPersonalAccount.configured) {
         self.restAPIService = restAPIService
         self.setErrorBannerText = setErrorBannerText
         self.spotify = spotify
         self.queueSocket = queueSocket
+        self.personalAccounts = personalAccounts
         isSpotifyAuthorized = spotify.isAuthorized
         var initialSpeakers: [EntityId: MediaPlayerEntity] = [:]
         for speakerID in Self.speakerIDs {

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -32,6 +32,11 @@ struct MusicView: View {
                         LibraryPlaylistsSection(title: "Favoriter",
                                                 playlists: viewModel.favoritePlaylists,
                                                 viewModel: viewModel)
+                        ForEach(viewModel.personalPlaylistSections) { section in
+                            LibraryPlaylistsSection(title: section.title,
+                                                    playlists: section.playlists,
+                                                    viewModel: viewModel)
+                        }
                     } else {
                         SpeakerPickerView(viewModel: viewModel)
                     }
@@ -43,7 +48,10 @@ struct MusicView: View {
         .foregroundStyle(.white)
         // Spotify is the source of truth — refresh the account's playlists each
         // time the view appears rather than trusting the once-per-session cache.
-        .task { await viewModel.refreshSpotifyPlaylists() }
+        .task {
+            await viewModel.refreshSpotifyPlaylists()
+            await viewModel.refreshPersonalPlaylists()
+        }
         // Keep the library-row stars in sync as the favourite/recents lists load.
         .task(id: viewModel.librarySavedStateSignature) {
             await viewModel.loadLibrarySavedStates()

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -368,6 +368,7 @@ extension MusicViewModelTests {
         let stub = StubSpotifyPlaylistService(userPlaylistItems: tobiasTräning())
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
         stubAllSpeakers(playing: .mediaPlayerKitchen)
+        XCTAssertTrue(model.personalPlaylistSections.isEmpty)
         await model.reload()
         XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor"])
     }

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -13,6 +13,8 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
     var accountPlaylistItems: [MusicSearchItem]
     var editableIDs: Set<String>
     var savedSongTrackIDs: Set<String>
+    /// Public playlists keyed by Spotify user id, returned from `userPlaylists`.
+    var userPlaylistItems: [String: [MusicSearchItem]]
     private(set) var authorizeCallCount = 0
     private(set) var saveCallCount = 0
     private(set) var removeCallCount = 0
@@ -21,6 +23,7 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
     private(set) var removeSongCallCount = 0
     private(set) var addedTracks: [(playlistID: String, trackID: String)] = []
     private(set) var removedTracks: [(playlistID: String, trackID: String)] = []
+    private(set) var userPlaylistsCalls: [String] = []
 
     init(authorized: Bool = true,
          savedIDs: Set<String> = [],
@@ -28,7 +31,8 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
          authorizeThrows: Bool = false,
          accountPlaylistItems: [MusicSearchItem] = [],
          editableIDs: Set<String> = [],
-         savedSongTrackIDs: Set<String> = []) {
+         savedSongTrackIDs: Set<String> = [],
+         userPlaylistItems: [String: [MusicSearchItem]] = [:]) {
         self.authorized = authorized
         self.savedIDs = savedIDs
         self.operationSucceeds = operationSucceeds
@@ -36,6 +40,7 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
         self.accountPlaylistItems = accountPlaylistItems
         self.editableIDs = editableIDs
         self.savedSongTrackIDs = savedSongTrackIDs
+        self.userPlaylistItems = userPlaylistItems
     }
 
     var isAuthorized: Bool { authorized }
@@ -55,6 +60,11 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
 
     func editablePlaylistIDs() async -> Set<String> {
         editableIDs
+    }
+
+    func userPlaylists(userID: String) async -> [MusicSearchItem] {
+        userPlaylistsCalls.append(userID)
+        return userPlaylistItems[userID] ?? []
     }
 
     func isPlaylistSaved(playlistID: String) async -> Bool {
@@ -124,10 +134,25 @@ extension MusicViewModelTests {
                         name: "Lugnt & Skönt", mediaType: .playlist, imageURL: nil, artist: nil)
     }
 
-    func makeViewModel(spotify: SpotifyPlaylistService) -> MusicViewModel {
+    func makeViewModel(spotify: SpotifyPlaylistService,
+                       personalAccounts: [SpotifyPersonalAccount] = SpotifyPersonalAccount.configured) -> MusicViewModel {
         MusicViewModel(restAPIService: restAPIService,
                        setErrorBannerText: { [weak self] title, _ in self?.bannerTitles.append(title) },
-                       spotify: spotify)
+                       spotify: spotify,
+                       personalAccounts: personalAccounts)
+    }
+
+    // Fixed personal-account ids/titles — grep-searchable, no random data.
+    var tobiasAccount: SpotifyPersonalAccount { SpotifyPersonalAccount(userID: "tobiasc91", title: "Mina spellistor") }
+    var sarahAccount: SpotifyPersonalAccount { SpotifyPersonalAccount(userID: "sarahtest42", title: "Sarahs spellistor") }
+
+    func playlistItem(uri: String, name: String) -> MusicSearchItem {
+        MusicSearchItem(uri: uri, name: name, mediaType: .playlist, imageURL: nil, artist: nil)
+    }
+
+    /// A "Träning" playlist keyed under Tobias's user id — the common single-account fixture.
+    func tobiasTräning() -> [String: [MusicSearchItem]] {
+        ["tobiasc91": [playlistItem(uri: "spotify://playlist/p1", name: "Träning")]]
     }
 
     func testIsSpotifyPlaylistRequiresLoginAndResolvableUri() {
@@ -323,5 +348,110 @@ extension MusicViewModelTests {
         await viewModel.playPlaylistShuffled(spotifyPlaylist())
         XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.state, "playing")
         XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.shuffle, true)
+    }
+
+    // MARK: - Personal account playlist sections
+
+    func testPersonalSectionAppearsWhenLoggedInWithPlaylists() async {
+        let playlists = [playlistItem(uri: "spotify://playlist/p1", name: "Träning"),
+                         playlistItem(uri: "spotify://playlist/p2", name: "Lugnt & skönt")]
+        let stub = StubSpotifyPlaylistService(userPlaylistItems: ["tobiasc91": playlists])
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        await model.refreshPersonalPlaylists()
+        XCTAssertEqual(model.personalPlaylistSections.count, 1)
+        XCTAssertEqual(model.personalPlaylistSections.first?.title, "Mina spellistor")
+        // Order is preserved exactly as returned — no client-side re-sorting.
+        XCTAssertEqual(model.personalPlaylistSections.first?.playlists.map(\.name), ["Träning", "Lugnt & skönt"])
+    }
+
+    func testPersonalSectionLoadsViaReload() async {
+        let stub = StubSpotifyPlaylistService(userPlaylistItems: tobiasTräning())
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await model.reload()
+        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor"])
+    }
+
+    func testPersonalSectionHiddenWhenAccountHasNoPlaylists() async {
+        let stub = StubSpotifyPlaylistService(userPlaylistItems: ["tobiasc91": []])
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        await model.refreshPersonalPlaylists()
+        XCTAssertTrue(model.personalPlaylistSections.isEmpty)
+        // The fetch was still attempted (empty result, not skipped).
+        XCTAssertEqual(stub.userPlaylistsCalls, ["tobiasc91"])
+    }
+
+    func testPersonalSectionHiddenWhenLoggedOut() async {
+        let stub = StubSpotifyPlaylistService(authorized: false, userPlaylistItems: tobiasTräning())
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        await model.refreshPersonalPlaylists()
+        XCTAssertTrue(model.personalPlaylistSections.isEmpty)
+        XCTAssertTrue(stub.userPlaylistsCalls.isEmpty)
+    }
+
+    func testPersonalSectionsClearedWhenSessionBecomesLoggedOut() async {
+        let stub = StubSpotifyPlaylistService(userPlaylistItems: tobiasTräning())
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        await model.refreshPersonalPlaylists()
+        XCTAssertEqual(model.personalPlaylistSections.count, 1)
+        // The session is lost; a refresh now clears the sections so they disappear.
+        stub.authorized = false
+        await model.refreshPersonalPlaylists()
+        XCTAssertTrue(model.personalPlaylistSections.isEmpty)
+    }
+
+    func testMultipleAccountsEachGetASectionInConfiguredOrder() async {
+        let stub = StubSpotifyPlaylistService(userPlaylistItems: [
+            "tobiasc91": [playlistItem(uri: "spotify://playlist/p1", name: "Träning")],
+            "sarahtest42": [playlistItem(uri: "spotify://playlist/p2", name: "Sarahs mix")]
+        ])
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount, sarahAccount])
+        await model.refreshPersonalPlaylists()
+        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor", "Sarahs spellistor"])
+    }
+
+    func testEmptyAccountDroppedWhileOthersRemain() async {
+        let stub = StubSpotifyPlaylistService(userPlaylistItems: [
+            "tobiasc91": [],
+            "sarahtest42": [playlistItem(uri: "spotify://playlist/p2", name: "Sarahs mix")]
+        ])
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount, sarahAccount])
+        await model.refreshPersonalPlaylists()
+        // Tobias has nothing → dropped; only Sarah's section shows.
+        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Sarahs spellistor"])
+    }
+
+    func testPersonalSectionRefreshReflectsLatestPlaylists() async {
+        let stub = StubSpotifyPlaylistService(userPlaylistItems: tobiasTräning())
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        await model.refreshPersonalPlaylists()
+        XCTAssertEqual(model.personalPlaylistSections.first?.playlists.map(\.name), ["Träning"])
+        // Renamed/changed on Spotify; a refresh reflects it with no stale cache.
+        stub.userPlaylistItems = ["tobiasc91": [playlistItem(uri: "spotify://playlist/p3", name: "Ny spellista")]]
+        await model.refreshPersonalPlaylists()
+        XCTAssertEqual(model.personalPlaylistSections.first?.playlists.map(\.name), ["Ny spellista"])
+    }
+
+    func testConnectSpotifyLoadsPersonalSections() async {
+        let stub = StubSpotifyPlaylistService(authorized: false, userPlaylistItems: tobiasTräning())
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        await model.connectSpotify()
+        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor"])
+    }
+
+    func testTappingPersonalPlaylistRoutesThroughBrowseFlow() async {
+        let playlist = playlistItem(uri: "spotify://playlist/p1", name: "Träning")
+        let stub = StubSpotifyPlaylistService(userPlaylistItems: ["tobiasc91": [playlist]])
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.refreshPersonalPlaylists()
+        // Tapping a personal playlist uses the same browse flow as a favourite.
+        await model.browseLibraryPlaylist(model.personalPlaylistSections.first!.playlists.first!)
+        XCTAssertEqual(model.browsingLibraryPlaylist?.uri, playlist.uri)
+    }
+
+    func testDefaultPersonalAccountsConfiguresTobiasOnly() {
+        XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.userID), ["tobiasc91"])
+        XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.title), ["Mina spellistor"])
     }
 }

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -454,4 +454,25 @@ extension MusicViewModelTests {
         XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.userID), ["tobiasc91"])
         XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.title), ["Mina spellistor"])
     }
+
+    func testLoadLibrarySavedStatesResolvesPersonalSectionRows() async {
+        // A personal playlist saved in the huset library but not a favourite must
+        // still get its row star resolved, so it isn't shown empty until detail open.
+        let personal = playlistItem(uri: "spotify://playlist/p1", name: "Träning")
+        let stub = StubSpotifyPlaylistService(savedIDs: ["p1"], userPlaylistItems: ["tobiasc91": [personal]])
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        await model.refreshPersonalPlaylists()
+        XCTAssertTrue(model.librarySavedStateSignature.contains("spotify://playlist/p1"))
+        await model.loadLibrarySavedStates()
+        XCTAssertTrue(model.isSaved(personal))
+    }
+
+    func testLoadLibrarySavedStatesLeavesUnsavedPersonalRowUnmarked() async {
+        let personal = playlistItem(uri: "spotify://playlist/p9", name: "Inte sparad")
+        let stub = StubSpotifyPlaylistService(savedIDs: [], userPlaylistItems: ["tobiasc91": [personal]])
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        await model.refreshPersonalPlaylists()
+        await model.loadLibrarySavedStates()
+        XCTAssertFalse(model.isSaved(personal))
+    }
 }

--- a/IntelliNestTests/SpotifyApiServiceTests.swift
+++ b/IntelliNestTests/SpotifyApiServiceTests.swift
@@ -112,6 +112,57 @@ final class SpotifyApiServiceTests: XCTestCase {
         XCTAssertTrue(playlists.isEmpty)
     }
 
+    // MARK: - userPlaylists
+
+    func userPlaylistsURL(userID: String) -> URL {
+        spotifyURL(path: "/users/\(userID)/playlists", query: [URLQueryItem(name: "limit", value: "50")])
+    }
+
+    func testUserPlaylistsMapsOwnedAndFollowedItems() async {
+        // A public profile lists both owned playlists and ones it merely follows;
+        // there is no owner filtering, so both map through.
+        let json = """
+        {"items":[
+          {"id":"own1","name":"Träning","images":[{"url":"https://img/t.jpg"}],"owner":{"display_name":"tobiasc91"}},
+          {"id":"fol1","name":"Lugnt & skönt","images":[],"owner":{"display_name":"Spotify"}},
+          {"id":null,"name":"Trasig"}
+        ]}
+        """
+        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 200, json: json)
+        let playlists = await service.userPlaylists(userID: "tobiasc91")
+        XCTAssertEqual(playlists.map(\.name), ["Träning", "Lugnt & skönt"])
+        XCTAssertEqual(playlists.first?.uri, "spotify://playlist/own1")
+        XCTAssertEqual(playlists.first?.imageURL, "https://img/t.jpg")
+        XCTAssertEqual(playlists.last?.uri, "spotify://playlist/fol1")
+        XCTAssertTrue(playlists.allSatisfy { $0.mediaType == .playlist })
+    }
+
+    func testUserPlaylistsReturnsEmptyWhenNoPlaylists() async {
+        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 200, json: "{\"items\":[]}")
+        let playlists = await service.userPlaylists(userID: "tobiasc91")
+        XCTAssertTrue(playlists.isEmpty)
+    }
+
+    func testUserPlaylistsReturnsEmptyOnFailure() async {
+        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 404, json: "{}")
+        let playlists = await service.userPlaylists(userID: "tobiasc91")
+        XCTAssertTrue(playlists.isEmpty)
+    }
+
+    func testUserPlaylistsSendsBearerTokenToUserPath() async {
+        let expectation = XCTestExpectation(description: "GET user playlists with bearer token")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "GET",
+               request.url?.path == "/v1/users/tobiasc91/playlists",
+               request.value(forHTTPHeaderField: "Authorization") == "Bearer stub-access-token" {
+                expectation.fulfill()
+            }
+        }
+        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 200, json: "{\"items\":[]}")
+        _ = await service.userPlaylists(userID: "tobiasc91")
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+
     // MARK: - isPlaylistSaved
 
     func testIsPlaylistSavedReturnsTrueWhenFollowed() async {


### PR DESCRIPTION
## Summary
- Surfaces a configured personal Spotify account's **public** playlists (created + followed) as a "Mina spellistor"
  section directly below "Favoriter" in the music view, reusing the existing huset login (no second sign-in).
- Accounts are baked-in and ordered (`SpotifyPersonalAccount.configured`); only `tobiasc91` → "Mina spellistor" is
  configured now. Adding Sarah later is a one-line append; each account renders as its own titled section.
- Tapping a playlist reuses the existing detail flow (browse tracks, play on the group leader, star saves/removes in
  the huset library). No de-duplication with Favoriter; star state stays consistent via the shared mechanism.
- Refreshes on every music-view appearance and on Spotify login; the section is hidden entirely when the account has
  no public playlists, the fetch fails, or the user is logged out.

## Test plan
- New `userPlaylists(userID:)` on `SpotifyPlaylistService` + concrete/disabled/stub impls; unit-tested for success
  (owned + followed), empty, and HTTP failure.
- MusicViewModel tests: section appears when logged in with playlists, hidden when empty/failed/logged-out, ordering
  preserved, multiple-account structure (fake second account), and tap routes through the existing browse flow.
- Rebased onto current main (#131 music-queue/#132/#134); music test suite green locally (`** TEST SUCCEEDED **`).
- Linters clean (two pre-existing-style file-length warnings only).

Feature folder: ~/.claude/features/spotify-personal-playlists/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personal Spotify account playlists now display as dedicated library sections alongside your own playlists and favorites
  * Saved-state indicators now reflect whether tracks appear in your personal playlists

* **Tests**
  * Comprehensive test coverage added for personal account playlist rendering and saved-state synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->