### PR TITLE
Personalised playlist section order and titles per logged-in user

### DIFF
--- a/IntelliNest/Model/UserManager.swift
+++ b/IntelliNest/Model/UserManager.swift
@@ -18,6 +18,14 @@ enum User: String, CaseIterable {
             "Unknown User"
         }
     }
+
+    /// The music-view section heading for this person's playlists from another
+    /// viewer's perspective, e.g. "Sarahs spellistor". Swedish genitive: names
+    /// already ending in s/x/z take no extra "s" ("Tobias spellistor").
+    var playlistSectionTitle: String {
+        let genitive = "sxzSXZ".contains(name.last ?? " ") ? "" : "s"
+        return "\(name)\(genitive) spellistor"
+    }
 }
 
 struct UserManager {

--- a/IntelliNest/Services/SpotifyApiService.swift
+++ b/IntelliNest/Services/SpotifyApiService.swift
@@ -11,17 +11,20 @@ import Foundation
 /// music view as its own titled section. Baked into the app (no in-app management);
 /// add another account by appending to `SpotifyPersonalAccount.configured`.
 struct SpotifyPersonalAccount: Identifiable, Equatable {
-    /// The Spotify user id (the `/users/{id}` path component).
+    /// The Spotify user id that owns these playlists in the huset library.
     let userID: String
-    /// The Swedish section title shown above this account's playlists.
-    let title: String
+    /// The app user this account belongs to — drives the per-viewer section title
+    /// ("Mina spellistor" for the logged-in user, the person's name for everyone
+    /// else) and ordering (the viewer's own section is shown first).
+    let user: User
 
     var id: String { userID }
 
-    /// The ordered list of personal accounts. Sections render in this order.
+    /// The configured personal accounts. The viewer's own is surfaced first at
+    /// render time; this is just the known set.
     static let configured: [SpotifyPersonalAccount] = [
-        SpotifyPersonalAccount(userID: "tobiasc91", title: "Mina spellistor"),
-        SpotifyPersonalAccount(userID: "mbostroem", title: "Sarahs spellistor")
+        SpotifyPersonalAccount(userID: "tobiasc91", user: .tobias),
+        SpotifyPersonalAccount(userID: "mbostroem", user: .sarah)
     ]
 }
 

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -72,9 +72,18 @@ extension MusicViewModel {
             }
             return !personalAccountIDs.contains(ownerID)
         }
-        personalPlaylistSections = personalAccounts.compactMap { account in
+        // Show the viewer's own section first; the rest keep configured order. The
+        // viewer's own is titled "Mina spellistor", everyone else's by their name.
+        let viewer = currentUser()
+        let orderedAccounts = personalAccounts.filter { $0.user == viewer }
+            + personalAccounts.filter { $0.user != viewer }
+        personalPlaylistSections = orderedAccounts.compactMap { account in
             let owned = playlists.filter { $0.ownerID == account.userID }
-            return owned.isEmpty ? nil : PersonalPlaylistSection(account: account, playlists: owned)
+            guard owned.isNotEmpty else {
+                return nil
+            }
+            let title = account.user == viewer ? "Mina spellistor" : account.user.playlistSectionTitle
+            return PersonalPlaylistSection(account: account, title: title, playlists: owned)
         }
         hasLoadedSpotifyPlaylists = true
         editablePlaylistSpotifyIDs = await spotify.editablePlaylistIDs()

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -7,14 +7,15 @@
 
 import Foundation
 
-/// A personal account's section of public playlists, ready to render. Carries the
-/// account (for title + stable identity) and the playlists fetched for it.
+/// A personal account's section of playlists, ready to render. The `title` is
+/// resolved per viewer ("Mina spellistor" for the logged-in user, the person's
+/// name otherwise), so it's stored rather than derived from the account.
 struct PersonalPlaylistSection: Identifiable, Equatable {
     let account: SpotifyPersonalAccount
+    let title: String
     let playlists: [MusicSearchItem]
 
     var id: String { account.id }
-    var title: String { account.title }
 }
 
 @MainActor
@@ -112,6 +113,10 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// sections. Injectable so tests can exercise multiple-account ordering and the
     /// hide-when-empty rule without depending on the baked-in list.
     let personalAccounts: [SpotifyPersonalAccount]
+    /// The logged-in app user, read when building the personal sections so the
+    /// viewer's own playlists are shown first and titled "Mina spellistor".
+    /// Injected as a closure so tests don't depend on shared `UserDefaults`.
+    let currentUser: @MainActor () -> User
 
     /// Speakers that are reachable right now (anything not `unavailable`),
     /// in the fixed display order.
@@ -130,12 +135,14 @@ class MusicViewModel: ObservableObject, Reloadable {
          setErrorBannerText: @escaping StringStringClosure = { _, _ in },
          spotify: SpotifyPlaylistService = DisabledSpotifyPlaylistService(),
          queueSocket: MusicAssistantQueueSocket = DisabledMusicAssistantQueueSocket(),
-         personalAccounts: [SpotifyPersonalAccount] = SpotifyPersonalAccount.configured) {
+         personalAccounts: [SpotifyPersonalAccount] = SpotifyPersonalAccount.configured,
+         currentUser: @escaping @MainActor () -> User = { UserManager.currentUser }) {
         self.restAPIService = restAPIService
         self.setErrorBannerText = setErrorBannerText
         self.spotify = spotify
         self.queueSocket = queueSocket
         self.personalAccounts = personalAccounts
+        self.currentUser = currentUser
         isSpotifyAuthorized = spotify.isAuthorized
         var initialSpeakers: [EntityId: MediaPlayerEntity] = [:]
         for speakerID in Self.speakerIDs {

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -125,16 +125,18 @@ extension MusicViewModelTests {
     }
 
     func makeViewModel(spotify: SpotifyPlaylistService,
-                       personalAccounts: [SpotifyPersonalAccount] = SpotifyPersonalAccount.configured) -> MusicViewModel {
+                       personalAccounts: [SpotifyPersonalAccount] = SpotifyPersonalAccount.configured,
+                       currentUser: @escaping @MainActor () -> User = { .tobias }) -> MusicViewModel {
         MusicViewModel(restAPIService: restAPIService,
                        setErrorBannerText: { [weak self] title, _ in self?.bannerTitles.append(title) },
                        spotify: spotify,
-                       personalAccounts: personalAccounts)
+                       personalAccounts: personalAccounts,
+                       currentUser: currentUser)
     }
 
-    // Fixed personal-account ids/titles — grep-searchable, no random data.
-    var tobiasAccount: SpotifyPersonalAccount { SpotifyPersonalAccount(userID: "tobiasc91", title: "Mina spellistor") }
-    var sarahAccount: SpotifyPersonalAccount { SpotifyPersonalAccount(userID: "sarahtest42", title: "Sarahs spellistor") }
+    // Fixed personal-account ids — grep-searchable, no random data.
+    var tobiasAccount: SpotifyPersonalAccount { SpotifyPersonalAccount(userID: "tobiasc91", user: .tobias) }
+    var sarahAccount: SpotifyPersonalAccount { SpotifyPersonalAccount(userID: "sarahtest42", user: .sarah) }
 
     func playlistItem(uri: String, name: String, ownerID: String? = nil) -> MusicSearchItem {
         MusicSearchItem(uri: uri, name: name, mediaType: .playlist, imageURL: nil, artist: nil, ownerID: ownerID)
@@ -461,7 +463,19 @@ extension MusicViewModelTests {
 
     func testDefaultPersonalAccountsConfiguresTobiasThenSarah() {
         XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.userID), ["tobiasc91", "mbostroem"])
-        XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.title), ["Mina spellistor", "Sarahs spellistor"])
+        XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.user), [.tobias, .sarah])
+    }
+
+    func testViewerOwnSectionIsFirstAndTitledMina() async {
+        let library = [playlistItem(uri: "spotify://playlist/p1", name: "Tobias lista", ownerID: "tobiasc91"),
+                       playlistItem(uri: "spotify://playlist/p2", name: "Sarahs lista", ownerID: "sarahtest42")]
+        let stub = StubSpotifyPlaylistService(accountPlaylistItems: library)
+        // Sarah is the viewer → her section is first and titled "Mina spellistor",
+        // Tobias's drops below, titled by his name.
+        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount, sarahAccount], currentUser: { .sarah })
+        await model.refreshSpotifyPlaylists()
+        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor", "Tobias spellistor"])
+        XCTAssertEqual(model.personalPlaylistSections.first?.account.userID, "sarahtest42")
     }
 
     func testLoadLibrarySavedStatesResolvesPersonalSectionRows() async {


### PR DESCRIPTION
## Why

The personal playlist sections were a fixed global list (yours, then Sarah's) with hardcoded titles, identical
for every viewer — so Sarah saw "Mina spellistor" ("My playlists") showing *Tobias's* playlists, with hers below.

## What changed

- `SpotifyPersonalAccount` now carries the app `User` it belongs to instead of a hardcoded `title`.
- The personal sections are built per viewer (`UserManager.currentUser`, injected as a closure for testability):
  the logged-in user's own section is shown **first** and titled **"Mina spellistor"**; everyone else's keeps
  configured order and is titled by name (`User.playlistSectionTitle`, e.g. "Sarahs spellistor"). Swedish genitive
  handles names ending in s/x/z ("Tobias spellistor", no double-s).
- `PersonalPlaylistSection.title` is now a stored, resolved value rather than derived from the account.

So you see "Mina spellistor" (yours) on top and "Sarahs spellistor" below; Sarah sees "Mina spellistor" (hers)
on top and "Tobias spellistor" below.

## Tests

Full suite green. Added `testViewerOwnSectionIsFirstAndTitledMina` (viewer = Sarah → her section first, titled
"Mina spellistor", Tobias's below by name); updated the personal-section fixtures/assertions for the per-user model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personal playlist sections are now reordered with your playlists appearing first for improved visibility.
  * Playlist section titles now properly reflect your name using Swedish grammatical conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->