### PR TITLE
Added error and warning log forwarding to Home Assistant

### DIFF
--- a/.claude/skills/read-logs/SKILL.md
+++ b/.claude/skills/read-logs/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: read-logs
+description: >-
+  Read IntelliNest's logs on this machine — the app's own os_log output (iOS Simulator or a
+  connected device) and the error/warning lines forwarded into Home Assistant. Use when asked to
+  read, tail, check, or grep the IntelliNest logs, or to debug what the running app logged.
+allowed-tools: Bash, Read
+---
+
+# Reading IntelliNest logs
+
+IntelliNest logs to two places. The app writes every `Log.info/error/warning/debug/verbose` call
+(`IntelliNest/Utils/Extensions/LogExtension.swift`) to Apple's unified logging system. Since the
+"Added error logs to Home Assistant" change, every **error** and **warning** is *also* forwarded to
+Home Assistant's system log via `system_log.create`, tagged with logger `intellinest`. So the app's
+own log is the full firehose; Home Assistant holds errors + warnings in one place alongside HA's
+own logs.
+
+Identifiers used below:
+
+- os_log **subsystem**: `se.laross.IntelliNest`  •  **category**: `App`
+- Home Assistant: `http://192.168.1.205:8123` (internal LAN URL)
+- Forwarded HA logger name: `intellinest`
+
+## 1. App logs from the iOS Simulator (most common on this Mac)
+
+Simulator logs flow into the host's unified log. Use `simctl` against the booted simulator.
+
+Live tail (all levels):
+
+```bash
+xcrun simctl spawn booted log stream \
+  --level debug \
+  --predicate 'subsystem == "se.laross.IntelliNest"'
+```
+
+Errors and warnings only (the formatter prefixes each line with `[ERROR]` / `[WARNING]`):
+
+```bash
+xcrun simctl spawn booted log stream \
+  --predicate 'subsystem == "se.laross.IntelliNest" && (eventMessage CONTAINS "[ERROR]" || eventMessage CONTAINS "[WARNING]")'
+```
+
+Recent history instead of a live tail (last hour, including info/debug):
+
+```bash
+xcrun simctl spawn booted log show \
+  --last 1h --info --debug \
+  --predicate 'subsystem == "se.laross.IntelliNest"'
+```
+
+If nothing appears, confirm a simulator is booted (`xcrun simctl list devices booted`) and the app
+has been launched so it has emitted at least one log line.
+
+## 2. App logs from a physical iPhone
+
+`simctl` only covers simulators. For a device plugged into this Mac:
+
+- **Console.app** — open Console, select the device in the sidebar, click Start, and filter on
+  `subsystem:se.laross.IntelliNest`. This is the simplest path for a real device.
+- It is not capturable from a plain `log stream` on the Mac (that streams the Mac's own log, not
+  the phone's).
+
+## 3. Errors + warnings inside Home Assistant
+
+These are the lines the app forwarded. Three ways to read them:
+
+- **HA UI** — Settings → System → Logs, then filter/search for `intellinest`.
+- **HA REST API** (scriptable, no UI). `GET /api/error_log` returns the whole log as plain text;
+  grep it for the forwarded lines. The bearer token is the same long-lived Home Assistant token the
+  app uses (kept in `IntelliNest-Info.xcconfig`, never committed — paste it inline, do not hardcode
+  it into any committed file):
+
+  ```bash
+  curl -s -H "Authorization: Bearer <HA_LONG_LIVED_TOKEN>" \
+    http://192.168.1.205:8123/api/error_log | grep -i intellinest
+  ```
+
+- **Log file on the HA host** — `/config/home-assistant.log` (via SSH or the Samba/File-editor
+  add-on), again grep for `intellinest`.
+
+## Reading the output
+
+Each app log line is formatted as:
+
+```
+[LEVEL] [optionalTag] File.swift:42 functionName(_:) - <user>: <message>
+```
+
+so you can grep by level (`[ERROR]`), by source file, or by the acting user. The HA-forwarded lines
+carry the identical text under the `intellinest` logger, which makes them easy to correlate with the
+on-device log when chasing the same incident.

--- a/IntelliNest/Navigation/Navigator.swift
+++ b/IntelliNest/Navigation/Navigator.swift
@@ -109,6 +109,14 @@ class Navigator: ObservableObject {
     init() {
         WidgetCenter.shared.reloadAllTimelines()
 
+        // Route the app's error/warning logs into Home Assistant's system log so they
+        // live alongside HA's own logs. Skipped under tests to avoid real network calls.
+        if NSClassFromString("XCTestCase") == nil {
+            Log.remoteReporter = { [weak self] level, message in
+                self?.restAPIService.reportToSystemLog(message: message, level: level)
+            }
+        }
+
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(registerAPNSToken(_:)),
                                                name: Notification.Name("UpdatedAPNSToken"),

--- a/IntelliNest/Services/RestAPIService.swift
+++ b/IntelliNest/Services/RestAPIService.swift
@@ -349,3 +349,47 @@ extension RestAPIService {
         }
     }
 }
+
+// MARK: - Remote logging
+
+extension RestAPIService {
+    /// Forwards a log line to Home Assistant's system log (`system_log.create`) so the
+    /// app's errors and warnings show up next to HA's own logs. Failures here are
+    /// swallowed on purpose: this runs from `Log.error`/`Log.warning`, so logging a
+    /// failure — or showing the error banner — would recurse or spam the user.
+    func reportToSystemLog(message: String, level: String) {
+        let json: [JSONKey: Any] = [
+            .message: message,
+            .level: level,
+            .logger: "intellinest"
+        ]
+        guard let jsonData = createJSONData(json: json) else { return }
+        let path = "/api/services/\(Domain.systemLog.rawValue)/\(Action.create.rawValue)"
+        Task {
+            await sendSystemLogRequest(path: path, jsonData: jsonData, forceExternalURL: false)
+        }
+    }
+
+    private func sendSystemLogRequest(path: String, jsonData: Data, forceExternalURL: Bool) async {
+        guard let request = createURLRequest(shouldForceExternalURL: forceExternalURL,
+                                             path: path,
+                                             jsonData: jsonData,
+                                             method: .post) else {
+            return
+        }
+
+        let statusCode: Int?
+        do {
+            let (_, response) = try await session.data(for: request)
+            statusCode = (response as? HTTPURLResponse)?.statusCode
+        } catch {
+            statusCode = nil
+        }
+
+        let succeeded = (statusCode ?? 500) < 300
+        let url = request.url?.absoluteString ?? ""
+        if !succeeded, !forceExternalURL, !url.contains(GlobalConstants.baseExternalUrlString) {
+            await sendSystemLogRequest(path: path, jsonData: jsonData, forceExternalURL: true)
+        }
+    }
+}

--- a/IntelliNest/Utils/Constants/Actions.swift
+++ b/IntelliNest/Utils/Constants/Actions.swift
@@ -56,4 +56,6 @@ enum Action: String, Codable {
     case browseMedia = "browse_media"
     case getLibrary = "get_library"
     case getQueue = "get_queue"
+    /* system_log */
+    case create
 }

--- a/IntelliNest/Utils/Constants/Domain.swift
+++ b/IntelliNest/Utils/Constants/Domain.swift
@@ -29,5 +29,6 @@ enum Domain: String, Encodable {
     case kiaUvo = "kia_uvo"
     case mediaPlayer = "media_player"
     case musicAssistant = "music_assistant"
+    case systemLog = "system_log"
     case unknown
 }

--- a/IntelliNest/Utils/Constants/JSONKey.swift
+++ b/IntelliNest/Utils/Constants/JSONKey.swift
@@ -63,4 +63,8 @@ enum JSONKey: String, Equatable, Codable, Hashable {
     case groupMembers = "group_members"
     case favorite
     case orderBy = "order_by"
+    /* system_log */
+    case message
+    case level
+    case logger
 }

--- a/IntelliNest/Utils/Extensions/LogExtension.swift
+++ b/IntelliNest/Utils/Extensions/LogExtension.swift
@@ -11,6 +11,19 @@ import OSLog
 enum Log {
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "IntelliNest", category: "App")
 
+    /// Forwards error and warning logs to Home Assistant so the app's logs live in the
+    /// same place as HA's own. Wired up by `Navigator` once `RestAPIService` exists; the
+    /// level is an HA `system_log` level string ("error"/"warning") and the message is the
+    /// same formatted line sent to os.log.
+    @MainActor
+    static var remoteReporter: ((_ level: String, _ message: String) -> Void)?
+
+    /// An identical message is only forwarded once per this window, so a failure that
+    /// recurs on every 5-second reload doesn't flood Home Assistant's log.
+    private static let remoteReportCooldown: TimeInterval = 60
+    @MainActor
+    private static var recentRemoteReports: [String: Date] = [:]
+
     @MainActor
     static var user: String {
         UserManager.currentUser.rawValue
@@ -78,6 +91,16 @@ enum Log {
             case .verbose: .debug
             }
         }
+
+        /// The matching Home Assistant `system_log` level, or nil for levels that are not
+        /// forwarded to HA (info/debug/verbose).
+        var homeAssistantLevel: String? {
+            switch self {
+            case .error: "error"
+            case .warning: "warning"
+            default: nil
+            }
+        }
     }
 
     private static func output(_ level: Level, _ message: String, tag: String?, source: Source) {
@@ -86,6 +109,35 @@ enum Log {
             let tagPart = tag.map { value in "[\(value)] " } ?? ""
             let formatted = "[\(level.rawValue)] \(tagPart)\(fileName):\(source.line) \(source.function) - \(user): \(message)"
             logger.log(level: level.osLogType, "\(formatted, privacy: .public)")
+            reportToHomeAssistantIfNeeded(level: level, formatted: formatted)
         }
+    }
+
+    @MainActor
+    private static func reportToHomeAssistantIfNeeded(level: Level, formatted: String) {
+        guard let homeAssistantLevel = level.homeAssistantLevel,
+              let remoteReporter,
+              shouldForwardRemotely(formatted) else {
+            return
+        }
+        remoteReporter(homeAssistantLevel, formatted)
+    }
+
+    @MainActor
+    private static func shouldForwardRemotely(_ message: String) -> Bool {
+        let now = Date()
+        recentRemoteReports = recentRemoteReports.filter { now.timeIntervalSince($0.value) < remoteReportCooldown }
+        if let lastSent = recentRemoteReports[message], now.timeIntervalSince(lastSent) < remoteReportCooldown {
+            return false
+        }
+        recentRemoteReports[message] = now
+        return true
+    }
+
+    /// Test seam: clears the remote reporter and dedupe cache between tests.
+    @MainActor
+    static func resetRemoteReporting() {
+        remoteReporter = nil
+        recentRemoteReports.removeAll()
     }
 }

--- a/IntelliNestTests/RestAPIServiceTests.swift
+++ b/IntelliNestTests/RestAPIServiceTests.swift
@@ -192,4 +192,135 @@ class RestAPIServiceTests: XCTestCase {
 
         XCTAssertEqual(statusCode, 500)
     }
+
+    // MARK: - System log reporting
+
+    private func stubInternalSystemLogURL() -> URL {
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/services/system_log/create"
+        let url = components.url!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(), response: response, error: nil)
+        return url
+    }
+
+    func testReportToSystemLog_postsMessageLevelAndLoggerToSystemLogCreate() async {
+        _ = stubInternalSystemLogURL()
+
+        let requestObserved = expectation(description: "system_log.create POST observed")
+        var capturedPath: String?
+        var capturedBody: [String: Any]?
+        URLProtocolStub.observerRequests { request in
+            guard request.httpMethod == "POST" else { return }
+            capturedPath = request.url?.path
+            if let body = request.httpBodyStreamData() ?? request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                capturedBody = json
+            }
+            requestObserved.fulfill()
+        }
+
+        restAPIService.reportToSystemLog(message: "Something broke", level: "error")
+
+        await fulfillment(of: [requestObserved], timeout: 2)
+        XCTAssertEqual(capturedPath, "/api/services/system_log/create")
+        XCTAssertEqual(capturedBody?["message"] as? String, "Something broke")
+        XCTAssertEqual(capturedBody?["level"] as? String, "error")
+        XCTAssertEqual(capturedBody?["logger"] as? String, "intellinest")
+    }
+
+    func testReportToSystemLog_fallsBackToExternalURLWhenLocalFails() async {
+        // Local URL has no stub — only external is reachable.
+        var components = URLComponents(string: GlobalConstants.baseExternalUrlString)!
+        components.path = "/api/services/system_log/create"
+        let externalURL = components.url!
+        let response = HTTPURLResponse(url: externalURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: externalURL, data: Data(), response: response, error: nil)
+
+        let externalObserved = expectation(description: "external system_log.create POST observed")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST",
+               request.url?.absoluteString.contains(GlobalConstants.baseExternalUrlString) == true {
+                externalObserved.fulfill()
+            }
+        }
+
+        restAPIService.reportToSystemLog(message: "Fallback please", level: "warning")
+
+        await fulfillment(of: [externalObserved], timeout: 2)
+    }
+
+    // MARK: - Log → Home Assistant forwarding
+
+    /// Emitted from a single call site so repeated calls produce an identical formatted
+    /// line, which is what the dedupe cache keys on.
+    private func emitDuplicateError() {
+        Log.error("Recurring failure")
+    }
+
+    func testLogError_isForwardedToReporter() async {
+        Log.resetRemoteReporting()
+        defer { Log.resetRemoteReporting() }
+
+        let forwarded = expectation(description: "error forwarded")
+        var capturedLevel: String?
+        Log.remoteReporter = { level, _ in
+            capturedLevel = level
+            forwarded.fulfill()
+        }
+
+        Log.error("Boom")
+
+        await fulfillment(of: [forwarded], timeout: 2)
+        XCTAssertEqual(capturedLevel, "error")
+    }
+
+    func testLogInfo_isNotForwardedToReporter() async {
+        Log.resetRemoteReporting()
+        defer { Log.resetRemoteReporting() }
+
+        var forwardCount = 0
+        Log.remoteReporter = { _, _ in forwardCount += 1 }
+
+        Log.info("Just info")
+        // Let the @MainActor logging Task drain.
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(forwardCount, 0, "info-level logs must not be forwarded to Home Assistant")
+    }
+
+    func testLogError_duplicateWithinCooldownIsForwardedOnce() async {
+        Log.resetRemoteReporting()
+        defer { Log.resetRemoteReporting() }
+
+        var forwardCount = 0
+        Log.remoteReporter = { _, _ in forwardCount += 1 }
+
+        emitDuplicateError()
+        emitDuplicateError()
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(forwardCount, 1, "an identical log must only reach Home Assistant once per cooldown")
+    }
+}
+
+private extension URLRequest {
+    /// `URLProtocol` strips `httpBody` into a stream for POSTs, so read it back out.
+    func httpBodyStreamData() -> Data? {
+        guard let stream = httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data.isEmpty ? nil : data
+    }
 }


### PR DESCRIPTION
## What

Routes the app's `Log.error` and `Log.warning` output into Home Assistant's system log
(`system_log.create`, tagged `logger=intellinest`) so the iOS app's failures sit alongside
HA's own logs — all logs in one place.

## How

- `Log.remoteReporter` hook in `LogExtension.swift` — fires for error/warning only (info/debug/
  verbose are not forwarded), with a 60s dedupe so a failure that recurs on the 5s reload loop
  doesn't flood HA's log.
- `RestAPIService.reportToSystemLog(message:level:)` POSTs to `system_log.create` with the same
  internal→external URL fallback as other calls. Its own failures are swallowed (no `Log`, no error
  banner) to avoid recursing back through `Log.error`.
- `Navigator.init` wires the reporter to `RestAPIService`, skipped under XCTest.
- New `Domain.systemLog`, `Action.create`, and `JSONKey.message/level/logger`.

## Reading the logs

Added a `/read-logs` project skill documenting how to read both log sources on this machine —
the app's os_log (Simulator via `simctl`, device via Console.app) and the HA-forwarded
errors/warnings (HA UI or `GET /api/error_log`).

## Tests

`RestAPIServiceTests` covers the `system_log.create` POST (path + message/level/logger body),
the external-URL fallback, and the `Log` → reporter path (error forwarded, info not forwarded,
duplicate forwarded once). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)