### PR TITLE
Logged Spotify playlist fetch failures and empty results

### DIFF
--- a/IntelliNest/Services/SpotifyApiService.swift
+++ b/IntelliNest/Services/SpotifyApiService.swift
@@ -93,6 +93,7 @@ final class SpotifyApiService: SpotifyPlaylistService {
                                                       queryItems: [URLQueryItem(name: "limit", value: "50")])
             let (data, response) = try await session.data(for: request)
             guard isSuccess(response) else {
+                Log.error("Spotify accountPlaylists failed: \(httpFailureDescription(response, data))")
                 return []
             }
             return try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data).playlists
@@ -112,9 +113,17 @@ final class SpotifyApiService: SpotifyPlaylistService {
                                                       queryItems: [URLQueryItem(name: "limit", value: "50")])
             let (data, response) = try await session.data(for: request)
             guard isSuccess(response) else {
+                Log.error("Spotify userPlaylists(\(userID)) failed: \(httpFailureDescription(response, data))")
                 return []
             }
-            return try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data).playlists
+            let playlists = try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data).playlists
+            if playlists.isEmpty {
+                // A configured personal account is expected to have public playlists;
+                // a 200-but-empty result is the anomaly to capture (distinguishes a
+                // genuine empty/filtered profile from an HTTP error logged above).
+                Log.warning("Spotify userPlaylists(\(userID)) returned 0 playlists (HTTP 200): \(bodySnippet(data))")
+            }
+            return playlists
         } catch {
             Log.error("Spotify userPlaylists(\(userID)) failed: \(error)")
             return []
@@ -290,6 +299,22 @@ final class SpotifyApiService: SpotifyPlaylistService {
 
     private func isSuccess(_ response: URLResponse) -> Bool {
         (response as? HTTPURLResponse).map { (200 ... 299).contains($0.statusCode) } ?? false
+    }
+
+    /// A compact "HTTP <code>: <body>" description for a failed response, used to
+    /// surface *why* a request was rejected. The body is Spotify's JSON error
+    /// envelope (e.g. `{"error":{"status":403,"message":"…"}}`); it's truncated so
+    /// a forwarded log line stays short. Callers swallow non-2xx responses and
+    /// return empty, so without this the failure would be invisible.
+    private func httpFailureDescription(_ response: URLResponse, _ data: Data) -> String {
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        let body = bodySnippet(data)
+        return body.isEmpty ? "HTTP \(status)" : "HTTP \(status): \(body)"
+    }
+
+    /// The leading slice of a response body, for diagnostic log lines.
+    private func bodySnippet(_ data: Data) -> String {
+        String(decoding: data.prefix(300), as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 


### PR DESCRIPTION
## Why

On the latest build "Mina spellistor" (the personal-account playlist section) is empty even though the configured
account `tobiasc91` has 29 public playlists — and **nothing is logged**, so the cause is invisible. The reason it's
invisible: `accountPlaylists` and `userPlaylists` swallow a non-2xx Spotify response via
`guard isSuccess(response) else { return [] }` with no log. Only a decode/transport *throw* hits the `catch`.

So a `401/403/404/429` from `/users/tobiasc91/playlists` — or a `200` with an empty/filtered body — both surface as
an empty section with zero diagnostics.

## What changed

Purely diagnostic (no behaviour change — still returns `[]` on failure):

- **non-2xx** now logs `Spotify userPlaylists(<id>) failed: HTTP <code>: <body>` (and the same for
  `accountPlaylists`). The body is Spotify's JSON error envelope, truncated to 300 chars.
- **`200` with zero playlists** logs `Spotify userPlaylists(<id>) returned 0 playlists (HTTP 200): <body>` — a
  configured personal account is expected to have public playlists, so an empty result is the anomaly worth
  capturing. This distinguishes a genuine empty/filtered profile from an HTTP error in a single build.

These forward to Home Assistant's `system_log` (errors + warnings), so the next time the music view is opened the HA
log will name the exact cause and the real fix can follow.

## Tests

`SpotifyApiServiceTests` green (12/12). Behaviour is unchanged — the existing empty/failure cases still assert `[]`;
the additions are log lines only, which have no test seam without refactoring `Log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics for Spotify playlist retrieval with detailed logging when requests encounter issues
  * Enhanced handling of edge cases, including detection and logging when playlist results are unexpectedly empty despite successful server responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->