### PR TITLE
Titled personal playlist sections by owner name instead of Mina

### DIFF
--- a/IntelliNest/Services/SpotifyApiService.swift
+++ b/IntelliNest/Services/SpotifyApiService.swift
@@ -13,9 +13,9 @@ import Foundation
 struct SpotifyPersonalAccount: Identifiable, Equatable {
     /// The Spotify user id that owns these playlists in the huset library.
     let userID: String
-    /// The app user this account belongs to — drives the per-viewer section title
-    /// ("Mina spellistor" for the logged-in user, the person's name for everyone
-    /// else) and ordering (the viewer's own section is shown first).
+    /// The app user this account belongs to — drives the section title (the
+    /// owner's name, e.g. "Tobias spellistor") and ordering (the viewer's own
+    /// section is shown first).
     let user: User
 
     var id: String { userID }

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -72,8 +72,8 @@ extension MusicViewModel {
             }
             return !personalAccountIDs.contains(ownerID)
         }
-        // Show the viewer's own section first; the rest keep configured order. The
-        // viewer's own is titled "Mina spellistor", everyone else's by their name.
+        // Show the viewer's own section first; the rest keep configured order.
+        // Every section is titled by its owner's name (e.g. "Tobias spellistor").
         let viewer = currentUser()
         let orderedAccounts = personalAccounts.filter { $0.user == viewer }
             + personalAccounts.filter { $0.user != viewer }
@@ -82,8 +82,7 @@ extension MusicViewModel {
             guard owned.isNotEmpty else {
                 return nil
             }
-            let title = account.user == viewer ? "Mina spellistor" : account.user.playlistSectionTitle
-            return PersonalPlaylistSection(account: account, title: title, playlists: owned)
+            return PersonalPlaylistSection(account: account, title: account.user.playlistSectionTitle, playlists: owned)
         }
         hasLoadedSpotifyPlaylists = true
         editablePlaylistSpotifyIDs = await spotify.editablePlaylistIDs()

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 /// A personal account's section of playlists, ready to render. The `title` is
-/// resolved per viewer ("Mina spellistor" for the logged-in user, the person's
-/// name otherwise), so it's stored rather than derived from the account.
+/// the owner's name ("Tobias spellistor", "Sarahs spellistor"), so it's stored
+/// rather than derived from the account.
 struct PersonalPlaylistSection: Identifiable, Equatable {
     let account: SpotifyPersonalAccount
     let title: String
@@ -117,8 +117,9 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// hide-when-empty rule without depending on the baked-in list.
     let personalAccounts: [SpotifyPersonalAccount]
     /// The logged-in app user, read when building the personal sections so the
-    /// viewer's own playlists are shown first and titled "Mina spellistor".
-    /// Injected as a closure so tests don't depend on shared `UserDefaults`.
+    /// viewer's own playlists are shown first (each section is titled by its
+    /// owner's name). Injected as a closure so tests don't depend on shared
+    /// `UserDefaults`.
     let currentUser: @MainActor () -> User
     /// Reads/writes the last speaker the user controlled, so it can be
     /// pre-selected when the music view next opens. Injected as closures so tests

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -340,7 +340,7 @@ extension MusicViewModelTests {
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
         await model.refreshSpotifyPlaylists()
         XCTAssertEqual(model.personalPlaylistSections.count, 1)
-        XCTAssertEqual(model.personalPlaylistSections.first?.title, "Mina spellistor")
+        XCTAssertEqual(model.personalPlaylistSections.first?.title, "Tobias spellistor")
         // Order is preserved exactly as returned — no client-side re-sorting.
         XCTAssertEqual(model.personalPlaylistSections.first?.playlists.map(\.name), ["Träning", "Lugnt & skönt"])
     }
@@ -363,11 +363,11 @@ extension MusicViewModelTests {
         stubAllSpeakers(playing: .mediaPlayerKitchen)
         XCTAssertTrue(model.personalPlaylistSections.isEmpty)
         await model.reload()
-        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor"])
+        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Tobias spellistor"])
     }
 
     func testPersonalSectionHiddenWhenAccountOwnsNoLibraryPlaylists() async {
-        // The library has playlists, but none owned by Tobias → no Mina section.
+        // The library has playlists, but none owned by Tobias → no Tobias section.
         let stub = StubSpotifyPlaylistService(accountPlaylistItems: [
             playlistItem(uri: "spotify://playlist/h1", name: "Husets", ownerID: "huset")
         ])
@@ -402,7 +402,7 @@ extension MusicViewModelTests {
         ])
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount, sarahAccount])
         await model.refreshSpotifyPlaylists()
-        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor", "Sarahs spellistor"])
+        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Tobias spellistor", "Sarahs spellistor"])
     }
 
     func testEmptyAccountDroppedWhileOthersRemain() async {
@@ -430,7 +430,7 @@ extension MusicViewModelTests {
         let stub = StubSpotifyPlaylistService(authorized: false, accountPlaylistItems: tobiasLibrary())
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount])
         await model.connectSpotify()
-        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor"])
+        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Tobias spellistor"])
     }
 
     func testTappingPersonalPlaylistRoutesThroughBrowseFlow() async {
@@ -449,15 +449,15 @@ extension MusicViewModelTests {
         XCTAssertEqual(SpotifyPersonalAccount.configured.map(\.user), [.tobias, .sarah])
     }
 
-    func testViewerOwnSectionIsFirstAndTitledMina() async {
+    func testViewerOwnSectionIsFirstAndTitledByName() async {
         let library = [playlistItem(uri: "spotify://playlist/p1", name: "Tobias lista", ownerID: "tobiasc91"),
                        playlistItem(uri: "spotify://playlist/p2", name: "Sarahs lista", ownerID: "sarahtest42")]
         let stub = StubSpotifyPlaylistService(accountPlaylistItems: library)
-        // Sarah is the viewer → her section is first and titled "Mina spellistor",
-        // Tobias's drops below, titled by his name.
+        // Sarah is the viewer → her section is first, titled by her own name;
+        // Tobias's drops below, also titled by his name.
         let model = makeViewModel(spotify: stub, personalAccounts: [tobiasAccount, sarahAccount], currentUser: { .sarah })
         await model.refreshSpotifyPlaylists()
-        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Mina spellistor", "Tobias spellistor"])
+        XCTAssertEqual(model.personalPlaylistSections.map(\.title), ["Sarahs spellistor", "Tobias spellistor"])
         XCTAssertEqual(model.personalPlaylistSections.first?.account.userID, "sarahtest42")
     }
 }


### PR DESCRIPTION
## What

The viewer's own Spotify playlist section was titled **"Mina spellistor"**. Now every personal section is titled by its owner's name, e.g. **"Tobias spellistor"** / **"Sarahs spellistor"**, regardless of who is viewing.

Ordering is unchanged — the viewer's own section is still shown first.

## Why

Tobias wanted his name on his playlists rather than the generic "Mina".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Personal playlist sections now consistently display the account owner's name instead of a generic placeholder, ensuring better clarity when managing multiple connected Spotify accounts.

* **Documentation**
  * Updated documentation to clarify how personal playlist section titles are determined and how sections are ordered when multiple accounts are connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->