### PR TITLE
Moved playlist favourites to Music Assistant

### DIFF
--- a/IntelliNest/Services/MusicAssistantSocketService.swift
+++ b/IntelliNest/Services/MusicAssistantSocketService.swift
@@ -17,6 +17,14 @@ protocol MusicAssistantQueueSocket: Sendable {
     func queueItems(queueID: String) async -> [MusicQueueItem]
     /// Removes the item from the queue. Returns whether the command succeeded.
     func deleteItem(queueID: String, itemID: String) async -> Bool
+    /// Adds the media item (by uri, e.g. `spotify://playlist/<id>`) to the Music
+    /// Assistant library favourites. With MA's Spotify 2-way sync on, this also
+    /// follows the playlist on Spotify. Returns whether the command succeeded.
+    func addFavorite(uri: String) async -> Bool
+    /// Removes a favourite by its Music Assistant library id (parsed from a
+    /// `library://<type>/<id>` uri). With 2-way sync on, this also unfollows it on
+    /// Spotify. Returns whether the command succeeded.
+    func removeFavorite(mediaType: String, libraryItemID: String) async -> Bool
 }
 
 /// Talks to the Music Assistant server's WebSocket API. Each call opens a short
@@ -54,6 +62,15 @@ final class MusicAssistantSocketService: MusicAssistantQueueSocket {
     func deleteItem(queueID: String, itemID: String) async -> Bool {
         await send(command: "player_queues/delete_item",
                    args: ["queue_id": queueID, "item_id_or_index": itemID]) != nil
+    }
+
+    func addFavorite(uri: String) async -> Bool {
+        await send(command: "music/favorites/add_item", args: ["item": uri]) != nil
+    }
+
+    func removeFavorite(mediaType: String, libraryItemID: String) async -> Bool {
+        await send(command: "music/favorites/remove_item",
+                   args: ["media_type": mediaType, "library_item_id": libraryItemID]) != nil
     }
 
     // MARK: - WebSocket plumbing
@@ -173,4 +190,6 @@ final class MusicAssistantSocketService: MusicAssistantQueueSocket {
 struct DisabledMusicAssistantQueueSocket: MusicAssistantQueueSocket {
     func queueItems(queueID _: String) async -> [MusicQueueItem] { [] }
     func deleteItem(queueID _: String, itemID _: String) async -> Bool { false }
+    func addFavorite(uri _: String) async -> Bool { false }
+    func removeFavorite(mediaType _: String, libraryItemID _: String) async -> Bool { false }
 }

--- a/IntelliNest/Services/RestAPIService+Music.swift
+++ b/IntelliNest/Services/RestAPIService+Music.swift
@@ -34,6 +34,13 @@ extension RestAPIService {
         try await getLibraryPlaylists(favorite: nil, orderBy: "last_played_desc", limit: limit)
     }
 
+    /// Fetches the favourited playlists from the Music Assistant library. These are
+    /// `library://playlist/<id>` items whose `<id>` is the library id needed to
+    /// unfavourite over the socket. Drives the favourite-star state.
+    func getFavoritePlaylists(limit: Int = 100) async throws -> [MusicSearchItem] {
+        try await getLibraryPlaylists(favorite: true, orderBy: "sort_name", limit: limit)
+    }
+
     /// Shared `get_library` call for playlists (`?return_response`). `favorite`
     /// applies the favourite filter only when non-nil.
     private func getLibraryPlaylists(favorite: Bool?, orderBy: String, limit: Int) async throws -> [MusicSearchItem] {

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -263,49 +263,36 @@ extension MusicViewModel {
         do {
             try await spotify.authorize()
             isSpotifyAuthorized = true
-            await refreshSpotifyPlaylists()
+            await refreshFavorites()
         } catch {
             Log.error("Spotify login failed: \(error)")
             setErrorBannerText("Spotify-inloggning misslyckades", "Kunde inte logga in på Spotify")
         }
     }
 
-    // MARK: - Spotify favourite
+    // MARK: - Favourites (Music Assistant)
 
-    /// Whether to show the favourite star for this playlist: it resolves to a
-    /// Spotify id, directly or via the account match. The star shows even when
-    /// logged out for a directly-resolvable `spotify://` playlist (a search
-    /// result) — tapping it logs in first, then saves — so there's an affordance
-    /// instead of a blank toolbar. Built-ins and non-account `library://` items
-    /// still get no star (they only resolve via the logged-in account match).
-    func isSpotifyPlaylist(_ playlist: MusicSearchItem) -> Bool {
-        spotifyPlaylistID(for: playlist) != nil
+    /// Whether to show the favourite star: any playlist can be favourited in MA
+    /// (and MA's Spotify 2-way sync mirrors it to the follow). Spotify writes are
+    /// blocked for this dev-mode app, so the star goes through MA, not Spotify.
+    func canFavoritePlaylist(_ playlist: MusicSearchItem) -> Bool {
+        playlist.mediaType == .playlist
     }
 
-    /// Whether the playlist is currently marked saved (drives the filled star).
-    /// Resolved by Spotify id, not uri, so the same playlist reads identically
-    /// whether it came in as a `spotify://` favourite or a `library://` recent.
+    /// Whether the playlist is currently favourited in Music Assistant. MA
+    /// favourites are `library://` items while the listing is `spotify://`, so
+    /// they are matched by normalized name.
     func isSaved(_ playlist: MusicSearchItem) -> Bool {
-        guard let id = spotifyPlaylistID(for: playlist) else {
-            return false
-        }
-        return savedPlaylistIDs.contains(id)
+        maFavoriteNames.contains(normalizedName(playlist.name))
     }
 
-    /// The Spotify ids of every playlist currently in the account library (the
-    /// favourites section). Library membership — not Spotify's follow-contains
-    /// check, which returns false for playlists the account owns — is the source
-    /// of truth for whether a playlist is saved.
-    var libraryPlaylistIDs: Set<String> {
-        Set(favoritePlaylists.compactMap { spotifyPlaylistID(for: $0) })
+    var maFavoriteNames: Set<String> {
+        Set(maFavorites.map { normalizedName($0.name) })
     }
 
-    /// Resolves the Spotify playlist id for a playlist. A `spotify://playlist/<id>`
-    /// uri gives it directly. Music Assistant library items instead use opaque
-    /// `library://playlist/<n>` uris with no Spotify id, so they're matched by name
-    /// against the logged-in account's playlists (Spotify is the source of truth,
-    /// and an MA Spotify-library playlist is by definition one of those). Returns
-    /// nil for non-Spotify playlists (MA built-ins, or anything not in the account).
+    /// Resolves the Spotify playlist id for a playlist (used by the add-to-playlist
+    /// feature). A `spotify://playlist/<id>` uri gives it directly; a `library://`
+    /// item is matched by name against the account's playlists.
     func spotifyPlaylistID(for playlist: MusicSearchItem) -> String? {
         if let id = directSpotifyPlaylistID(from: playlist.uri) {
             return id
@@ -328,66 +315,82 @@ extension MusicViewModel {
         name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
-    /// Reads the saved-state when the playlist detail appears, so the star
-    /// reflects reality. Skipped (and silent) for non-Spotify playlists or when
-    /// the user hasn't logged in yet — the star only loads after first login. A
-    /// playlist already in the account library is saved by definition: Spotify's
-    /// follow-contains check returns false for playlists the account *owns*, so
-    /// trust library membership first and only query the API for playlists
-    /// outside the library (e.g. someone else's playlist opened from search).
-    func loadSavedState(for playlist: MusicSearchItem) async {
-        guard let playlistID = spotifyPlaylistID(for: playlist), spotify.isAuthorized else {
-            return
+    /// The Music Assistant library id from a `library://playlist/<id>` uri, needed
+    /// to unfavourite over the socket.
+    private func libraryPlaylistID(from uri: String) -> String? {
+        let prefix = "library://playlist/"
+        guard uri.hasPrefix(prefix) else {
+            return nil
         }
-        if libraryPlaylistIDs.contains(playlistID) {
-            savedPlaylistIDs.insert(playlistID)
-            return
-        }
-        await setSaved(spotify.isPlaylistSaved(playlistID: playlistID), for: playlist)
+        let id = String(uri.dropFirst(prefix.count))
+        return id.isNotEmpty ? id : nil
     }
 
-    /// Toggles whether the playlist is in the user's Spotify library. Triggers the
-    /// one-time Spotify login when needed, flips the star optimistically, then
-    /// reverts and shows a banner if the request fails.
-    func toggleSpotifySaved(_ playlist: MusicSearchItem) async {
-        guard let playlistID = spotifyPlaylistID(for: playlist) else {
-            return
+    /// Ensures the MA favourites are loaded so the star reflects reality when a
+    /// playlist detail opens straight from a search result.
+    func loadSavedState(for _: MusicSearchItem) async {
+        if maFavorites.isEmpty {
+            await refreshFavorites()
         }
-        if !spotify.isAuthorized {
-            do {
-                try await spotify.authorize()
-                isSpotifyAuthorized = true
-            } catch {
-                Log.error("Spotify authorization failed: \(error)")
-                setErrorBannerText("Spotify-inloggning misslyckades", "Kunde inte logga in på Spotify")
-                return
-            }
-        }
+    }
 
+    /// Toggles the playlist's Music Assistant favourite. MA's Spotify 2-way sync
+    /// then follows/unfollows it on Spotify, and the next listing reload reflects
+    /// it. Flips the star optimistically; reverts and banners on failure.
+    func toggleFavorite(_ playlist: MusicSearchItem) async {
         let wasSaved = isSaved(playlist)
-        setSaved(!wasSaved, for: playlist)
-        let success = wasSaved
-            ? await spotify.removePlaylist(playlistID: playlistID)
-            : await spotify.savePlaylist(playlistID: playlistID)
-        if success {
-            // The account's playlist set just changed — refresh the favourites
-            // section so it reflects the save/remove.
-            await refreshSpotifyPlaylists()
+        // Capture the unfavourite target's library id before the optimistic flip
+        // removes it from `maFavorites`.
+        let removalID = wasSaved ? maLibraryID(matching: playlist) : nil
+        setFavoriteOptimistically(!wasSaved, playlist: playlist)
+        let success: Bool = if wasSaved {
+            if let removalID {
+                await queueSocket.removeFavorite(mediaType: "playlist", libraryItemID: removalID)
+            } else {
+                false
+            }
         } else {
-            setSaved(wasSaved, for: playlist)
-            setErrorBannerText("Kunde inte uppdatera favorit", "Det gick inte att ändra favoritmarkeringen på Spotify")
+            await queueSocket.addFavorite(uri: playlist.uri)
+        }
+        if success {
+            await refreshFavorites()
+        } else {
+            setFavoriteOptimistically(wasSaved, playlist: playlist)
+            setErrorBannerText("Kunde inte uppdatera favorit", "Det gick inte att ändra favoritmarkeringen")
         }
     }
 
-    func setSaved(_ saved: Bool, for playlist: MusicSearchItem) {
-        guard let id = spotifyPlaylistID(for: playlist) else {
-            return
+    /// The MA library id for the favourite matching `playlist` by name, or nil if
+    /// no matching favourite is loaded.
+    private func maLibraryID(matching playlist: MusicSearchItem) -> String? {
+        let name = normalizedName(playlist.name)
+        guard let item = maFavorites.first(where: { normalizedName($0.name) == name }) else {
+            return nil
         }
-        if saved {
-            savedPlaylistIDs.insert(id)
+        return libraryPlaylistID(from: item.uri)
+    }
+
+    /// Optimistically flips the favourite-name membership so the star updates
+    /// before the socket round-trip completes.
+    private func setFavoriteOptimistically(_ favorite: Bool, playlist: MusicSearchItem) {
+        let name = normalizedName(playlist.name)
+        if favorite {
+            if !maFavorites.contains(where: { normalizedName($0.name) == name }) {
+                maFavorites.append(playlist)
+            }
         } else {
-            savedPlaylistIDs.remove(id)
+            maFavorites.removeAll { normalizedName($0.name) == name }
         }
+    }
+
+    /// Re-fetches the MA favourites (drives the star state and the unfavourite id
+    /// lookup), then the Spotify listing so the per-owner sections reflect any
+    /// follow change the 2-way sync propagated.
+    func refreshFavorites() async {
+        if let favorites = try? await restAPIService.getFavoritePlaylists() {
+            maFavorites = favorites
+        }
+        await refreshSpotifyPlaylists()
     }
 
     // MARK: - Transport & volume

--- a/IntelliNest/ViewModels/MusicViewModel+SpotifyTracks.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+SpotifyTracks.swift
@@ -78,29 +78,6 @@ extension MusicViewModel {
         }
     }
 
-    // MARK: - Library row saved-state
-
-    /// Changes whenever the library lists change, so the view can reload the
-    /// row stars' saved-state without polling.
-    var librarySavedStateSignature: String {
-        (recentlyPlayedPlaylists.map(\.uri)
-            + favoritePlaylists.map(\.uri)
-            + personalPlaylistSections.flatMap { $0.playlists.map(\.uri) }).joined(separator: "|")
-    }
-
-    /// Populates the saved-state for the library rows. The favourites section is
-    /// the account library, so every id in it is saved by definition — start from
-    /// that set (resetting so an un-favourited playlist still shown elsewhere drops
-    /// its star). Recently-played and personal-account playlists not already in the
-    /// library are then queried so their star reflects reality even when they are
-    /// not favourites.
-    func loadLibrarySavedStates() async {
-        savedPlaylistIDs = libraryPlaylistIDs
-        for playlist in recentlyPlayedPlaylists + personalPlaylistSections.flatMap(\.playlists) {
-            await loadSavedState(for: playlist)
-        }
-    }
-
     // MARK: - Playlist membership
 
     /// The account playlists the user may add tracks to (owned or collaborative).

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -53,11 +53,11 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// A library playlist the user opened to browse from the main view (favourites
     /// or recents), presented in its own sheet. Nil when no browse sheet is shown.
     @Published var browsingLibraryPlaylist: MusicSearchItem?
-    /// Spotify ids of playlists currently saved in the user's Spotify library,
-    /// driving the favourite star everywhere a playlist is shown. Keyed by
-    /// resolved Spotify id rather than uri so the same playlist reads the same
-    /// whether it arrived as a `spotify://` favourite or a `library://` recent.
-    @Published var savedPlaylistIDs: Set<String> = []
+    /// The playlists favourited in Music Assistant (`library://playlist/<id>`
+    /// items). Drives the favourite-star fill (matched by name) and carries the
+    /// library id needed to unfavourite over the socket. With MA's Spotify 2-way
+    /// sync on, this mirrors what the huset account follows on Spotify.
+    @Published var maFavorites: [MusicSearchItem] = []
     /// Whether the user is logged into Spotify. Drives the login warning triangle
     /// and its prompt — shown only while logged out.
     @Published var isSpotifyAuthorized = false

--- a/IntelliNest/Views/Music/MusicSearchResultsView.swift
+++ b/IntelliNest/Views/Music/MusicSearchResultsView.swift
@@ -133,7 +133,7 @@ struct MusicPlaylistView: View {
             // large in the header below, so a cramped, truncated nav-bar copy adds
             // nothing. Keep only the favourite star.
             ToolbarItem(placement: .topBarTrailing) {
-                if viewModel.isSpotifyPlaylist(playlist) {
+                if viewModel.canFavoritePlaylist(playlist) {
                     favoriteButton
                 }
             }
@@ -161,17 +161,18 @@ struct MusicPlaylistView: View {
         .padding(.top, 12)
     }
 
-    /// The Spotify favourite star. Filled and yellow when the playlist is saved,
-    /// outlined otherwise. Toggling it logs in to Spotify first if needed.
+    /// The favourite star. Filled and yellow when favourited in Music Assistant,
+    /// outlined otherwise. Toggling it adds/removes the MA favourite (which 2-way
+    /// syncs to the Spotify follow).
     private var favoriteButton: some View {
         let saved = viewModel.isSaved(playlist)
         return Button {
-            Task { await viewModel.toggleSpotifySaved(playlist) }
+            Task { await viewModel.toggleFavorite(playlist) }
         } label: {
             Image(systemName: saved ? "star.fill" : "star")
                 .foregroundStyle(saved ? .yellow : .white)
         }
-        .accessibilityLabel(saved ? "Ta bort från Spotify-favoriter" : "Lägg till i Spotify-favoriter")
+        .accessibilityLabel(saved ? "Ta bort från favoriter" : "Lägg till i favoriter")
     }
 
     private func capsuleButton(title: String,

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -46,14 +46,10 @@ struct MusicView: View {
         }
         .padding(.horizontal)
         .foregroundStyle(.white)
-        // Spotify is the source of truth — refresh the account's playlists each
-        // time the view appears rather than trusting the once-per-session cache.
+        // Refresh the MA favourites (star state) and the Spotify listing each time
+        // the view appears rather than trusting the once-per-session cache.
         .task {
-            await viewModel.refreshSpotifyPlaylists()
-        }
-        // Keep the library-row stars in sync as the favourite/recents lists load.
-        .task(id: viewModel.librarySavedStateSignature) {
-            await viewModel.loadLibrarySavedStates()
+            await viewModel.refreshFavorites()
         }
         .sheet(isPresented: $viewModel.isShowingSearchResults) {
             MusicSearchResultsView(viewModel: viewModel)
@@ -225,7 +221,7 @@ private struct LibraryPlaylistRow: View {
             .accessibilityLabel(playlist.name)
             .accessibilityHint("Öppna spellistan")
 
-            if viewModel.isSpotifyPlaylist(playlist) {
+            if viewModel.canFavoritePlaylist(playlist) {
                 favoriteStar
             } else {
                 Image(systemName: "chevron.right")
@@ -239,13 +235,13 @@ private struct LibraryPlaylistRow: View {
     private var favoriteStar: some View {
         let saved = viewModel.isSaved(playlist)
         return Button {
-            Task { await viewModel.toggleSpotifySaved(playlist) }
+            Task { await viewModel.toggleFavorite(playlist) }
         } label: {
             Image(systemName: saved ? "star.fill" : "star")
                 .foregroundStyle(saved ? .yellow : .white.opacity(0.6))
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(saved ? "Ta bort \(playlist.name) från Spotify-favoriter" : "Lägg till \(playlist.name) i Spotify-favoriter")
+        .accessibilityLabel(saved ? "Ta bort \(playlist.name) från favoriter" : "Lägg till \(playlist.name) i favoriter")
     }
 }
 

--- a/IntelliNestTests/MusicViewModelQueueTests.swift
+++ b/IntelliNestTests/MusicViewModelQueueTests.swift
@@ -6,11 +6,15 @@ import XCTest
 actor StubMusicAssistantQueueSocket: MusicAssistantQueueSocket {
     var items: [MusicQueueItem]
     var deleteSucceeds: Bool
+    var favoriteSucceeds: Bool
     private(set) var deletedItemIDs: [String] = []
+    private(set) var addedFavoriteURIs: [String] = []
+    private(set) var removedFavorites: [String] = []
 
-    init(items: [MusicQueueItem] = [], deleteSucceeds: Bool = true) {
+    init(items: [MusicQueueItem] = [], deleteSucceeds: Bool = true, favoriteSucceeds: Bool = true) {
         self.items = items
         self.deleteSucceeds = deleteSucceeds
+        self.favoriteSucceeds = favoriteSucceeds
     }
 
     func queueItems(queueID _: String) async -> [MusicQueueItem] { items }
@@ -18,6 +22,16 @@ actor StubMusicAssistantQueueSocket: MusicAssistantQueueSocket {
     func deleteItem(queueID _: String, itemID: String) async -> Bool {
         deletedItemIDs.append(itemID)
         return deleteSucceeds
+    }
+
+    func addFavorite(uri: String) async -> Bool {
+        addedFavoriteURIs.append(uri)
+        return favoriteSucceeds
+    }
+
+    func removeFavorite(mediaType: String, libraryItemID: String) async -> Bool {
+        removedFavorites.append("\(mediaType):\(libraryItemID)")
+        return favoriteSucceeds
     }
 }
 

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -125,11 +125,13 @@ extension MusicViewModelTests {
     }
 
     func makeViewModel(spotify: SpotifyPlaylistService,
+                       socket: MusicAssistantQueueSocket = DisabledMusicAssistantQueueSocket(),
                        personalAccounts: [SpotifyPersonalAccount] = SpotifyPersonalAccount.configured,
                        currentUser: @escaping @MainActor () -> User = { .tobias }) -> MusicViewModel {
         MusicViewModel(restAPIService: restAPIService,
                        setErrorBannerText: { [weak self] title, _ in self?.bannerTitles.append(title) },
                        spotify: spotify,
+                       queueSocket: socket,
                        personalAccounts: personalAccounts,
                        currentUser: currentUser)
     }
@@ -149,109 +151,51 @@ extension MusicViewModelTests {
         [playlistItem(uri: "spotify://playlist/p1", name: "Träning", ownerID: "tobiasc91")]
     }
 
-    func testIsSpotifyPlaylistShowsStarForResolvableUriEvenLoggedOut() {
-        let spotifyItem = spotifyPlaylist()
-        let localItem = MusicSearchItem(uri: "library://playlist/3", name: "Lokal",
-                                        mediaType: .playlist, imageURL: nil, artist: nil)
-        // Logged in: star shows for a Spotify uri, not for an unmatched library item.
-        let loggedIn = makeViewModel(spotify: StubSpotifyPlaylistService(authorized: true))
-        XCTAssertTrue(loggedIn.isSpotifyPlaylist(spotifyItem))
-        XCTAssertFalse(loggedIn.isSpotifyPlaylist(localItem))
-        // Logged out: a directly-resolvable Spotify playlist (a search result) still
-        // shows the star — tapping it logs in first, then saves — but an unmatched
-        // library item has no Spotify id to resolve (the account list is empty), so
-        // it stays starless.
-        let loggedOut = makeViewModel(spotify: StubSpotifyPlaylistService(authorized: false))
-        XCTAssertTrue(loggedOut.isSpotifyPlaylist(spotifyItem))
-        XCTAssertFalse(loggedOut.isSpotifyPlaylist(localItem))
+    func testCanFavoriteShownForPlaylistsOnly() {
+        let model = makeViewModel(spotify: StubSpotifyPlaylistService())
+        XCTAssertTrue(model.canFavoritePlaylist(spotifyPlaylist()))
+        let track = MusicSearchItem(uri: "spotify://track/1", name: "Song", mediaType: .track, imageURL: nil, artist: nil)
+        XCTAssertFalse(model.canFavoritePlaylist(track))
     }
 
-    func testLibraryPlaylistResolvesToSpotifyByName() async {
-        // The huset account has this playlist (with its real Spotify id); Music
-        // Assistant exposes the same playlist as an opaque library:// item.
-        let account = [MusicSearchItem(uri: "spotify://playlist/realid42",
-                                       name: "Barnlåtar 🐵 musik för barn",
-                                       mediaType: .playlist, imageURL: nil, artist: nil)]
-        let stub = StubSpotifyPlaylistService(accountPlaylistItems: account)
-        let model = makeViewModel(spotify: stub)
-        await model.refreshSpotifyPlaylists()
-        let libraryItem = MusicSearchItem(uri: "library://playlist/12",
-                                          name: "Barnlåtar 🐵 musik för barn  ",
-                                          mediaType: .playlist, imageURL: nil, artist: nil)
-        XCTAssertTrue(model.isSpotifyPlaylist(libraryItem))
-        await model.toggleSpotifySaved(libraryItem)
-        // It resolved to a Spotify id, so the save went through.
-        XCTAssertEqual(stub.saveCallCount, 1)
+    func testIsSavedMatchesMusicAssistantFavouriteByName() {
+        let model = makeViewModel(spotify: StubSpotifyPlaylistService())
+        model.maFavorites = [playlistItem(uri: "library://playlist/1", name: "Träning")]
+        // Matched by normalized name across the spotify:// / library:// uri spaces.
+        XCTAssertTrue(model.isSaved(playlistItem(uri: "spotify://playlist/x", name: "  träning ")))
+        XCTAssertFalse(model.isSaved(playlistItem(uri: "spotify://playlist/y", name: "Annan")))
     }
 
-    func testLibraryBuiltinPlaylistHasNoStar() async {
-        let account = [MusicSearchItem(uri: "spotify://playlist/realid42", name: "Barnlåtar",
-                                       mediaType: .playlist, imageURL: nil, artist: nil)]
-        let stub = StubSpotifyPlaylistService(accountPlaylistItems: account)
-        let model = makeViewModel(spotify: stub)
-        await model.refreshSpotifyPlaylists()
-        let builtin = MusicSearchItem(uri: "library://playlist/3", name: "Random Album (from library)",
-                                      mediaType: .playlist, imageURL: nil, artist: nil)
-        XCTAssertFalse(model.isSpotifyPlaylist(builtin))
+    func testToggleFavoriteAddsViaSocket() async {
+        let socket = StubMusicAssistantQueueSocket()
+        let model = makeViewModel(spotify: StubSpotifyPlaylistService(), socket: socket)
+        let playlist = spotifyPlaylist()
+        await model.toggleFavorite(playlist)
+        let added = await socket.addedFavoriteURIs
+        XCTAssertEqual(added, [playlist.uri])
+        XCTAssertTrue(model.isSaved(playlist)) // optimistic
     }
 
-    func testLoadSavedStateReflectsLibrary() async {
-        let stub = StubSpotifyPlaylistService(savedIDs: [spotifyPlaylistID])
-        let model = makeViewModel(spotify: stub)
-        await model.loadSavedState(for: spotifyPlaylist())
-        XCTAssertTrue(model.isSaved(spotifyPlaylist()))
+    func testToggleFavoriteRemovesViaSocketUsingLibraryID() async {
+        let socket = StubMusicAssistantQueueSocket()
+        let model = makeViewModel(spotify: StubSpotifyPlaylistService(), socket: socket)
+        let playlist = playlistItem(uri: "spotify://playlist/x", name: "Lugnt")
+        // It's favourited in MA as a library:// item with the same name.
+        model.maFavorites = [playlistItem(uri: "library://playlist/42", name: "Lugnt")]
+        XCTAssertTrue(model.isSaved(playlist))
+        await model.toggleFavorite(playlist)
+        let removed = await socket.removedFavorites
+        XCTAssertEqual(removed, ["playlist:42"])
+        XCTAssertFalse(model.isSaved(playlist)) // optimistic
     }
 
-    func testToggleSavesWhenNotSaved() async {
-        let stub = StubSpotifyPlaylistService()
-        let model = makeViewModel(spotify: stub)
-        await model.toggleSpotifySaved(spotifyPlaylist())
-        XCTAssertTrue(model.isSaved(spotifyPlaylist()))
-        XCTAssertEqual(stub.saveCallCount, 1)
-    }
-
-    func testToggleRemovesWhenSaved() async {
-        let stub = StubSpotifyPlaylistService(savedIDs: [spotifyPlaylistID])
-        let model = makeViewModel(spotify: stub)
-        await model.loadSavedState(for: spotifyPlaylist())
-        await model.toggleSpotifySaved(spotifyPlaylist())
-        XCTAssertFalse(model.isSaved(spotifyPlaylist()))
-        XCTAssertEqual(stub.removeCallCount, 1)
-    }
-
-    func testToggleFailureRevertsAndBanners() async {
-        let stub = StubSpotifyPlaylistService(operationSucceeds: false)
-        let model = makeViewModel(spotify: stub)
-        await model.toggleSpotifySaved(spotifyPlaylist())
-        XCTAssertFalse(model.isSaved(spotifyPlaylist()))
+    func testToggleFavoriteFailureRevertsAndBanners() async {
+        let socket = StubMusicAssistantQueueSocket(favoriteSucceeds: false)
+        let model = makeViewModel(spotify: StubSpotifyPlaylistService(), socket: socket)
+        let playlist = spotifyPlaylist()
+        await model.toggleFavorite(playlist)
+        XCTAssertFalse(model.isSaved(playlist)) // reverted
         XCTAssertTrue(bannerTitles.contains("Kunde inte uppdatera favorit"))
-    }
-
-    func testToggleLogsInWhenUnauthorized() async {
-        let stub = StubSpotifyPlaylistService(authorized: false)
-        let model = makeViewModel(spotify: stub)
-        await model.toggleSpotifySaved(spotifyPlaylist())
-        XCTAssertEqual(stub.authorizeCallCount, 1)
-        XCTAssertTrue(model.isSaved(spotifyPlaylist()))
-    }
-
-    func testToggleAuthorizeFailureBanners() async {
-        let stub = StubSpotifyPlaylistService(authorized: false, authorizeThrows: true)
-        let model = makeViewModel(spotify: stub)
-        await model.toggleSpotifySaved(spotifyPlaylist())
-        XCTAssertEqual(stub.saveCallCount, 0)
-        XCTAssertFalse(model.isSaved(spotifyPlaylist()))
-        XCTAssertTrue(bannerTitles.contains("Spotify-inloggning misslyckades"))
-    }
-
-    func testToggleIgnoresNonSpotifyPlaylist() async {
-        let stub = StubSpotifyPlaylistService()
-        let model = makeViewModel(spotify: stub)
-        let localItem = MusicSearchItem(uri: "library://playlist/3", name: "Lokal",
-                                        mediaType: .playlist, imageURL: nil, artist: nil)
-        await model.toggleSpotifySaved(localItem)
-        XCTAssertEqual(stub.saveCallCount, 0)
-        XCTAssertTrue(model.savedPlaylistIDs.isEmpty)
     }
 
     func testSpotifyAccountPlaylistsLoadIntoFavoritesOnReload() async {
@@ -327,12 +271,13 @@ extension MusicViewModelTests {
         XCTAssertEqual(stub.accountPlaylistsCallCount, 0)
     }
 
-    func testToggleRefreshesAccountPlaylists() async {
+    func testToggleRefreshesListing() async {
         let item = MusicSearchItem(uri: "spotify://playlist/x", name: "Ny",
                                    mediaType: .playlist, imageURL: nil, artist: nil)
         let stub = StubSpotifyPlaylistService(accountPlaylistItems: [item])
-        let model = makeViewModel(spotify: stub)
-        await model.toggleSpotifySaved(spotifyPlaylist())
+        let model = makeViewModel(spotify: stub, socket: StubMusicAssistantQueueSocket())
+        // A successful favourite refreshes the listing (which 2-way sync may change).
+        await model.toggleFavorite(spotifyPlaylist())
         XCTAssertEqual(model.favoritePlaylists.map(\.name), ["Ny"])
         XCTAssertGreaterThanOrEqual(stub.accountPlaylistsCallCount, 1)
     }
@@ -476,60 +421,5 @@ extension MusicViewModelTests {
         await model.refreshSpotifyPlaylists()
         XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor", "Tobias spellistor"])
         XCTAssertEqual(model.personalPlaylistSections.first?.account.userID, "sarahtest42")
-    }
-
-    func testLoadLibrarySavedStatesResolvesPersonalSectionRows() async {
-        // A personal playlist saved in the huset library but not a favourite must
-        // still get its row star resolved, so it isn't shown empty until detail open.
-        let personal = playlistItem(uri: "spotify://playlist/p1", name: "Träning", ownerID: "tobiasc91")
-        let stub = StubSpotifyPlaylistService(savedIDs: ["p1"], accountPlaylistItems: [personal])
-        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
-        await model.refreshSpotifyPlaylists()
-        XCTAssertTrue(model.librarySavedStateSignature.contains("spotify://playlist/p1"))
-        await model.loadLibrarySavedStates()
-        XCTAssertTrue(model.isSaved(personal))
-    }
-
-    func testLoadLibrarySavedStatesLeavesUnsavedPersonalRowUnmarked() async {
-        let personal = playlistItem(uri: "spotify://playlist/p9", name: "Inte sparad", ownerID: "tobiasc91")
-        let stub = StubSpotifyPlaylistService(savedIDs: [], accountPlaylistItems: [personal])
-        let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
-        await model.refreshSpotifyPlaylists()
-        await model.loadLibrarySavedStates()
-        XCTAssertFalse(model.isSaved(personal))
-    }
-
-    // A playlist the account *owns* isn't "followed", so Spotify's follow-contains
-    // check (`savedIDs` here) returns false for it. Library membership, not that
-    // check, must decide the star — otherwise the same owned playlist shows filled
-    // under Favoriter but hollow under Senast spelade.
-    func testOwnedFavouriteShowsSavedInBothFavouritesAndRecents() async {
-        let name = "Låtar som är ganska sköna och avslappnande"
-        let owned = MusicSearchItem(uri: "spotify://playlist/owned1", name: name,
-                                    mediaType: .playlist, imageURL: nil, artist: "huset")
-        // savedIDs empty → the follow-contains check would say "not saved".
-        let stub = StubSpotifyPlaylistService(savedIDs: [], accountPlaylistItems: [owned])
-        let model = makeViewModel(spotify: stub)
-        await model.refreshSpotifyPlaylists()
-        // The same playlist surfaces in Senast spelade as an opaque library:// item.
-        let recent = MusicSearchItem(uri: "library://playlist/42", name: name,
-                                     mediaType: .playlist, imageURL: nil, artist: nil)
-        model.recentlyPlayedPlaylists = [recent]
-        await model.loadLibrarySavedStates()
-        XCTAssertTrue(model.isSaved(owned))
-        XCTAssertTrue(model.isSaved(recent))
-    }
-
-    // Opening an owned favourite's detail must not un-mark it: the follow-contains
-    // check returns false, but library membership keeps the star filled (the popup
-    // no longer drops the playlist to non-favourite on dismiss).
-    func testOpeningOwnedFavouriteDetailKeepsItSaved() async {
-        let owned = MusicSearchItem(uri: "spotify://playlist/owned1", name: "Min egen lista",
-                                    mediaType: .playlist, imageURL: nil, artist: "huset")
-        let stub = StubSpotifyPlaylistService(savedIDs: [], accountPlaylistItems: [owned])
-        let model = makeViewModel(spotify: stub)
-        await model.refreshSpotifyPlaylists()
-        await model.loadSavedState(for: owned)
-        XCTAssertTrue(model.isSaved(owned))
     }
 }


### PR DESCRIPTION
## Why

The favourite star never worked: the app's Spotify client is in **Development mode**, so the
follow/unfollow *write* returns **403** (same family as the playlist-read 403s). There's no Spotify
path to favourite a playlist from this app.

Music Assistant can, though — and the user has MA's Spotify provider **"Sync back library
additions/removals (2-way sync)"** enabled, so an MA favourite ⟺ a Spotify follow stay in sync
automatically. So favourites move to MA. (Builds on #143, which authenticated the MA socket.)

## What changed

- **Star → MA favourite.** `toggleFavorite` adds/removes the favourite over the MA socket
  (`music/favorites/add_item` by uri / `remove_item` by library id), with optimistic flip + revert on
  failure. MA's 2-way sync then follows/unfollows it on Spotify; the next listing reload reflects it.
- **Favourite state from MA.** `isSaved` matches a playlist against the MA favourites
  (`get_library favorite:true`) by normalized name (MA favourites are `library://`, the listing is
  `spotify://`). Replaced the whole Spotify follow-contains saved-state machinery
  (`savedPlaylistIDs`/`libraryPlaylistIDs`/`loadLibrarySavedStates`/…).
- The listing (Favoriter + per-person sections from `/me/playlists`, partitioned by owner) is
  **unchanged** — Spotify stays the catalog source; MA is now the favourite store.
- Socket gains `addFavorite`/`removeFavorite`; `getFavoritePlaylists` reads MA favourites.

No app-level sync or tombstones — MA's 2-way sync handles propagation both directions, which also
resolves the "unfavourite in MA doesn't unfollow Spotify" concern.

## Tests

Full suite green. Reworked the favourite tests to MA (`toggleFavorite` add/remove via the socket stub,
`isSaved` by name, optimistic revert + banner); the obsolete Spotify-follow saved-state tests removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)