### PR TITLE
Fixed log forwarding to use system_log.write service

### DIFF
--- a/.claude/skills/read-logs/SKILL.md
+++ b/.claude/skills/read-logs/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Bash, Read
 IntelliNest logs to two places. The app writes every `Log.info/error/warning/debug/verbose` call
 (`IntelliNest/Utils/Extensions/LogExtension.swift`) to Apple's unified logging system. Since the
 "Added error logs to Home Assistant" change, every **error** and **warning** is *also* forwarded to
-Home Assistant's system log via `system_log.create`, tagged with logger `intellinest`. So the app's
+Home Assistant's system log via `system_log.write`, tagged with logger `intellinest`. So the app's
 own log is the full firehose; Home Assistant holds errors + warnings in one place alongside HA's
 own logs.
 

--- a/IntelliNest/Services/RestAPIService.swift
+++ b/IntelliNest/Services/RestAPIService.swift
@@ -353,7 +353,7 @@ extension RestAPIService {
 // MARK: - Remote logging
 
 extension RestAPIService {
-    /// Forwards a log line to Home Assistant's system log (`system_log.create`) so the
+    /// Forwards a log line to Home Assistant's system log (`system_log.write`) so the
     /// app's errors and warnings show up next to HA's own logs. Failures here are
     /// swallowed on purpose: this runs from `Log.error`/`Log.warning`, so logging a
     /// failure — or showing the error banner — would recurse or spam the user.
@@ -364,7 +364,7 @@ extension RestAPIService {
             .logger: "intellinest"
         ]
         guard let jsonData = createJSONData(json: json) else { return }
-        let path = "/api/services/\(Domain.systemLog.rawValue)/\(Action.create.rawValue)"
+        let path = "/api/services/\(Domain.systemLog.rawValue)/\(Action.write.rawValue)"
         Task {
             await sendSystemLogRequest(path: path, jsonData: jsonData, forceExternalURL: false)
         }

--- a/IntelliNest/Utils/Constants/Actions.swift
+++ b/IntelliNest/Utils/Constants/Actions.swift
@@ -57,5 +57,5 @@ enum Action: String, Codable {
     case getLibrary = "get_library"
     case getQueue = "get_queue"
     /* system_log */
-    case create
+    case write
 }

--- a/IntelliNestTests/RestAPIServiceTests.swift
+++ b/IntelliNestTests/RestAPIServiceTests.swift
@@ -197,17 +197,17 @@ class RestAPIServiceTests: XCTestCase {
 
     private func stubInternalSystemLogURL() -> URL {
         var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
-        components.path = "/api/services/system_log/create"
+        components.path = "/api/services/system_log/write"
         let url = components.url!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
         URLProtocolStub.setStub(for: url, data: Data(), response: response, error: nil)
         return url
     }
 
-    func testReportToSystemLog_postsMessageLevelAndLoggerToSystemLogCreate() async {
+    func testReportToSystemLog_postsMessageLevelAndLoggerToSystemLogWrite() async {
         _ = stubInternalSystemLogURL()
 
-        let requestObserved = expectation(description: "system_log.create POST observed")
+        let requestObserved = expectation(description: "system_log.write POST observed")
         var capturedPath: String?
         var capturedBody: [String: Any]?
         URLProtocolStub.observerRequests { request in
@@ -223,7 +223,7 @@ class RestAPIServiceTests: XCTestCase {
         restAPIService.reportToSystemLog(message: "Something broke", level: "error")
 
         await fulfillment(of: [requestObserved], timeout: 2)
-        XCTAssertEqual(capturedPath, "/api/services/system_log/create")
+        XCTAssertEqual(capturedPath, "/api/services/system_log/write")
         XCTAssertEqual(capturedBody?["message"] as? String, "Something broke")
         XCTAssertEqual(capturedBody?["level"] as? String, "error")
         XCTAssertEqual(capturedBody?["logger"] as? String, "intellinest")
@@ -232,12 +232,12 @@ class RestAPIServiceTests: XCTestCase {
     func testReportToSystemLog_fallsBackToExternalURLWhenLocalFails() async {
         // Local URL has no stub — only external is reachable.
         var components = URLComponents(string: GlobalConstants.baseExternalUrlString)!
-        components.path = "/api/services/system_log/create"
+        components.path = "/api/services/system_log/write"
         let externalURL = components.url!
         let response = HTTPURLResponse(url: externalURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
         URLProtocolStub.setStub(for: externalURL, data: Data(), response: response, error: nil)
 
-        let externalObserved = expectation(description: "external system_log.create POST observed")
+        let externalObserved = expectation(description: "external system_log.write POST observed")
         URLProtocolStub.observerRequests { request in
             if request.httpMethod == "POST",
                request.url?.absoluteString.contains(GlobalConstants.baseExternalUrlString) == true {


### PR DESCRIPTION
## Why

App error/warning forwarding to Home Assistant has never worked. The forwarder calls
`system_log.create`, but **HA has no such service** — the `system_log` integration exposes only
`write` and `clear`. So every forwarded log got a silent **HTTP 400** from HA (failures in
`reportToSystemLog` are swallowed by design to avoid recursion), and the app's logger `intellinest`
never appeared in HA's system log.

Verified directly against the live HA: `POST /api/services/system_log/create` → 400;
`POST /api/services/system_log/write` (same `{message, level, logger}` body) → 200, and the entry
shows up under logger `intellinest`.

This also explains why the #138 Spotify diagnostics never surfaced — they *were* firing, but the
forward to HA was 400ing.

## What changed

- `Action.create` → `write` (the case is used only for this forwarding call).
- `reportToSystemLog` now posts to `/api/services/system_log/write`.
- Updated `RestAPIServiceTests` — the existing tests had hard-coded the wrong
  `/api/services/system_log/create` path, which is exactly why CI never caught the bug.
- Corrected the `read-logs` skill doc reference (`system_log.create` → `system_log.write`).

## Tests

`RestAPIServiceTests` green (`** TEST SUCCEEDED **`), now asserting the `system_log/write` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated system log forwarding to Home Assistant to use the correct service endpoint for error and warning messages.

* **Documentation**
  * Updated skill documentation to accurately reflect how app errors and warnings are forwarded to Home Assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->