### PR TITLE
Auto-favourited Spotify library playlists in Music Assistant on load

### DIFF
--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -385,12 +385,54 @@ extension MusicViewModel {
 
     /// Re-fetches the MA favourites (drives the star state and the unfavourite id
     /// lookup), then the Spotify listing so the per-owner sections reflect any
-    /// follow change the 2-way sync propagated.
+    /// follow change the 2-way sync propagated, then stars any Spotify-library
+    /// playlist that isn't already an MA favourite.
     func refreshFavorites() async {
+        var maFavoritesLoaded = false
         if let favorites = try? await restAPIService.getFavoritePlaylists() {
             maFavorites = favorites
+            maFavoritesLoaded = true
         }
         await refreshSpotifyPlaylists()
+        // Only sync once both sides are actually loaded — otherwise an empty MA
+        // fetch would make every Spotify playlist look unfavourited and re-add it.
+        if maFavoritesLoaded {
+            await syncSpotifyLibraryToMAFavorites()
+        }
+    }
+
+    /// Auto-favourites in Music Assistant every playlist in the huset Spotify
+    /// library that isn't already an MA favourite, so a playlist saved on Spotify
+    /// shows a filled star without a manual tap. MA's own 2-way sync is meant to
+    /// keep these aligned but doesn't always; this closes the gap. One-way and
+    /// additive — it never removes a favourite, so a deliberate unstar isn't undone
+    /// — and runs once per session so it can't fight a manual toggle. Best-effort:
+    /// per-item failures are ignored.
+    func syncSpotifyLibraryToMAFavorites() async {
+        guard spotify.isAuthorized, !hasSyncedSpotifyFavorites else {
+            return
+        }
+        let libraryPlaylists = favoritePlaylists + personalPlaylistSections.flatMap(\.playlists)
+        guard libraryPlaylists.isNotEmpty else {
+            // Spotify side not loaded yet — leave the latch open so a later refresh
+            // retries once the library is available.
+            return
+        }
+        hasSyncedSpotifyFavorites = true
+        let alreadyFavorited = maFavoriteNames
+        let toFavorite = libraryPlaylists.filter { !alreadyFavorited.contains(normalizedName($0.name)) }
+        guard toFavorite.isNotEmpty else {
+            return
+        }
+        var didAddAny = false
+        for playlist in toFavorite {
+            let added = await queueSocket.addFavorite(uri: playlist.uri)
+            didAddAny = didAddAny || added
+        }
+        // Reload the favourites so the freshly-starred playlists fill their stars.
+        if didAddAny, let favorites = try? await restAPIService.getFavoritePlaylists() {
+            maFavorites = favorites
+        }
     }
 
     // MARK: - Transport & volume

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -93,6 +93,9 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// Guards the one-time load of the Spotify account's playlists. Reset after a
     /// favourite toggle so the favourites section reflects the change next reload.
     var hasLoadedSpotifyPlaylists = false
+    /// Guards the one-time Spotify-library → MA-favourite sync so it runs once per
+    /// session and can't re-add a playlist the user just unstarred.
+    var hasSyncedSpotifyFavorites = false
     /// Increments on every search so a slow, older response can't overwrite the
     /// results of a newer query.
     private var searchRequestToken = 0

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -198,6 +198,44 @@ extension MusicViewModelTests {
         XCTAssertTrue(bannerTitles.contains("Kunde inte uppdatera favorit"))
     }
 
+    func testSyncStarsUnfavoritedSpotifyLibraryInMA() async {
+        let socket = StubMusicAssistantQueueSocket()
+        let model = makeViewModel(spotify: StubSpotifyPlaylistService(), socket: socket)
+        model.favoritePlaylists = [
+            playlistItem(uri: "spotify://playlist/a", name: "Svensk sommar"),
+            playlistItem(uri: "spotify://playlist/b", name: "Sommarklassiker")
+        ]
+        // Sommarklassiker is already an MA favourite; only Svensk sommar needs syncing.
+        model.maFavorites = [playlistItem(uri: "library://playlist/9", name: "Sommarklassiker")]
+        await model.syncSpotifyLibraryToMAFavorites()
+        let added = await socket.addedFavoriteURIs
+        XCTAssertEqual(added, ["spotify://playlist/a"])
+        XCTAssertTrue(model.hasSyncedSpotifyFavorites)
+    }
+
+    func testSyncRunsOncePerSession() async {
+        let socket = StubMusicAssistantQueueSocket()
+        let model = makeViewModel(spotify: StubSpotifyPlaylistService(), socket: socket)
+        model.favoritePlaylists = [playlistItem(uri: "spotify://playlist/a", name: "Svensk sommar")]
+        await model.syncSpotifyLibraryToMAFavorites()
+        // A second run (e.g. after the user unstarred it) must not re-add anything.
+        model.favoritePlaylists = [playlistItem(uri: "spotify://playlist/c", name: "Ny lista")]
+        await model.syncSpotifyLibraryToMAFavorites()
+        let added = await socket.addedFavoriteURIs
+        XCTAssertEqual(added, ["spotify://playlist/a"])
+    }
+
+    func testSyncSkippedWhenLoggedOut() async {
+        let socket = StubMusicAssistantQueueSocket()
+        let model = makeViewModel(spotify: StubSpotifyPlaylistService(authorized: false), socket: socket)
+        model.favoritePlaylists = [playlistItem(uri: "spotify://playlist/a", name: "Svensk sommar")]
+        await model.syncSpotifyLibraryToMAFavorites()
+        let added = await socket.addedFavoriteURIs
+        XCTAssertTrue(added.isEmpty)
+        // Latch stays open so it can run once the user logs in.
+        XCTAssertFalse(model.hasSyncedSpotifyFavorites)
+    }
+
     func testSpotifyAccountPlaylistsLoadIntoFavoritesOnReload() async {
         let accountPlaylists = [
             MusicSearchItem(uri: "spotify://playlist/a", name: "Morgon", mediaType: .playlist, imageURL: nil, artist: "huset"),


### PR DESCRIPTION
## What

Closes the gap behind "why are some Favoriter rows not starred?" — the **Favoriter** list is sourced from the huset Spotify account library (`/me/playlists`), while the ⭐ is sourced from **Music Assistant favourites**. They were meant to stay aligned by MA's own 2-way Spotify sync, but in practice some followed-on-Spotify playlists were never favourited in MA, so they showed empty stars.

This adds a load-time, one-way sync: on `refreshFavorites`, any playlist in the Spotify library that isn't already an MA favourite gets `add_favorite`'d over the socket, so saved-on-Spotify playlists show a filled star automatically.

## Behaviour

- **One-way (Spotify → MA), additive only** — never removes a favourite, so a deliberate unstar is never undone.
- **Once per session** (`hasSyncedSpotifyFavorites` latch) — can't fight a manual toggle within a session.
- **Guarded** — only runs after a successful MA-favourites fetch (so an empty/failed fetch doesn't make everything look unfavourited and re-add it) and only when the Spotify library has actually loaded (latch stays open otherwise, to retry next refresh).
- **Best-effort** — per-item socket failures are ignored; a successful pass reloads MA favourites so the stars fill.

## Tests

`testSyncStarsUnfavoritedSpotifyLibraryInMA` (only the not-yet-favourited one is added), `testSyncRunsOncePerSession` (no re-add after a manual unstar), `testSyncSkippedWhenLoggedOut`. Full suite green.

## Note

This does **not** make "Lugnt & Skönt" appear in Favoriter — that playlist isn't in the Spotify library (`/me/playlists`) at all (it's a "Made for Huset" personalized playlist saved only in the Spotify app, not followed), so there's nothing to sync from. It's favourited directly in MA instead and shows under Senast spelade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic one-time synchronization of favorite Spotify library playlists to Music Assistant per session, preventing duplicate additions.
  * Enhanced favorites refresh to intelligently sync missing Spotify library items while respecting unsync preferences.

* **Tests**
  * Added comprehensive test coverage for Spotify-to-Music Assistant favorites synchronization, including sync state management and session-based behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->