### PR TITLE
Pre-selected last used speaker and reworked group controls

### DIFF
--- a/IntelliNest/Utils/Constants/StorageKeys.swift
+++ b/IntelliNest/Utils/Constants/StorageKeys.swift
@@ -16,4 +16,5 @@ enum StorageKeys: String {
     case webhookID
     case yaleAccessToken
     case spotifyTokens
+    case lastMusicSpeaker
 }

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -117,6 +117,11 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// viewer's own playlists are shown first and titled "Mina spellistor".
     /// Injected as a closure so tests don't depend on shared `UserDefaults`.
     let currentUser: @MainActor () -> User
+    /// Reads/writes the last speaker the user controlled, so it can be
+    /// pre-selected when the music view next opens. Injected as closures so tests
+    /// don't depend on shared `UserDefaults`.
+    let loadLastSpeaker: @MainActor () -> EntityId?
+    let saveLastSpeaker: @MainActor (EntityId) -> Void
 
     /// Speakers that are reachable right now (anything not `unavailable`),
     /// in the fixed display order.
@@ -136,13 +141,21 @@ class MusicViewModel: ObservableObject, Reloadable {
          spotify: SpotifyPlaylistService = DisabledSpotifyPlaylistService(),
          queueSocket: MusicAssistantQueueSocket = DisabledMusicAssistantQueueSocket(),
          personalAccounts: [SpotifyPersonalAccount] = SpotifyPersonalAccount.configured,
-         currentUser: @escaping @MainActor () -> User = { UserManager.currentUser }) {
+         currentUser: @escaping @MainActor () -> User = { UserManager.currentUser },
+         loadLastSpeaker: @escaping @MainActor () -> EntityId? = {
+             UserDefaults.shared.string(forKey: StorageKeys.lastMusicSpeaker.rawValue).flatMap { EntityId(rawValue: $0) }
+         },
+         saveLastSpeaker: @escaping @MainActor (EntityId) -> Void = {
+             UserDefaults.shared.set($0.rawValue, forKey: StorageKeys.lastMusicSpeaker.rawValue)
+         }) {
         self.restAPIService = restAPIService
         self.setErrorBannerText = setErrorBannerText
         self.spotify = spotify
         self.queueSocket = queueSocket
         self.personalAccounts = personalAccounts
         self.currentUser = currentUser
+        self.loadLastSpeaker = loadLastSpeaker
+        self.saveLastSpeaker = saveLastSpeaker
         isSpotifyAuthorized = spotify.isAuthorized
         var initialSpeakers: [EntityId: MediaPlayerEntity] = [:]
         for speakerID in Self.speakerIDs {
@@ -182,8 +195,9 @@ class MusicViewModel: ObservableObject, Reloadable {
     }
 
     /// On the first reload after the view appears, default the active speaker to
-    /// whatever is currently playing. If nothing is playing, leave it unselected
-    /// so the picker is shown. Runs only once so it never overrides a manual pick.
+    /// whatever is currently playing, falling back to the last speaker the user
+    /// controlled (if it's reachable). If neither applies, leave it unselected so
+    /// the picker is shown. Runs only once so it never overrides a manual pick.
     private func selectDefaultSpeakerIfNeeded() {
         guard !hasSelectedDefaultSpeaker else {
             return
@@ -191,6 +205,9 @@ class MusicViewModel: ObservableObject, Reloadable {
         hasSelectedDefaultSpeaker = true
         if let playing = availableSpeakers.first(where: { $0.isPlaying }) {
             activeSpeakerID = playing.entityId
+        } else if let lastUsed = loadLastSpeaker(),
+                  availableSpeakers.contains(where: { $0.entityId == lastUsed }) {
+            activeSpeakerID = lastUsed
         }
     }
 
@@ -202,6 +219,7 @@ class MusicViewModel: ObservableObject, Reloadable {
 
     func selectSpeaker(_ entityID: EntityId) {
         activeSpeakerID = entityID
+        saveLastSpeaker(entityID)
     }
 
     // MARK: - Search
@@ -325,6 +343,40 @@ class MusicViewModel: ObservableObject, Reloadable {
             if !success {
                 setErrorBannerText("Kunde inte gruppera högtalare", "Det gick inte att lägga till \(speakerName) i gruppen")
             }
+        }
+    }
+
+    /// Promotes a grouped speaker to primary — the one shown and controlled as the
+    /// group's main speaker. Playback still routes through the live Music Assistant
+    /// group leader (`playbackTargetID`), so switching the primary never interrupts
+    /// what's playing. No-op for a speaker that isn't grouped with the active one.
+    func makePrimary(_ speakerID: EntityId) {
+        guard speakerID != activeSpeakerID, isGrouped(speakerID) else {
+            return
+        }
+        selectSpeaker(speakerID)
+    }
+
+    /// Removes the active (primary) speaker from its group and promotes the next
+    /// grouped speaker to active, so playback control follows the speakers that
+    /// keep playing. Music Assistant re-elects the real group leader on its own;
+    /// the new `activeSpeakerID` only needs to be a remaining member, since
+    /// playback commands are routed through the live group leader. No-op when the
+    /// active speaker isn't grouped with anyone.
+    func removeActiveSpeakerFromGroup() async {
+        guard let activeSpeakerID, let activeSpeaker else {
+            return
+        }
+        let remaining = Self.speakerIDs.filter { activeSpeaker.groupMembers.contains($0) && $0 != activeSpeakerID }
+        guard let newActiveID = remaining.first else {
+            return
+        }
+        let speakerName = activeSpeaker.friendlyName
+        let success = await restAPIService.unjoinSpeaker(memberID: activeSpeakerID)
+        if success {
+            self.activeSpeakerID = newActiveID
+        } else {
+            setErrorBannerText("Kunde inte dela upp högtalare", "Det gick inte att ta bort \(speakerName) från gruppen")
         }
     }
 }

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -374,7 +374,9 @@ class MusicViewModel: ObservableObject, Reloadable {
         let speakerName = activeSpeaker.friendlyName
         let success = await restAPIService.unjoinSpeaker(memberID: activeSpeakerID)
         if success {
-            self.activeSpeakerID = newActiveID
+            // Route through selectSpeaker so the promoted speaker is also persisted
+            // as the last-used one, like any other manual selection.
+            selectSpeaker(newActiveID)
         } else {
             setErrorBannerText("Kunde inte dela upp högtalare", "Det gick inte att ta bort \(speakerName) från gruppen")
         }

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -194,13 +194,22 @@ private struct GroupVolumeView: View {
             }
 
             if isExpanded {
-                VStack(spacing: 10) {
+                VStack(spacing: 12) {
                     ForEach(viewModel.groupedSpeakers, id: \.entityId) { speaker in
-                        HStack(spacing: 10) {
-                            Text(speaker.friendlyName)
-                                .font(.subheadline)
-                                .lineLimit(1)
-                                .frame(width: 88, alignment: .leading)
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 6) {
+                                Text(speaker.friendlyName)
+                                    .font(.subheadline)
+                                    .lineLimit(1)
+                                // The group leader (the active speaker) is the sync
+                                // source the others follow — flag it as primary.
+                                if speaker.entityId == viewModel.activeSpeakerID {
+                                    Text("Primär")
+                                        .font(.caption2)
+                                        .foregroundStyle(.yellow.opacity(0.8))
+                                }
+                                Spacer(minLength: 0)
+                            }
                             VolumeSliderView(volume: speaker.volumeLevel,
                                              onCommit: { viewModel.setVolume($0, for: speaker.entityId) })
                                 .accessibilityLabel("Volym \(speaker.friendlyName)")

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -200,7 +200,7 @@ private struct GroupVolumeView: View {
                             HStack(spacing: 6) {
                                 Text(speaker.friendlyName)
                                     .font(.subheadline)
-                                    .lineLimit(1)
+                                    .fixedSize(horizontal: false, vertical: true)
                                 // The group leader (the active speaker) is the sync
                                 // source the others follow — flag it as primary.
                                 if speaker.entityId == viewModel.activeSpeakerID {

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -17,6 +17,14 @@ struct SpeakerGroupingView: View {
         viewModel.availableSpeakers.filter { $0.entityId != viewModel.activeSpeakerID }
     }
 
+    /// The rows to show: every available speaker, but the active (primary) one is
+    /// only listed while it's grouped with others — so it can be removed, which
+    /// promotes another speaker to primary. Alone, removing it would be a no-op,
+    /// so it stays out of the list.
+    private var listedSpeakers: [MediaPlayerEntity] {
+        viewModel.availableSpeakers.filter { $0.entityId != viewModel.activeSpeakerID || viewModel.isGroupActive }
+    }
+
     /// Names of the speakers grouped with the active one, used for the collapsed
     /// summary line.
     private var groupedNames: [String] {
@@ -54,41 +62,95 @@ struct SpeakerGroupingView: View {
             .accessibilityValue(isExpanded ? "Expanderad" : "Hopfälld. \(summary)")
 
             if isExpanded {
-                ForEach(otherSpeakers, id: \.entityId) { speaker in
-                    let grouped = viewModel.isGrouped(speaker.entityId)
-                    VStack(spacing: 8) {
-                        Button {
-                            Task { await viewModel.toggleGroupMember(speaker.entityId) }
-                        } label: {
-                            HStack {
-                                Image(systemName: grouped ? "checkmark.circle.fill" : "circle")
-                                    .foregroundStyle(grouped ? .yellow : .white.opacity(0.6))
-                                Text(speaker.friendlyName)
-                                if speaker.isPlaying {
-                                    Image(systemName: "speaker.wave.2.fill")
-                                        .font(.caption)
-                                        .foregroundStyle(.green)
-                                        .accessibilityLabel("Spelar nu")
-                                }
-                                Spacer()
-                            }
-                        }
-                        .accessibilityLabel("\(grouped ? "Ta bort" : "Lägg till") \(speaker.friendlyName) i gruppen")
-                        .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
-
-                        VolumeSliderView(volume: speaker.volumeLevel,
-                                         onCommit: { viewModel.setVolume($0, for: speaker.entityId) })
-                            .accessibilityLabel("Volym \(speaker.friendlyName)")
-                    }
-                    .padding(.vertical, 8)
-                    .padding(.horizontal, 12)
-                    .background(grouped ? Color.yellow.opacity(0.12) : Color.white.opacity(0.06))
-                    .cornerRadius(10)
+                ForEach(listedSpeakers, id: \.entityId) { speaker in
+                    SpeakerGroupingRow(viewModel: viewModel,
+                                       speaker: speaker,
+                                       isPrimary: speaker.entityId == viewModel.activeSpeakerID)
                 }
             }
         }
         .padding()
         .background(Color.white.opacity(0.05))
         .cornerRadius(16)
+    }
+}
+
+/// A single grouping row. The leading toggle adds/removes the speaker (removing
+/// the primary promotes the next grouped speaker). A grouped follower also gets a
+/// trailing crown to promote it to primary. Volume lives in the group-volume
+/// control on the now-playing card above, so the row carries no slider.
+private struct SpeakerGroupingRow: View {
+    @ObservedObject var viewModel: MusicViewModel
+    let speaker: MediaPlayerEntity
+    let isPrimary: Bool
+
+    // The primary is always part of its own group; followers reflect membership.
+    private var grouped: Bool {
+        isPrimary || viewModel.isGrouped(speaker.entityId)
+    }
+
+    private var toggleAccessibilityLabel: String {
+        if isPrimary {
+            return "Ta bort \(speaker.friendlyName) som primär högtalare ur gruppen"
+        }
+        return "\(grouped ? "Ta bort" : "Lägg till") \(speaker.friendlyName) i gruppen"
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Button(action: toggle) {
+                HStack(spacing: 6) {
+                    Image(systemName: grouped ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(grouped ? .yellow : .white.opacity(0.6))
+                    Text(speaker.friendlyName)
+                    if isPrimary {
+                        Text("Primär")
+                            .font(.caption2)
+                            .foregroundStyle(.yellow.opacity(0.8))
+                    }
+                    if speaker.isPlaying {
+                        Image(systemName: "speaker.wave.2.fill")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                            .accessibilityLabel("Spelar nu")
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(toggleAccessibilityLabel)
+            .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
+
+            Spacer(minLength: 8)
+
+            // Only a grouped follower can be promoted — the primary is already it,
+            // and an ungrouped speaker has no group to lead.
+            if grouped, !isPrimary {
+                Button {
+                    viewModel.makePrimary(speaker.entityId)
+                } label: {
+                    Image(systemName: "crown")
+                        .foregroundStyle(.white.opacity(0.85))
+                        .frame(width: 40, height: 40)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Gör \(speaker.friendlyName) till primär högtalare")
+            }
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 12)
+        .background(grouped ? Color.yellow.opacity(0.12) : Color.white.opacity(0.06))
+        .cornerRadius(10)
+    }
+
+    private func toggle() {
+        Task {
+            if isPrimary {
+                await viewModel.removeActiveSpeakerFromGroup()
+            } else {
+                await viewModel.toggleGroupMember(speaker.entityId)
+            }
+        }
     }
 }

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -98,10 +98,16 @@ private struct SpeakerGroupingRow: View {
 
     var body: some View {
         HStack(spacing: 6) {
+            // The whole row toggles membership, so this is just a status mark —
+            // a plain checkmark when grouped, empty (but space-reserved so names
+            // stay aligned) otherwise. Not a control of its own.
             Button(action: toggle) {
-                HStack(spacing: 6) {
-                    Image(systemName: grouped ? "checkmark.circle.fill" : "circle")
-                        .foregroundStyle(grouped ? .yellow : .white.opacity(0.6))
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.yellow)
+                        .opacity(grouped ? 1 : 0)
+                        .frame(width: 18)
                     Text(speaker.friendlyName)
                     if isPrimary {
                         Text("Primär")
@@ -114,14 +120,13 @@ private struct SpeakerGroupingRow: View {
                             .foregroundStyle(.green)
                             .accessibilityLabel("Spelar nu")
                     }
+                    Spacer(minLength: 8)
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel(toggleAccessibilityLabel)
             .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
-
-            Spacer(minLength: 8)
 
             // Only a grouped follower can be promoted — the primary is already it,
             // and an ungrouped speaker has no group to lead.
@@ -139,7 +144,8 @@ private struct SpeakerGroupingRow: View {
             }
         }
         .padding(.vertical, 12)
-        .padding(.horizontal, 12)
+        .padding(.leading, 12)
+        .padding(.trailing, grouped && !isPrimary ? 4 : 12)
         .background(grouped ? Color.yellow.opacity(0.12) : Color.white.opacity(0.06))
         .cornerRadius(10)
     }

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -75,10 +75,11 @@ struct SpeakerGroupingView: View {
     }
 }
 
-/// A single grouping row. The leading toggle adds/removes the speaker (removing
-/// the primary promotes the next grouped speaker). A grouped follower also gets a
-/// trailing crown to promote it to primary. Volume lives in the group-volume
-/// control on the now-playing card above, so the row carries no slider.
+/// A single grouping row. Tapping the row adds/removes the speaker (removing the
+/// primary promotes the next grouped speaker). Each grouped row carries a "Primär"
+/// chip — solid on the current primary, a tappable outline on followers that
+/// promotes them. Volume lives in the group-volume control on the now-playing
+/// card above, so the row carries no slider.
 private struct SpeakerGroupingRow: View {
     @ObservedObject var viewModel: MusicViewModel
     let speaker: MediaPlayerEntity
@@ -97,7 +98,7 @@ private struct SpeakerGroupingRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 8) {
             // The whole row toggles membership, so this is just a status mark —
             // a plain checkmark when grouped, empty (but space-reserved so names
             // stay aligned) otherwise. Not a control of its own.
@@ -109,11 +110,6 @@ private struct SpeakerGroupingRow: View {
                         .opacity(grouped ? 1 : 0)
                         .frame(width: 18)
                     Text(speaker.friendlyName)
-                    if isPrimary {
-                        Text("Primär")
-                            .font(.caption2)
-                            .foregroundStyle(.yellow.opacity(0.8))
-                    }
                     if speaker.isPlaying {
                         Image(systemName: "speaker.wave.2.fill")
                             .font(.caption)
@@ -121,33 +117,51 @@ private struct SpeakerGroupingRow: View {
                             .accessibilityLabel("Spelar nu")
                     }
                     Spacer(minLength: 8)
+                    // The current primary's chip rides along with the row tap (which
+                    // removes it); a follower's chip is a separate promote button.
+                    if isPrimary {
+                        primaryChip(filled: true)
+                    }
                 }
+                .frame(minHeight: 28)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel(toggleAccessibilityLabel)
             .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
 
-            // Only a grouped follower can be promoted — the primary is already it,
-            // and an ungrouped speaker has no group to lead.
             if grouped, !isPrimary {
                 Button {
                     viewModel.makePrimary(speaker.entityId)
                 } label: {
-                    Image(systemName: "crown")
-                        .foregroundStyle(.white.opacity(0.85))
-                        .frame(width: 40, height: 40)
-                        .contentShape(Rectangle())
+                    primaryChip(filled: false)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Gör \(speaker.friendlyName) till primär högtalare")
             }
         }
-        .padding(.vertical, 12)
-        .padding(.leading, 12)
-        .padding(.trailing, grouped && !isPrimary ? 4 : 12)
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
         .background(grouped ? Color.yellow.opacity(0.12) : Color.white.opacity(0.06))
         .cornerRadius(10)
+    }
+
+    /// The "Primär" pill. Solid yellow marks the current primary; an outline marks
+    /// a follower that can be promoted by tapping it.
+    private func primaryChip(filled: Bool) -> some View {
+        Text("Primär")
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .foregroundStyle(filled ? .black : .yellow.opacity(0.9))
+            .background {
+                if filled {
+                    Capsule().fill(.yellow.opacity(0.9))
+                } else {
+                    Capsule().stroke(.yellow.opacity(0.55), lineWidth: 1)
+                }
+            }
+            .contentShape(Capsule())
     }
 
     private func toggle() {

--- a/IntelliNestTests/MusicViewModelGroupingTests.swift
+++ b/IntelliNestTests/MusicViewModelGroupingTests.swift
@@ -142,6 +142,57 @@ extension MusicViewModelTests {
         await viewModel.toggleGroupMember(.mediaPlayerKitchen)
     }
 
+    func testRemoveActiveSpeakerFromGroupPromotesNextSpeaker() async {
+        // Kitchen leads a group with Playroom and Matbord-ute.
+        await reloadGroupedKitchenLeader()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerKitchen)
+
+        let expectation = XCTestExpectation(description: "POST unjoin")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/media_player/unjoin") == true {
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/unjoin")
+        await viewModel.removeActiveSpeakerFromGroup()
+        await fulfillment(of: [expectation], timeout: 2.0)
+        // The next remaining member in display order takes over as active.
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerPlayroom)
+    }
+
+    func testMakePrimaryPromotesGroupedSpeaker() async {
+        await reloadGroupedKitchenLeader()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerKitchen)
+        XCTAssertTrue(viewModel.isGrouped(.mediaPlayerPlayroom))
+        viewModel.makePrimary(.mediaPlayerPlayroom)
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerPlayroom)
+    }
+
+    func testMakePrimaryIgnoresUngroupedSpeaker() async {
+        await reloadGroupedKitchenLeader()
+        // Spa isn't in the group, so it can't be made primary.
+        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerSpa))
+        viewModel.makePrimary(.mediaPlayerSpa)
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerKitchen)
+    }
+
+    func testRemoveActiveSpeakerNoOpWhenUngrouped() async {
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        XCTAssertFalse(viewModel.isGroupActive)
+        // Nothing to promote — the active speaker stays put.
+        await viewModel.removeActiveSpeakerFromGroup()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerKitchen)
+    }
+
+    func testRemoveActiveSpeakerFailureKeepsPrimaryAndBanners() async {
+        await reloadGroupedKitchenLeader()
+        stubPostService(path: "/api/services/media_player/unjoin", statusCode: 500)
+        await viewModel.removeActiveSpeakerFromGroup()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerKitchen)
+        XCTAssertTrue(bannerTitles.contains("Kunde inte dela upp högtalare"))
+    }
+
     // MARK: - Live updates
 
     func testReloadKeepsOtherSpeakersWhenOneFailsToDecode() async {

--- a/IntelliNestTests/MusicViewModelTests.swift
+++ b/IntelliNestTests/MusicViewModelTests.swift
@@ -7,6 +7,9 @@ class MusicViewModelTests: XCTestCase {
     var restAPIService: RestAPIService!
     var urlCreator: URLCreator!
     var bannerTitles: [String] = []
+    /// In-memory backing for the last-used-speaker persistence so tests stay
+    /// deterministic instead of touching shared `UserDefaults`.
+    var storedLastSpeaker: EntityId?
 
     // Fixed, grep-searchable literals — no random data.
     let trackURI = "spotify://track/3SjXx3rbNGk8nCho8YEoz5"
@@ -15,6 +18,7 @@ class MusicViewModelTests: XCTestCase {
 
     override func setUp() async throws {
         bannerTitles = []
+        storedLastSpeaker = nil
         URLProtocolStub.startInterceptingRequests()
         let stubbedSession = URLProtocolStub.createStubbedURLSession()
         urlCreator = URLCreator(session: stubbedSession)
@@ -28,7 +32,9 @@ class MusicViewModelTests: XCTestCase {
         viewModel = MusicViewModel(restAPIService: restAPIService,
                                    setErrorBannerText: { [weak self] title, _ in
                                        self?.bannerTitles.append(title)
-                                   })
+                                   },
+                                   loadLastSpeaker: { [weak self] in self?.storedLastSpeaker },
+                                   saveLastSpeaker: { [weak self] in self?.storedLastSpeaker = $0 })
     }
 
     override func tearDown() async throws {
@@ -133,6 +139,32 @@ class MusicViewModelTests: XCTestCase {
         viewModel.selectSpeaker(.mediaPlayerSpa)
         await viewModel.reload()
         XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerSpa)
+    }
+
+    func testSelectSpeakerPersistsLastUsed() {
+        viewModel.selectSpeaker(.mediaPlayerSpa)
+        XCTAssertEqual(storedLastSpeaker, .mediaPlayerSpa)
+    }
+
+    func testDefaultActiveSpeaker_picksLastUsedWhenNothingPlaying() async {
+        storedLastSpeaker = .mediaPlayerGuestRoom
+        stubAllSpeakers(playing: nil)
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerGuestRoom)
+    }
+
+    func testDefaultActiveSpeaker_playingWinsOverLastUsed() async {
+        storedLastSpeaker = .mediaPlayerGuestRoom
+        stubAllSpeakers(playing: .mediaPlayerLivingRoom)
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerLivingRoom)
+    }
+
+    func testDefaultActiveSpeaker_ignoresUnavailableLastUsed() async {
+        storedLastSpeaker = .mediaPlayerSpa
+        stubAllSpeakers(playing: nil, unavailable: [.mediaPlayerSpa])
+        await viewModel.reload()
+        XCTAssertNil(viewModel.activeSpeakerID)
     }
 
     // MARK: - Unavailable speaker filtering


### PR DESCRIPTION
## What

Music view improvements driven by feedback while using it:

- **Last used speaker is pre-selected.** When the music view opens and nothing is playing, the last speaker you controlled is selected instead of dropping you on the picker. A currently-playing speaker still wins. Persisted in `UserDefaults` (injected as closures so tests stay deterministic).
- **Per-speaker volume consolidated.** The grouping rows no longer carry their own volume sliders — volume lives only in the group-volume control on the now-playing card. There, the **speaker name now sits above** each slider (full width, no truncation), and the group leader is tagged **"Primär"**.
- **Primary shown in Gruppera högtalare.** The active (primary) speaker now appears in the grouping list while it's grouped; unchecking it removes it from the group and promotes the next grouped speaker to primary.
- **Choose the primary.** Each grouped follower has a 👑 button to promote it to primary. This is a non-disruptive UI switch — playback still routes through the live Music Assistant group leader via `playbackTargetID`, so nothing is interrupted.

## Tests

Added VM coverage for last-used persistence/restore (and playing-wins / unavailable-ignored), `removeActiveSpeakerFromGroup` (promote / no-op / failure-banner), and `makePrimary` (promote / ignore-ungrouped). Full suite green.

## Note on "Lugnt & Skönt"

Separately the user asked why that playlist shows in no list. It's a Spotify **"Made for Huset"** algorithmic playlist; those aren't returned by `/me/playlists` (what "Favoriter" is built from), so it can't appear there. Not addressed in this PR — answered in the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App now remembers and restores the last selected speaker
  * Added ability to promote grouped speakers to primary with visual "Primär" badge indicator
  * Added functionality to remove the active speaker from a group with automatic leader reassignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->