### PR TITLE
Sourced personal playlist sections from the account library by owner

### DIFF
--- a/IntelliNest/Model/MusicSearchResult.swift
+++ b/IntelliNest/Model/MusicSearchResult.swift
@@ -37,6 +37,24 @@ struct MusicSearchItem: Identifiable, Equatable, Hashable {
     let mediaType: MusicMediaType
     let imageURL: String?
     let artist: String?
+    /// The Spotify user id of the playlist's owner, when known (set for account
+    /// library playlists). Used to split the huset library into per-person
+    /// sections; nil for search results and non-playlist items.
+    let ownerID: String?
+
+    init(uri: String,
+         name: String,
+         mediaType: MusicMediaType,
+         imageURL: String?,
+         artist: String?,
+         ownerID: String? = nil) {
+        self.uri = uri
+        self.name = name
+        self.mediaType = mediaType
+        self.imageURL = imageURL
+        self.artist = artist
+        self.ownerID = ownerID
+    }
 
     var id: String { uri }
 }

--- a/IntelliNest/Services/SpotifyApiService.swift
+++ b/IntelliNest/Services/SpotifyApiService.swift
@@ -34,14 +34,13 @@ protocol SpotifyPlaylistService {
     var isAuthorized: Bool { get }
     /// Runs the interactive Spotify login.
     func authorize() async throws
-    /// The playlists in the signed-in account's library (owned + followed).
+    /// The playlists in the signed-in account's library (owned + followed), across
+    /// all pages. Each item carries its `ownerID` so the library can be split into
+    /// per-person sections.
     func accountPlaylists() async -> [MusicSearchItem]
     /// The Spotify ids of the playlists the user can edit (owned or collaborative).
     /// Used to gate the add-to-playlist picker and the remove-from-playlist action.
     func editablePlaylistIDs() async -> Set<String>
-    /// The public playlists on another Spotify user's profile (created + followed).
-    /// Reuses the signed-in account's token; only public playlists are visible.
-    func userPlaylists(userID: String) async -> [MusicSearchItem]
     /// Whether the playlist is currently in the user's Spotify library.
     func isPlaylistSaved(playlistID: String) async -> Bool
     /// Adds the playlist to the user's Spotify library. Returns success.
@@ -85,49 +84,42 @@ final class SpotifyApiService: SpotifyPlaylistService {
     }
 
     func accountPlaylists() async -> [MusicSearchItem] {
-        do {
-            // 50 is the API's per-page max; plenty for a personal library and keeps
-            // it to a single request (no pagination needed here).
-            let request = try await authorizedRequest(path: "/me/playlists",
-                                                      method: "GET",
-                                                      queryItems: [URLQueryItem(name: "limit", value: "50")])
-            let (data, response) = try await session.data(for: request)
-            guard isSuccess(response) else {
-                Log.error("Spotify accountPlaylists failed: \(httpFailureDescription(response, data))")
-                return []
-            }
-            return try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data).playlists
-        } catch {
-            Log.error("Spotify accountPlaylists failed: \(error)")
-            return []
-        }
+        await fetchAllLibraryPlaylistItems().compactMap(\.searchItem)
     }
 
-    func userPlaylists(userID: String) async -> [MusicSearchItem] {
-        do {
-            // 50 is the API's per-page max. Matching accountPlaylists' single-page
-            // limit keeps this to one request; a personal profile rarely exceeds it
-            // and pagination is out of scope (see design.md).
-            let request = try await authorizedRequest(path: "/users/\(userID)/playlists",
-                                                      method: "GET",
-                                                      queryItems: [URLQueryItem(name: "limit", value: "50")])
-            let (data, response) = try await session.data(for: request)
-            guard isSuccess(response) else {
-                Log.error("Spotify userPlaylists(\(userID)) failed: \(httpFailureDescription(response, data))")
-                return []
+    /// Fetches every page of the signed-in account's `/me/playlists`. Spotify caps a
+    /// page at 50, so we walk the `offset` until a short page ends it — the huset
+    /// library plus the followed personal-account playlists easily exceeds 50, and a
+    /// single page would silently truncate them. `maxPages` guards against an
+    /// unbounded loop. A page fetch that fails stops paging and returns what we have.
+    private func fetchAllLibraryPlaylistItems() async -> [SpotifyPlaylistItem] {
+        let pageSize = 50
+        let maxPages = 10
+        var items: [SpotifyPlaylistItem] = []
+        for page in 0 ..< maxPages {
+            do {
+                let request = try await authorizedRequest(
+                    path: "/me/playlists",
+                    method: "GET",
+                    queryItems: [URLQueryItem(name: "limit", value: "\(pageSize)"),
+                                 URLQueryItem(name: "offset", value: "\(page * pageSize)")]
+                )
+                let (data, response) = try await session.data(for: request)
+                guard isSuccess(response) else {
+                    Log.error("Spotify accountPlaylists failed: \(httpFailureDescription(response, data))")
+                    break
+                }
+                let decoded = try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data)
+                items.append(contentsOf: decoded.items.compactMap { $0 })
+                if decoded.items.count < pageSize {
+                    break
+                }
+            } catch {
+                Log.error("Spotify accountPlaylists failed: \(error)")
+                break
             }
-            let playlists = try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data).playlists
-            if playlists.isEmpty {
-                // A configured personal account is expected to have public playlists;
-                // a 200-but-empty result is the anomaly to capture (distinguishes a
-                // genuine empty/filtered profile from an HTTP error logged above).
-                Log.warning("Spotify userPlaylists(\(userID)) returned 0 playlists (HTTP 200): \(bodySnippet(data))")
-            }
-            return playlists
-        } catch {
-            Log.error("Spotify userPlaylists(\(userID)) failed: \(error)")
-            return []
         }
+        return items
     }
 
     func isPlaylistSaved(playlistID: String) async -> Bool {
@@ -157,21 +149,10 @@ final class SpotifyApiService: SpotifyPlaylistService {
     }
 
     func editablePlaylistIDs() async -> Set<String> {
-        do {
-            let userID = try await currentUserID()
-            let request = try await authorizedRequest(path: "/me/playlists",
-                                                      method: "GET",
-                                                      queryItems: [URLQueryItem(name: "limit", value: "50")])
-            let (data, response) = try await session.data(for: request)
-            guard isSuccess(response) else {
-                return []
-            }
-            let page = try JSONDecoder().decode(SpotifyPlaylistPage.self, from: data)
-            return page.editableIDs(currentUserID: userID)
-        } catch {
-            Log.error("Spotify editablePlaylistIDs failed: \(error)")
+        guard let userID = try? await currentUserID() else {
             return []
         }
+        return await Set(fetchAllLibraryPlaylistItems().compactMap { $0.editableID(currentUserID: userID) })
     }
 
     // MARK: - Liked Songs
@@ -332,10 +313,6 @@ private struct SpotifyPlaylistPage: Decodable {
     // the whole page — which would otherwise leave a populated profile empty.
     let items: [SpotifyPlaylistItem?]
 
-    var playlists: [MusicSearchItem] {
-        items.compactMap { $0?.searchItem }
-    }
-
     /// The ids of playlists the signed-in user may edit: ones they own, plus any
     /// collaborative playlist regardless of owner.
     func editableIDs(currentUserID: String) -> Set<String> {
@@ -358,7 +335,8 @@ private struct SpotifyPlaylistItem: Decodable {
                                name: name,
                                mediaType: .playlist,
                                imageURL: images?.first?.url,
-                               artist: owner?.displayName)
+                               artist: owner?.displayName,
+                               ownerID: owner?.id)
     }
 
     func editableID(currentUserID: String) -> String? {
@@ -393,7 +371,6 @@ struct DisabledSpotifyPlaylistService: SpotifyPlaylistService {
     func authorize() async throws {}
     func accountPlaylists() async -> [MusicSearchItem] { [] }
     func editablePlaylistIDs() async -> Set<String> { [] }
-    func userPlaylists(userID _: String) async -> [MusicSearchItem] { [] }
     func isPlaylistSaved(playlistID _: String) async -> Bool { false }
     func savePlaylist(playlistID _: String) async -> Bool { false }
     func removePlaylist(playlistID _: String) async -> Bool { false }

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -20,7 +20,6 @@ extension MusicViewModel {
     func loadLibraryPlaylistsIfNeeded() async {
         await loadRecentlyPlayedIfNeeded()
         await loadSpotifyPlaylistsIfNeeded()
-        await refreshPersonalPlaylists()
     }
 
     /// Loads the recently-played playlists from Music Assistant once.
@@ -49,38 +48,36 @@ extension MusicViewModel {
     /// (e.g. edited in the Spotify app or on another device). An empty result is
     /// kept off the list rather than clearing it, since `accountPlaylists` also
     /// returns empty on a failed/logged-out fetch.
+    /// Re-fetches the huset account's library (`/me/playlists`, all pages) and splits
+    /// it: playlists owned by a configured personal account become that person's
+    /// section, everything else stays in Favoriter — so nothing shows twice. Spotify
+    /// blocks reading another user's playlists for this dev-mode app (403), so the
+    /// personal sections are sourced from the playlists the huset account follows,
+    /// matched by `ownerID`. An account that owns none of the followed playlists is
+    /// dropped (no empty header). When logged out the personal sections are cleared;
+    /// favourites are left as-is, since an empty fetch shouldn't blank a loaded list.
     func refreshSpotifyPlaylists() async {
         guard spotify.isAuthorized else {
+            personalPlaylistSections = []
             return
         }
         let playlists = await spotify.accountPlaylists()
         guard playlists.isNotEmpty else {
             return
         }
-        favoritePlaylists = playlists
+        let personalAccountIDs = Set(personalAccounts.map(\.userID))
+        favoritePlaylists = playlists.filter { playlist in
+            guard let ownerID = playlist.ownerID else {
+                return true
+            }
+            return !personalAccountIDs.contains(ownerID)
+        }
+        personalPlaylistSections = personalAccounts.compactMap { account in
+            let owned = playlists.filter { $0.ownerID == account.userID }
+            return owned.isEmpty ? nil : PersonalPlaylistSection(account: account, playlists: owned)
+        }
         hasLoadedSpotifyPlaylists = true
         editablePlaylistSpotifyIDs = await spotify.editablePlaylistIDs()
-    }
-
-    /// Re-fetches each configured personal account's public playlists, reusing the
-    /// huset login, and rebuilds `personalPlaylistSections` in configured order.
-    /// Mirrors `refreshSpotifyPlaylists`: when logged out the sections are cleared,
-    /// and an account whose fetch returns nothing (empty profile or failed request)
-    /// is dropped so its section disappears — never shown as an empty header.
-    func refreshPersonalPlaylists() async {
-        guard spotify.isAuthorized else {
-            personalPlaylistSections = []
-            return
-        }
-        var sections: [PersonalPlaylistSection] = []
-        for account in personalAccounts {
-            let playlists = await spotify.userPlaylists(userID: account.userID)
-            guard playlists.isNotEmpty else {
-                continue
-            }
-            sections.append(PersonalPlaylistSection(account: account, playlists: playlists))
-        }
-        personalPlaylistSections = sections
     }
 
     /// Re-fetches the recently-played list after a playlist launch so the new
@@ -258,7 +255,6 @@ extension MusicViewModel {
             try await spotify.authorize()
             isSpotifyAuthorized = true
             await refreshSpotifyPlaylists()
-            await refreshPersonalPlaylists()
         } catch {
             Log.error("Spotify login failed: \(error)")
             setErrorBannerText("Spotify-inloggning misslyckades", "Kunde inte logga in på Spotify")

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -50,7 +50,6 @@ struct MusicView: View {
         // time the view appears rather than trusting the once-per-session cache.
         .task {
             await viewModel.refreshSpotifyPlaylists()
-            await viewModel.refreshPersonalPlaylists()
         }
         // Keep the library-row stars in sync as the favourite/recents lists load.
         .task(id: viewModel.librarySavedStateSignature) {

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -13,8 +13,6 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
     var accountPlaylistItems: [MusicSearchItem]
     var editableIDs: Set<String>
     var savedSongTrackIDs: Set<String>
-    /// Public playlists keyed by Spotify user id, returned from `userPlaylists`.
-    var userPlaylistItems: [String: [MusicSearchItem]]
     private(set) var authorizeCallCount = 0
     private(set) var saveCallCount = 0
     private(set) var removeCallCount = 0
@@ -23,7 +21,6 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
     private(set) var removeSongCallCount = 0
     private(set) var addedTracks: [(playlistID: String, trackID: String)] = []
     private(set) var removedTracks: [(playlistID: String, trackID: String)] = []
-    private(set) var userPlaylistsCalls: [String] = []
 
     init(authorized: Bool = true,
          savedIDs: Set<String> = [],
@@ -31,8 +28,7 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
          authorizeThrows: Bool = false,
          accountPlaylistItems: [MusicSearchItem] = [],
          editableIDs: Set<String> = [],
-         savedSongTrackIDs: Set<String> = [],
-         userPlaylistItems: [String: [MusicSearchItem]] = [:]) {
+         savedSongTrackIDs: Set<String> = []) {
         self.authorized = authorized
         self.savedIDs = savedIDs
         self.operationSucceeds = operationSucceeds
@@ -40,7 +36,6 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
         self.accountPlaylistItems = accountPlaylistItems
         self.editableIDs = editableIDs
         self.savedSongTrackIDs = savedSongTrackIDs
-        self.userPlaylistItems = userPlaylistItems
     }
 
     var isAuthorized: Bool { authorized }
@@ -60,11 +55,6 @@ final class StubSpotifyPlaylistService: SpotifyPlaylistService {
 
     func editablePlaylistIDs() async -> Set<String> {
         editableIDs
-    }
-
-    func userPlaylists(userID: String) async -> [MusicSearchItem] {
-        userPlaylistsCalls.append(userID)
-        return userPlaylistItems[userID] ?? []
     }
 
     func isPlaylistSaved(playlistID: String) async -> Bool {
@@ -146,13 +136,15 @@ extension MusicViewModelTests {
     var tobiasAccount: SpotifyPersonalAccount { SpotifyPersonalAccount(userID: "tobiasc91", title: "Mina spellistor") }
     var sarahAccount: SpotifyPersonalAccount { SpotifyPersonalAccount(userID: "sarahtest42", title: "Sarahs spellistor") }
 
-    func playlistItem(uri: String, name: String) -> MusicSearchItem {
-        MusicSearchItem(uri: uri, name: name, mediaType: .playlist, imageURL: nil, artist: nil)
+    func playlistItem(uri: String, name: String, ownerID: String? = nil) -> MusicSearchItem {
+        MusicSearchItem(uri: uri, name: name, mediaType: .playlist, imageURL: nil, artist: nil, ownerID: ownerID)
     }
 
-    /// A "Träning" playlist keyed under Tobias's user id — the common single-account fixture.
-    func tobiasTräning() -> [String: [MusicSearchItem]] {
-        ["tobiasc91": [playlistItem(uri: "spotify://playlist/p1", name: "Träning")]]
+    /// The huset library containing a single "Träning" playlist owned by Tobias —
+    /// the common single-account fixture. Personal sections are sourced from the
+    /// account library filtered by `ownerID`.
+    func tobiasLibrary() -> [MusicSearchItem] {
+        [playlistItem(uri: "spotify://playlist/p1", name: "Träning", ownerID: "tobiasc91")]
     }
 
     func testIsSpotifyPlaylistShowsStarForResolvableUriEvenLoggedOut() {
@@ -356,19 +348,32 @@ extension MusicViewModelTests {
     // MARK: - Personal account playlist sections
 
     func testPersonalSectionAppearsWhenLoggedInWithPlaylists() async {
-        let playlists = [playlistItem(uri: "spotify://playlist/p1", name: "Träning"),
-                         playlistItem(uri: "spotify://playlist/p2", name: "Lugnt & skönt")]
-        let stub = StubSpotifyPlaylistService(userPlaylistItems: ["tobiasc91": playlists])
+        // Personal sections are sourced from the huset library, matched by ownerID.
+        let library = [playlistItem(uri: "spotify://playlist/p1", name: "Träning", ownerID: "tobiasc91"),
+                       playlistItem(uri: "spotify://playlist/p2", name: "Lugnt & skönt", ownerID: "tobiasc91")]
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: library)
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         XCTAssertEqual(model.personalPlaylistSections.count, 1)
         XCTAssertEqual(model.personalPlaylistSections.first?.title, "Mina spellistor")
         // Order is preserved exactly as returned — no client-side re-sorting.
         XCTAssertEqual(model.personalPlaylistSections.first?.playlists.map(\.name), ["Träning", "Lugnt & skönt"])
     }
 
+    func testPersonalOwnedPlaylistsExcludedFromFavourites() async {
+        // A huset-owned playlist stays in Favoriter; a personal-account-owned one
+        // moves to that person's section so it never shows in both.
+        let library = [playlistItem(uri: "spotify://playlist/h1", name: "Husets", ownerID: "huset"),
+                       playlistItem(uri: "spotify://playlist/p1", name: "Träning", ownerID: "tobiasc91")]
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: library)
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
+        await model.refreshSpotifyPlaylists()
+        XCTAssertEqual(model.favoritePlaylists.map(\.name), ["Husets"])
+        XCTAssertEqual(model.personalPlaylistSections.first?.playlists.map(\.name), ["Träning"])
+    }
+
     func testPersonalSectionLoadsViaReload() async {
-        let stub = StubSpotifyPlaylistService(userPlaylistItems: tobiasTräning())
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: tobiasLibrary())
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
         stubAllSpeakers(playing: .mediaPlayerKitchen)
         XCTAssertTrue(model.personalPlaylistSections.isEmpty)
@@ -376,79 +381,79 @@ extension MusicViewModelTests {
         XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor"])
     }
 
-    func testPersonalSectionHiddenWhenAccountHasNoPlaylists() async {
-        let stub = StubSpotifyPlaylistService(userPlaylistItems: ["tobiasc91": []])
+    func testPersonalSectionHiddenWhenAccountOwnsNoLibraryPlaylists() async {
+        // The library has playlists, but none owned by Tobias → no Mina section.
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: [
+            playlistItem(uri: "spotify://playlist/h1", name: "Husets", ownerID: "huset")
+        ])
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         XCTAssertTrue(model.personalPlaylistSections.isEmpty)
-        // The fetch was still attempted (empty result, not skipped).
-        XCTAssertEqual(stub.userPlaylistsCalls, ["tobiasc91"])
     }
 
     func testPersonalSectionHiddenWhenLoggedOut() async {
-        let stub = StubSpotifyPlaylistService(authorized: false, userPlaylistItems: tobiasTräning())
+        let stub = StubSpotifyPlaylistService(authorized: false, accountPlaylistItems: tobiasLibrary())
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         XCTAssertTrue(model.personalPlaylistSections.isEmpty)
-        XCTAssertTrue(stub.userPlaylistsCalls.isEmpty)
+        XCTAssertEqual(stub.accountPlaylistsCallCount, 0)
     }
 
     func testPersonalSectionsClearedWhenSessionBecomesLoggedOut() async {
-        let stub = StubSpotifyPlaylistService(userPlaylistItems: tobiasTräning())
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: tobiasLibrary())
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         XCTAssertEqual(model.personalPlaylistSections.count, 1)
         // The session is lost; a refresh now clears the sections so they disappear.
         stub.authorized = false
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         XCTAssertTrue(model.personalPlaylistSections.isEmpty)
     }
 
     func testMultipleAccountsEachGetASectionInConfiguredOrder() async {
-        let stub = StubSpotifyPlaylistService(userPlaylistItems: [
-            "tobiasc91": [playlistItem(uri: "spotify://playlist/p1", name: "Träning")],
-            "sarahtest42": [playlistItem(uri: "spotify://playlist/p2", name: "Sarahs mix")]
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: [
+            playlistItem(uri: "spotify://playlist/p1", name: "Träning", ownerID: "tobiasc91"),
+            playlistItem(uri: "spotify://playlist/p2", name: "Sarahs mix", ownerID: "sarahtest42")
         ])
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount, sarahAccount])
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor", "Sarahs spellistor"])
     }
 
     func testEmptyAccountDroppedWhileOthersRemain() async {
-        let stub = StubSpotifyPlaylistService(userPlaylistItems: [
-            "tobiasc91": [],
-            "sarahtest42": [playlistItem(uri: "spotify://playlist/p2", name: "Sarahs mix")]
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: [
+            playlistItem(uri: "spotify://playlist/p2", name: "Sarahs mix", ownerID: "sarahtest42")
         ])
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount, sarahAccount])
-        await model.refreshPersonalPlaylists()
-        // Tobias has nothing → dropped; only Sarah's section shows.
+        await model.refreshSpotifyPlaylists()
+        // Tobias owns nothing in the library → dropped; only Sarah's section shows.
         XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Sarahs spellistor"])
     }
 
     func testPersonalSectionRefreshReflectsLatestPlaylists() async {
-        let stub = StubSpotifyPlaylistService(userPlaylistItems: tobiasTräning())
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: tobiasLibrary())
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         XCTAssertEqual(model.personalPlaylistSections.first?.playlists.map(\.name), ["Träning"])
         // Renamed/changed on Spotify; a refresh reflects it with no stale cache.
-        stub.userPlaylistItems = ["tobiasc91": [playlistItem(uri: "spotify://playlist/p3", name: "Ny spellista")]]
-        await model.refreshPersonalPlaylists()
+        stub.accountPlaylistItems = [playlistItem(uri: "spotify://playlist/p3", name: "Ny spellista", ownerID: "tobiasc91")]
+        await model.refreshSpotifyPlaylists()
         XCTAssertEqual(model.personalPlaylistSections.first?.playlists.map(\.name), ["Ny spellista"])
     }
 
     func testConnectSpotifyLoadsPersonalSections() async {
-        let stub = StubSpotifyPlaylistService(authorized: false, userPlaylistItems: tobiasTräning())
+        let stub = StubSpotifyPlaylistService(authorized: false, accountPlaylistItems: tobiasLibrary())
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
         await model.connectSpotify()
         XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor"])
     }
 
     func testTappingPersonalPlaylistRoutesThroughBrowseFlow() async {
-        let playlist = playlistItem(uri: "spotify://playlist/p1", name: "Träning")
-        let stub = StubSpotifyPlaylistService(userPlaylistItems: ["tobiasc91": [playlist]])
+        let playlist = playlistItem(uri: "spotify://playlist/p1", name: "Träning", ownerID: "tobiasc91")
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: [playlist])
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
         model.selectSpeaker(.mediaPlayerKitchen)
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         // Tapping a personal playlist uses the same browse flow as a favourite.
         await model.browseLibraryPlaylist(model.personalPlaylistSections.first!.playlists.first!)
         XCTAssertEqual(model.browsingLibraryPlaylist?.uri, playlist.uri)
@@ -462,20 +467,20 @@ extension MusicViewModelTests {
     func testLoadLibrarySavedStatesResolvesPersonalSectionRows() async {
         // A personal playlist saved in the huset library but not a favourite must
         // still get its row star resolved, so it isn't shown empty until detail open.
-        let personal = playlistItem(uri: "spotify://playlist/p1", name: "Träning")
-        let stub = StubSpotifyPlaylistService(savedIDs: ["p1"], userPlaylistItems: ["tobiasc91": [personal]])
+        let personal = playlistItem(uri: "spotify://playlist/p1", name: "Träning", ownerID: "tobiasc91")
+        let stub = StubSpotifyPlaylistService(savedIDs: ["p1"], accountPlaylistItems: [personal])
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         XCTAssertTrue(model.librarySavedStateSignature.contains("spotify://playlist/p1"))
         await model.loadLibrarySavedStates()
         XCTAssertTrue(model.isSaved(personal))
     }
 
     func testLoadLibrarySavedStatesLeavesUnsavedPersonalRowUnmarked() async {
-        let personal = playlistItem(uri: "spotify://playlist/p9", name: "Inte sparad")
-        let stub = StubSpotifyPlaylistService(savedIDs: [], userPlaylistItems: ["tobiasc91": [personal]])
+        let personal = playlistItem(uri: "spotify://playlist/p9", name: "Inte sparad", ownerID: "tobiasc91")
+        let stub = StubSpotifyPlaylistService(savedIDs: [], accountPlaylistItems: [personal])
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
-        await model.refreshPersonalPlaylists()
+        await model.refreshSpotifyPlaylists()
         await model.loadLibrarySavedStates()
         XCTAssertFalse(model.isSaved(personal))
     }

--- a/IntelliNestTests/SpotifyApiServiceTests.swift
+++ b/IntelliNestTests/SpotifyApiServiceTests.swift
@@ -86,96 +86,59 @@ final class SpotifyApiServiceTests: XCTestCase {
 
     // MARK: - accountPlaylists
 
-    func testAccountPlaylistsMapsItems() async {
+    func mePlaylistsURL(offset: Int) -> URL {
+        spotifyURL(path: "/me/playlists", query: [URLQueryItem(name: "limit", value: "50"),
+                                                  URLQueryItem(name: "offset", value: "\(offset)")])
+    }
+
+    func testAccountPlaylistsMapsItemsWithOwnerID() async {
         let json = """
         {"items":[
-          {"id":"abc123","name":"Morgon","images":[{"url":"https://img/a.jpg"}],"owner":{"display_name":"huset"}},
-          {"id":"def456","name":"Träning","images":[],"owner":{"display_name":"huset"}},
+          {"id":"abc123","name":"Morgon","images":[{"url":"https://img/a.jpg"}],"owner":{"id":"huset","display_name":"huset"}},
+          {"id":"def456","name":"Träning","images":[],"owner":{"id":"tobiasc91","display_name":"Tobias"}},
           {"id":null,"name":"Trasig"}
         ]}
         """
-        stub(url: spotifyURL(path: "/me/playlists", query: [URLQueryItem(name: "limit", value: "50")]),
-             statusCode: 200, json: json)
+        stub(url: mePlaylistsURL(offset: 0), statusCode: 200, json: json)
         let playlists = await service.accountPlaylists()
-        // The null-id item is dropped; the rest map to spotify:// uris.
+        // The null-id item is dropped; the rest map to spotify:// uris with ownerID.
         XCTAssertEqual(playlists.map(\.name), ["Morgon", "Träning"])
         XCTAssertEqual(playlists.first?.uri, "spotify://playlist/abc123")
         XCTAssertEqual(playlists.first?.imageURL, "https://img/a.jpg")
-        XCTAssertEqual(playlists.first?.artist, "huset")
+        XCTAssertEqual(playlists.first?.ownerID, "huset")
+        XCTAssertEqual(playlists.last?.ownerID, "tobiasc91")
         XCTAssertTrue(playlists.allSatisfy { $0.mediaType == .playlist })
     }
 
-    func testAccountPlaylistsReturnsEmptyOnFailure() async {
-        stub(url: spotifyURL(path: "/me/playlists", query: [URLQueryItem(name: "limit", value: "50")]),
-             statusCode: 401, json: "{}")
-        let playlists = await service.accountPlaylists()
-        XCTAssertTrue(playlists.isEmpty)
-    }
-
-    // MARK: - userPlaylists
-
-    func userPlaylistsURL(userID: String) -> URL {
-        spotifyURL(path: "/users/\(userID)/playlists", query: [URLQueryItem(name: "limit", value: "50")])
-    }
-
-    func testUserPlaylistsMapsOwnedAndFollowedItems() async {
-        // A public profile lists both owned playlists and ones it merely follows;
-        // there is no owner filtering, so both map through.
-        let json = """
-        {"items":[
-          {"id":"own1","name":"Träning","images":[{"url":"https://img/t.jpg"}],"owner":{"display_name":"tobiasc91"}},
-          {"id":"fol1","name":"Lugnt & skönt","images":[],"owner":{"display_name":"Spotify"}},
-          {"id":null,"name":"Trasig"}
-        ]}
-        """
-        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 200, json: json)
-        let playlists = await service.userPlaylists(userID: "tobiasc91")
-        XCTAssertEqual(playlists.map(\.name), ["Träning", "Lugnt & skönt"])
-        XCTAssertEqual(playlists.first?.uri, "spotify://playlist/own1")
-        XCTAssertEqual(playlists.first?.imageURL, "https://img/t.jpg")
-        XCTAssertEqual(playlists.last?.uri, "spotify://playlist/fol1")
-        XCTAssertTrue(playlists.allSatisfy { $0.mediaType == .playlist })
-    }
-
-    func testUserPlaylistsToleratesNullArrayEntries() async {
+    func testAccountPlaylistsToleratesNullArrayEntries() async {
         // Spotify can return a bare `null` element in `items` for an unavailable
         // playlist; it must be skipped, not throw away the whole (populated) page.
         let json = """
-        {"items":[
-          null,
-          {"id":"own1","name":"Träning","images":[],"owner":{"display_name":"tobiasc91"}},
-          null
-        ]}
+        {"items":[null,{"id":"own1","name":"Träning","owner":{"id":"tobiasc91"}},null]}
         """
-        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 200, json: json)
-        let playlists = await service.userPlaylists(userID: "tobiasc91")
+        stub(url: mePlaylistsURL(offset: 0), statusCode: 200, json: json)
+        let playlists = await service.accountPlaylists()
         XCTAssertEqual(playlists.map(\.name), ["Träning"])
     }
 
-    func testUserPlaylistsReturnsEmptyWhenNoPlaylists() async {
-        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 200, json: "{\"items\":[]}")
-        let playlists = await service.userPlaylists(userID: "tobiasc91")
-        XCTAssertTrue(playlists.isEmpty)
+    func testAccountPlaylistsPaginatesPastFiftyUntilShortPage() async {
+        // A full 50-item page triggers a second fetch at offset 50; the short page
+        // there ends paging, so the whole library is returned, not just the first 50.
+        let firstPage = (0 ..< 50).map { index in
+            "{\"id\":\"p\(index)\",\"name\":\"P\(index)\",\"owner\":{\"id\":\"huset\"}}"
+        }.joined(separator: ",")
+        stub(url: mePlaylistsURL(offset: 0), statusCode: 200, json: "{\"items\":[\(firstPage)]}")
+        stub(url: mePlaylistsURL(offset: 50), statusCode: 200,
+             json: "{\"items\":[{\"id\":\"p50\",\"name\":\"P50\",\"owner\":{\"id\":\"huset\"}}]}")
+        let playlists = await service.accountPlaylists()
+        XCTAssertEqual(playlists.count, 51)
+        XCTAssertEqual(playlists.last?.name, "P50")
     }
 
-    func testUserPlaylistsReturnsEmptyOnFailure() async {
-        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 404, json: "{}")
-        let playlists = await service.userPlaylists(userID: "tobiasc91")
+    func testAccountPlaylistsReturnsEmptyOnFailure() async {
+        stub(url: mePlaylistsURL(offset: 0), statusCode: 401, json: "{}")
+        let playlists = await service.accountPlaylists()
         XCTAssertTrue(playlists.isEmpty)
-    }
-
-    func testUserPlaylistsSendsBearerTokenToUserPath() async {
-        let expectation = XCTestExpectation(description: "GET user playlists with bearer token")
-        URLProtocolStub.observerRequests { request in
-            if request.httpMethod == "GET",
-               request.url?.path == "/v1/users/tobiasc91/playlists",
-               request.value(forHTTPHeaderField: "Authorization") == "Bearer stub-access-token" {
-                expectation.fulfill()
-            }
-        }
-        stub(url: userPlaylistsURL(userID: "tobiasc91"), statusCode: 200, json: "{\"items\":[]}")
-        _ = await service.userPlaylists(userID: "tobiasc91")
-        await fulfillment(of: [expectation], timeout: 2.0)
     }
 
     // MARK: - isPlaylistSaved


### PR DESCRIPTION
## Why

The personal-playlist sections (#135/#139) read `GET /users/{id}/playlists`, which Spotify returns
**403 Forbidden** for a Development-mode app — confirmed from the on-device log:

```
Spotify userPlaylists(mbostroem) failed: HTTP 403: {"error":{"status":403,"message":"Forbidden"}}
```

Per [Spotify's quota docs](https://developer.spotify.com/documentation/web-api/concepts/quota-modes),
dev-mode apps get 403 on endpoints reading *another* user's data, while `/me/...` keeps working — and
[extended access is no longer granted to small apps](https://developer.spotify.com/blog/2025-04-15-updating-the-criteria-for-web-api-extended-access).
So the sections must be sourced from an endpoint we *can* call: `/me/playlists`.

## What changed

- Personal sections are now built from the **huset account's own library** (`/me/playlists`), grouped by
  `owner.id`. The huset account follows (♡-saves) the people's playlists; we attribute each to its owner.
- `MusicSearchItem` carries an optional `ownerID` (set for account-library playlists) to drive the split.
- **`/me/playlists` is now paginated** (50/page, walked by `offset`) — the huset library plus ~37 followed
  personal playlists easily exceeds the old single-page cap, which would have silently truncated them.
- **Partitioned** the library: a playlist owned by a configured personal account goes to that person's
  section *only*; everything else stays in Favoriter, so nothing appears twice.
- Removed the dead `userPlaylists(userID:)` path (the forbidden endpoint) from the service, protocol, and
  disabled stub. `refreshPersonalPlaylists` is folded into `refreshSpotifyPlaylists` (one fetch drives both
  Favoriter and the per-person sections).

## Operational note

This only surfaces playlists the **huset account has saved (♡)** to its library — following a *profile*
doesn't pull them in, and the app can't save them via API (dev-mode blocks writes too). New playlists need
saving as they're created.

## Tests

Full suite green. Personal-section tests rewritten to source from the account library by `ownerID`; added
`testPersonalOwnedPlaylistsExcludedFromFavourites` (partition) and `testAccountPlaylistsPaginatesPastFiftyUntilShortPage`
(pagination); `accountPlaylists` now asserts `ownerID` and tolerates `null` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)