### PR TITLE
Fixed playlist favourite star state

### DIFF
--- a/IntelliNest/Services/SpotifyApiService.swift
+++ b/IntelliNest/Services/SpotifyApiService.swift
@@ -301,16 +301,20 @@ private struct SpotifyUser: Decodable {
 /// app's `MusicSearchItem`. The Spotify `id` is rewritten into the `spotify://`
 /// uri form Music Assistant expects for playback.
 private struct SpotifyPlaylistPage: Decodable {
-    let items: [SpotifyPlaylistItem]
+    // Spotify occasionally returns `null` entries in a playlist page's `items`
+    // array (e.g. an unavailable playlist on a large public profile). Decoding the
+    // element as optional lets a `null` map to nil instead of throwing and losing
+    // the whole page — which would otherwise leave a populated profile empty.
+    let items: [SpotifyPlaylistItem?]
 
     var playlists: [MusicSearchItem] {
-        items.compactMap(\.searchItem)
+        items.compactMap { $0?.searchItem }
     }
 
     /// The ids of playlists the signed-in user may edit: ones they own, plus any
     /// collaborative playlist regardless of owner.
     func editableIDs(currentUserID: String) -> Set<String> {
-        Set(items.compactMap { $0.editableID(currentUserID: currentUserID) })
+        Set(items.compactMap { $0?.editableID(currentUserID: currentUserID) })
     }
 }
 

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -267,17 +267,32 @@ extension MusicViewModel {
 
     // MARK: - Spotify favourite
 
-    /// Whether to show the favourite star for this playlist. Only true when logged
-    /// in (so the star never appears unless tapping it actually saves) and the
-    /// playlist resolves to a Spotify id — directly or via the account match.
-    /// Built-ins, non-account playlists, and the logged-out state get no star.
+    /// Whether to show the favourite star for this playlist: it resolves to a
+    /// Spotify id, directly or via the account match. The star shows even when
+    /// logged out for a directly-resolvable `spotify://` playlist (a search
+    /// result) — tapping it logs in first, then saves — so there's an affordance
+    /// instead of a blank toolbar. Built-ins and non-account `library://` items
+    /// still get no star (they only resolve via the logged-in account match).
     func isSpotifyPlaylist(_ playlist: MusicSearchItem) -> Bool {
-        isSpotifyAuthorized && spotifyPlaylistID(for: playlist) != nil
+        spotifyPlaylistID(for: playlist) != nil
     }
 
     /// Whether the playlist is currently marked saved (drives the filled star).
+    /// Resolved by Spotify id, not uri, so the same playlist reads identically
+    /// whether it came in as a `spotify://` favourite or a `library://` recent.
     func isSaved(_ playlist: MusicSearchItem) -> Bool {
-        savedPlaylistURIs.contains(playlist.uri)
+        guard let id = spotifyPlaylistID(for: playlist) else {
+            return false
+        }
+        return savedPlaylistIDs.contains(id)
+    }
+
+    /// The Spotify ids of every playlist currently in the account library (the
+    /// favourites section). Library membership — not Spotify's follow-contains
+    /// check, which returns false for playlists the account owns — is the source
+    /// of truth for whether a playlist is saved.
+    var libraryPlaylistIDs: Set<String> {
+        Set(favoritePlaylists.compactMap { spotifyPlaylistID(for: $0) })
     }
 
     /// Resolves the Spotify playlist id for a playlist. A `spotify://playlist/<id>`
@@ -308,11 +323,19 @@ extension MusicViewModel {
         name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
-    /// Reads the live Spotify saved-state when the playlist detail appears, so the
-    /// star reflects reality. Skipped (and silent) for non-Spotify playlists or
-    /// when the user hasn't logged in yet — the star only loads after first login.
+    /// Reads the saved-state when the playlist detail appears, so the star
+    /// reflects reality. Skipped (and silent) for non-Spotify playlists or when
+    /// the user hasn't logged in yet — the star only loads after first login. A
+    /// playlist already in the account library is saved by definition: Spotify's
+    /// follow-contains check returns false for playlists the account *owns*, so
+    /// trust library membership first and only query the API for playlists
+    /// outside the library (e.g. someone else's playlist opened from search).
     func loadSavedState(for playlist: MusicSearchItem) async {
         guard let playlistID = spotifyPlaylistID(for: playlist), spotify.isAuthorized else {
+            return
+        }
+        if libraryPlaylistIDs.contains(playlistID) {
+            savedPlaylistIDs.insert(playlistID)
             return
         }
         await setSaved(spotify.isPlaylistSaved(playlistID: playlistID), for: playlist)
@@ -352,10 +375,13 @@ extension MusicViewModel {
     }
 
     func setSaved(_ saved: Bool, for playlist: MusicSearchItem) {
+        guard let id = spotifyPlaylistID(for: playlist) else {
+            return
+        }
         if saved {
-            savedPlaylistURIs.insert(playlist.uri)
+            savedPlaylistIDs.insert(id)
         } else {
-            savedPlaylistURIs.remove(playlist.uri)
+            savedPlaylistIDs.remove(id)
         }
     }
 

--- a/IntelliNest/ViewModels/MusicViewModel+SpotifyTracks.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+SpotifyTracks.swift
@@ -88,18 +88,15 @@ extension MusicViewModel {
             + personalPlaylistSections.flatMap { $0.playlists.map(\.uri) }).joined(separator: "|")
     }
 
-    /// Populates the saved-state for the library rows. Favourites are in the
-    /// Spotify library by definition, so they are marked saved without a call;
-    /// recently-played and personal-account playlists are queried so their star
-    /// reflects reality even when they are not also favourites.
+    /// Populates the saved-state for the library rows. The favourites section is
+    /// the account library, so every id in it is saved by definition — start from
+    /// that set (resetting so an un-favourited playlist still shown elsewhere drops
+    /// its star). Recently-played and personal-account playlists not already in the
+    /// library are then queried so their star reflects reality even when they are
+    /// not favourites.
     func loadLibrarySavedStates() async {
-        for playlist in favoritePlaylists {
-            setSaved(true, for: playlist)
-        }
-        for playlist in recentlyPlayedPlaylists {
-            await loadSavedState(for: playlist)
-        }
-        for playlist in personalPlaylistSections.flatMap(\.playlists) {
+        savedPlaylistIDs = libraryPlaylistIDs
+        for playlist in recentlyPlayedPlaylists + personalPlaylistSections.flatMap(\.playlists) {
             await loadSavedState(for: playlist)
         }
     }

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -52,9 +52,11 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// A library playlist the user opened to browse from the main view (favourites
     /// or recents), presented in its own sheet. Nil when no browse sheet is shown.
     @Published var browsingLibraryPlaylist: MusicSearchItem?
-    /// URIs of playlists currently saved in the user's Spotify library, driving the
-    /// star toggle in the playlist detail view. Populated on demand per playlist.
-    @Published var savedPlaylistURIs: Set<String> = []
+    /// Spotify ids of playlists currently saved in the user's Spotify library,
+    /// driving the favourite star everywhere a playlist is shown. Keyed by
+    /// resolved Spotify id rather than uri so the same playlist reads the same
+    /// whether it arrived as a `spotify://` favourite or a `library://` recent.
+    @Published var savedPlaylistIDs: Set<String> = []
     /// Whether the user is logged into Spotify. Drives the login warning triangle
     /// and its prompt — shown only while logged out.
     @Published var isSpotifyAuthorized = false

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -155,7 +155,7 @@ extension MusicViewModelTests {
         ["tobiasc91": [playlistItem(uri: "spotify://playlist/p1", name: "Träning")]]
     }
 
-    func testIsSpotifyPlaylistRequiresLoginAndResolvableUri() {
+    func testIsSpotifyPlaylistShowsStarForResolvableUriEvenLoggedOut() {
         let spotifyItem = spotifyPlaylist()
         let localItem = MusicSearchItem(uri: "library://playlist/3", name: "Lokal",
                                         mediaType: .playlist, imageURL: nil, artist: nil)
@@ -163,10 +163,13 @@ extension MusicViewModelTests {
         let loggedIn = makeViewModel(spotify: StubSpotifyPlaylistService(authorized: true))
         XCTAssertTrue(loggedIn.isSpotifyPlaylist(spotifyItem))
         XCTAssertFalse(loggedIn.isSpotifyPlaylist(localItem))
-        // Logged out: no star at all, even on a Spotify playlist — tapping it
-        // couldn't save without logging in first.
+        // Logged out: a directly-resolvable Spotify playlist (a search result) still
+        // shows the star — tapping it logs in first, then saves — but an unmatched
+        // library item has no Spotify id to resolve (the account list is empty), so
+        // it stays starless.
         let loggedOut = makeViewModel(spotify: StubSpotifyPlaylistService(authorized: false))
-        XCTAssertFalse(loggedOut.isSpotifyPlaylist(spotifyItem))
+        XCTAssertTrue(loggedOut.isSpotifyPlaylist(spotifyItem))
+        XCTAssertFalse(loggedOut.isSpotifyPlaylist(localItem))
     }
 
     func testLibraryPlaylistResolvesToSpotifyByName() async {
@@ -254,7 +257,7 @@ extension MusicViewModelTests {
                                         mediaType: .playlist, imageURL: nil, artist: nil)
         await model.toggleSpotifySaved(localItem)
         XCTAssertEqual(stub.saveCallCount, 0)
-        XCTAssertTrue(model.savedPlaylistURIs.isEmpty)
+        XCTAssertTrue(model.savedPlaylistIDs.isEmpty)
     }
 
     func testSpotifyAccountPlaylistsLoadIntoFavoritesOnReload() async {
@@ -475,5 +478,39 @@ extension MusicViewModelTests {
         await model.refreshPersonalPlaylists()
         await model.loadLibrarySavedStates()
         XCTAssertFalse(model.isSaved(personal))
+    }
+
+    // A playlist the account *owns* isn't "followed", so Spotify's follow-contains
+    // check (`savedIDs` here) returns false for it. Library membership, not that
+    // check, must decide the star — otherwise the same owned playlist shows filled
+    // under Favoriter but hollow under Senast spelade.
+    func testOwnedFavouriteShowsSavedInBothFavouritesAndRecents() async {
+        let name = "Låtar som är ganska sköna och avslappnande"
+        let owned = MusicSearchItem(uri: "spotify://playlist/owned1", name: name,
+                                    mediaType: .playlist, imageURL: nil, artist: "huset")
+        // savedIDs empty → the follow-contains check would say "not saved".
+        let stub = StubSpotifyPlaylistService(savedIDs: [], accountPlaylistItems: [owned])
+        let model = makeViewModel(spotify: stub)
+        await model.refreshSpotifyPlaylists()
+        // The same playlist surfaces in Senast spelade as an opaque library:// item.
+        let recent = MusicSearchItem(uri: "library://playlist/42", name: name,
+                                     mediaType: .playlist, imageURL: nil, artist: nil)
+        model.recentlyPlayedPlaylists = [recent]
+        await model.loadLibrarySavedStates()
+        XCTAssertTrue(model.isSaved(owned))
+        XCTAssertTrue(model.isSaved(recent))
+    }
+
+    // Opening an owned favourite's detail must not un-mark it: the follow-contains
+    // check returns false, but library membership keeps the star filled (the popup
+    // no longer drops the playlist to non-favourite on dismiss).
+    func testOpeningOwnedFavouriteDetailKeepsItSaved() async {
+        let owned = MusicSearchItem(uri: "spotify://playlist/owned1", name: "Min egen lista",
+                                    mediaType: .playlist, imageURL: nil, artist: "huset")
+        let stub = StubSpotifyPlaylistService(savedIDs: [], accountPlaylistItems: [owned])
+        let model = makeViewModel(spotify: stub)
+        await model.refreshSpotifyPlaylists()
+        await model.loadSavedState(for: owned)
+        XCTAssertTrue(model.isSaved(owned))
     }
 }

--- a/IntelliNestTests/SpotifyApiServiceTests.swift
+++ b/IntelliNestTests/SpotifyApiServiceTests.swift
@@ -137,6 +137,21 @@ final class SpotifyApiServiceTests: XCTestCase {
         XCTAssertTrue(playlists.allSatisfy { $0.mediaType == .playlist })
     }
 
+    func testUserPlaylistsToleratesNullArrayEntries() async {
+        // Spotify can return a bare `null` element in `items` for an unavailable
+        // playlist; it must be skipped, not throw away the whole (populated) page.
+        let json = """
+        {"items":[
+          null,
+          {"id":"own1","name":"Träning","images":[],"owner":{"display_name":"tobiasc91"}},
+          null
+        ]}
+        """
+        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 200, json: json)
+        let playlists = await service.userPlaylists(userID: "tobiasc91")
+        XCTAssertEqual(playlists.map(\.name), ["Träning"])
+    }
+
     func testUserPlaylistsReturnsEmptyWhenNoPlaylists() async {
         stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 200, json: "{\"items\":[]}")
         let playlists = await service.userPlaylists(userID: "tobiasc91")


### PR DESCRIPTION
## Why

Several favourite-star issues surfaced in the music view:

1. **Star not matching across sections.** The same playlist showed a filled ⭐ under *Favoriter* but a hollow one
   under *Senast spelade*. Saved-state was keyed by raw URI, but the same playlist arrives with different URIs in
   each section (`spotify://playlist/X` vs `library://playlist/N`). Worse, the recents/detail path asked Spotify
   *"do you follow this?"* via `/playlists/{id}/followers/contains`, which returns **false for playlists the account
   owns** — so an owned favourite read as not-saved.

2. **Opening an owned favourite un-favourited it.** Tapping a favourite opened the detail with a non-yellow star and,
   on dismiss, dropped the playlist to non-favourite in the list — same follow-check root cause.

3. **No way to favourite from a search result while logged out.** The toolbar star was gated behind being logged in,
   so a logged-out user searching Spotify got a blank toolbar with no affordance.

## What changed

- Saved-state is now keyed by **resolved Spotify id** instead of URI, so the same playlist reads identically
  whether it came in as a `spotify://` favourite or a `library://` recent (`savedPlaylistURIs` → `savedPlaylistIDs`).
- **Library membership is the source of truth** for "saved" (the *Favoriter* list is the account library). The
  follow-contains API is only consulted for playlists outside the library (e.g. someone else's playlist opened from
  search), where it's meaningful. New `libraryPlaylistIDs` helper.
- The favourite star now shows for any directly-resolvable `spotify://` playlist **even when logged out**; tapping it
  logs in first, then saves (`toggleSpotifySaved` already handled login-on-tap).
- **Hardened Spotify playlist-page decoding** to tolerate `null` entries in the `items` array. Spotify can return a
  bare `null` element for an unavailable playlist on a large public profile; the old non-optional array element threw
  away the whole page, which could leave a populated "Mina spellistor" section empty.

## Tests

- Updated the logged-out expectation and the `savedPlaylistIDs` rename.
- Added `testOwnedFavouriteShowsSavedInBothFavouritesAndRecents` and `testOpeningOwnedFavouriteDetailKeepsItSaved`
  covering the owned-playlist mismatch.
- Added `testUserPlaylistsToleratesNullArrayEntries` for the null-element decode.
- `MusicViewModelTests` and `SpotifyApiServiceTests` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability when Spotify returns incomplete playlist data.
  * Fixed inconsistent saved status across favorites and recent playlists.
  * Owned playlists now maintain their saved status when opening details.

* **Improvements**
  * Spotify playlist information displays for recognized playlists even when logged out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->