### PR TITLE
Added Sarah's personal Spotify playlist section

### DIFF
--- a/IntelliNest/Services/SpotifyApiService.swift
+++ b/IntelliNest/Services/SpotifyApiService.swift
@@ -19,9 +19,9 @@ struct SpotifyPersonalAccount: Identifiable, Equatable {
     var id: String { userID }
 
     /// The ordered list of personal accounts. Sections render in this order.
-    /// Only Tobias is configured now; Sarah is appended here once her id is known.
     static let configured: [SpotifyPersonalAccount] = [
-        SpotifyPersonalAccount(userID: "tobiasc91", title: "Mina spellistor")
+        SpotifyPersonalAccount(userID: "tobiasc91", title: "Mina spellistor"),
+        SpotifyPersonalAccount(userID: "mbostroem", title: "Sarahs spellistor")
     ]
 }
 

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -454,9 +454,9 @@ extension MusicViewModelTests {
         XCTAssertEqual(model.browsingLibraryPlaylist?.uri, playlist.uri)
     }
 
-    func testDefaultPersonalAccountsConfiguresTobiasOnly() {
-        XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.userID), ["tobiasc91"])
-        XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.title), ["Mina spellistor"])
+    func testDefaultPersonalAccountsConfiguresTobiasThenSarah() {
+        XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.userID), ["tobiasc91", "mbostroem"])
+        XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.title), ["Mina spellistor", "Sarahs spellistor"])
     }
 
     func testLoadLibrarySavedStatesResolvesPersonalSectionRows() async {


### PR DESCRIPTION
## What

Adds Sarah's Spotify account (`mbostroem`, 8 public playlists) as a second personal-account section, titled
**"Sarahs spellistor"**, rendered below "Mina spellistor" in the music view. Follow-up to #135, which left the
account list ready for a second entry once her user id was known.

```swift
static let configured: [SpotifyPersonalAccount] = [
    SpotifyPersonalAccount(userID: "tobiasc91", title: "Mina spellistor"),
    SpotifyPersonalAccount(userID: "mbostroem", title: "Sarahs spellistor")
]
```

No new logic — the multi-account ordering, hide-when-empty, and browse flow already existed and are covered by
`MusicViewModelSpotifyTests`. The config-assertion test was updated to expect both accounts in order.

## Note

Personal sections currently render empty on-device (see #138, which adds logging to diagnose why `userPlaylists`
returns empty). Sarah's section will populate once that root cause is fixed; this PR just registers the account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)