### PR TITLE
Fixed Music Assistant socket crash on null command results

### DIFF
--- a/IntelliNest/Services/MusicAssistantSocketService.swift
+++ b/IntelliNest/Services/MusicAssistantSocketService.swift
@@ -122,7 +122,10 @@ final class MusicAssistantSocketService: MusicAssistantQueueSocket {
     /// can't be serialized.
     private static func frameJSON(command: String, messageID: String, args: [String: Any]) -> String? {
         let payload: [String: Any] = ["command": command, "message_id": messageID, "args": args]
-        guard let data = try? JSONSerialization.data(withJSONObject: payload) else {
+        // `JSONSerialization.data(withJSONObject:)` raises an uncatchable Obj-C
+        // exception on an invalid object, so validate before serializing.
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload) else {
             return nil
         }
         return String(data: data, encoding: .utf8)
@@ -144,10 +147,18 @@ final class MusicAssistantSocketService: MusicAssistantQueueSocket {
                   let replyID = replyMessageID(object), replyID == messageID else {
                 continue
             }
-            guard object["error_code"] == nil, let result = object["result"] else {
+            guard object["error_code"] == nil else {
                 return nil
             }
-            return try? JSONSerialization.data(withJSONObject: result)
+            // A successful command may return a non-container `result` — favourites
+            // add/remove reply with `null`. `JSONSerialization.data(withJSONObject:)`
+            // only accepts a top-level array/dictionary and raises an Obj-C exception
+            // (which `try?` can't catch) on a scalar/null, so only serialize a valid
+            // container; otherwise signal success with empty Data.
+            guard let result = object["result"], JSONSerialization.isValidJSONObject(result) else {
+                return Data()
+            }
+            return (try? JSONSerialization.data(withJSONObject: result)) ?? Data()
         }
         return nil
     }

--- a/IntelliNestTests/MusicViewModelGroupingTests.swift
+++ b/IntelliNestTests/MusicViewModelGroupingTests.swift
@@ -70,16 +70,16 @@ extension MusicViewModelTests {
                 return
             }
             if path.contains("/media_player/unjoin") {
-                orderLock.lock(); requestOrder.append("unjoin"); orderLock.unlock()
+                orderLock.withLock { requestOrder.append("unjoin") }
             } else if path.contains("/media_player/join") {
-                orderLock.lock(); requestOrder.append("join"); orderLock.unlock()
+                orderLock.withLock { requestOrder.append("join") }
             }
         }
         stubPostService(path: "/api/services/media_player/unjoin")
         stubPostService(path: "/api/services/media_player/join")
 
         await viewModel.toggleGroupMember(.mediaPlayerSpa)
-        orderLock.lock(); let recordedOrder = requestOrder; orderLock.unlock()
+        let recordedOrder = orderLock.withLock { requestOrder }
         XCTAssertEqual(recordedOrder, ["unjoin", "join"])
     }
 
@@ -96,16 +96,16 @@ extension MusicViewModelTests {
                 return
             }
             if path.contains("/media_player/unjoin") {
-                orderLock.lock(); requestOrder.append("unjoin"); orderLock.unlock()
+                orderLock.withLock { requestOrder.append("unjoin") }
             } else if path.contains("/media_player/join") {
-                orderLock.lock(); requestOrder.append("join"); orderLock.unlock()
+                orderLock.withLock { requestOrder.append("join") }
             }
         }
         stubPostService(path: "/api/services/media_player/unjoin")
         stubPostService(path: "/api/services/media_player/join")
 
         await viewModel.toggleGroupMember(.mediaPlayerSpa)
-        orderLock.lock(); let recordedOrder = requestOrder; orderLock.unlock()
+        let recordedOrder = orderLock.withLock { requestOrder }
         XCTAssertEqual(recordedOrder, ["join"])
     }
 


### PR DESCRIPTION
## Why

Tapping the favourite star **crashed the app**:

```
NSInvalidArgumentException — +[NSJSONSerialization dataWithJSONObject:options:error:]:
Invalid top-level type in JSON write
```

`MusicAssistantSocketService.awaitReply` serialized the reply's `result` with
`JSONSerialization.data(withJSONObject:)`. The favourite `add_item`/`remove_item` commands reply with
`result: null` (verified against the live MA 2.9 server), and that API **raises an Obj-C `NSException`** on
a non-container top level — which Swift's `try?` does **not** catch — so it terminated the app.

## What changed

- `awaitReply` now only serializes a `result` that passes `JSONSerialization.isValidJSONObject`; a
  `null`/scalar result returns empty `Data()` to signal success (commands like favourites return no body).
- `frameJSON` validates the payload with `isValidJSONObject` before serializing too — defensive, so no
  socket frame can ever trip the same exception.
- Swift 6 readiness: replaced `NSLock.lock()/unlock()` (unavailable from async contexts — a hard error in
  Swift 6) with scoped `NSLock.withLock { }` in the grouping tests. Build is now warning-clean there.

No behaviour change for the queue commands (their results are arrays — valid containers). Favourite
add/remove now succeed without crashing.

## Tests

Full suite green; the four `unavailable from asynchronous` warnings are gone. Verified end-to-end against
the live MA server that `add_item`/`remove_item` reply `result: null` and succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)