### PR TITLE
Fixed and extended the music queue (decode, remote up-next, play-next/last)

### DIFF
--- a/IntelliNest/Model/MusicQueue.swift
+++ b/IntelliNest/Model/MusicQueue.swift
@@ -120,29 +120,33 @@ struct MusicQueueItemDTO: Decodable {
 struct MusicQueueDTO: Decodable {
     let queueID: String?
     let currentItem: MusicQueueItemDTO?
+    let nextItem: MusicQueueItemDTO?
 
     private enum CodingKeys: String, CodingKey {
         case queueID = "queue_id"
         case currentItem = "current_item"
+        case nextItem = "next_item"
     }
 }
 
 enum MusicGetQueueParser {
     /// Parses the `music_assistant.get_queue` `return_response` body into the
-    /// queue id and current item. Home Assistant wraps service results under
-    /// `service_response`, and the queue then sits either directly under it or
-    /// keyed by the entity id (as `browse_media` does). Both shapes are handled,
+    /// queue id, current item, and next item. Home Assistant wraps service results
+    /// under `service_response`, and the queue then sits either directly under it
+    /// or keyed by the entity id (as `browse_media` does). Both shapes are handled,
     /// and a body in any unexpected shape yields an empty queue rather than
     /// throwing — the Queue screen falls back to session state when this is empty.
-    static func parse(_ data: Data) -> (queueID: String?, currentItem: MusicQueueItem?) {
+    /// `next_item` works over REST, so it backs the "Näst på tur" list away from
+    /// home when the LAN-only socket can't supply the full list.
+    static func parse(_ data: Data) -> (queueID: String?, currentItem: MusicQueueItem?, nextItem: MusicQueueItem?) {
         let decoder = JSONDecoder()
         for candidate in candidateObjects(in: data) {
             guard let dto = try? decoder.decode(MusicQueueDTO.self, from: candidate), dto.queueID != nil else {
                 continue
             }
-            return (dto.queueID, dto.currentItem?.queueItem)
+            return (dto.queueID, dto.currentItem?.queueItem, dto.nextItem?.queueItem)
         }
-        return (nil, nil)
+        return (nil, nil, nil)
     }
 
     /// Returns every JSON object worth trying to decode as a queue: the body

--- a/IntelliNest/Model/MusicQueue.swift
+++ b/IntelliNest/Model/MusicQueue.swift
@@ -67,8 +67,27 @@ struct MusicQueueItemDTO: Decodable {
     /// A Music Assistant image reference. Only a remotely-reachable `path` (an
     /// absolute URL) is usable directly; local provider images would need the MA
     /// image proxy, so those are dropped to nil rather than shown broken.
+    ///
+    /// The two transports disagree on the shape: the `player_queues/items` socket
+    /// sends an object (`{"path": "https://…"}`), while `get_queue` serializes a
+    /// `media_item.image` as a bare URL string. Decode both, otherwise a
+    /// string-shaped image throws and takes the whole `get_queue` decode with it —
+    /// which left `queue_id` nil and the "Näst på tur" list silently empty.
     struct ImageDTO: Decodable {
         let path: String?
+
+        init(from decoder: Decoder) throws {
+            if let single = try? decoder.singleValueContainer(), let url = try? single.decode(String.self) {
+                path = url
+                return
+            }
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            path = try container.decodeIfPresent(String.self, forKey: .path)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case path
+        }
 
         var usableURL: String? {
             guard let path, path.hasPrefix("http") else {

--- a/IntelliNest/Services/RestAPIService+Music.swift
+++ b/IntelliNest/Services/RestAPIService+Music.swift
@@ -82,10 +82,11 @@ extension RestAPIService {
 
     /// Reads the active queue for `entityID` via `music_assistant.get_queue`
     /// (`?return_response`). Returns the queue id (needed to target the WebSocket
-    /// delete command) and the current item ("Spelas nu"). The upcoming list is
-    /// fetched separately over the Music Assistant WebSocket, since `get_queue`
-    /// only carries the current/next item, not the full list.
-    func getQueue(on entityID: EntityId) async throws -> (queueID: String?, currentItem: MusicQueueItem?) {
+    /// delete command), the current item ("Spelas nu"), and the immediate next
+    /// item. The full upcoming list is fetched separately over the Music Assistant
+    /// WebSocket, since `get_queue` only carries the current/next item; the next
+    /// item backs "Näst på tur" over REST when that socket is unreachable.
+    func getQueue(on entityID: EntityId) async throws -> (queueID: String?, currentItem: MusicQueueItem?, nextItem: MusicQueueItem?) {
         let path = "/api/services/\(Domain.musicAssistant.rawValue)/\(Action.getQueue.rawValue)"
         var json = [JSONKey: Any]()
         json[.entityID] = entityID.rawValue

--- a/IntelliNest/ViewModels/MusicViewModel+Queue.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Queue.swift
@@ -7,6 +7,21 @@
 
 import Foundation
 
+/// Where a newly-added track lands in the queue, mapped to Music Assistant's
+/// `enqueue` modes: `.next` plays it right after the current track, `.last`
+/// appends it to the end.
+enum QueuePlacement {
+    case next
+    case last
+
+    var enqueueMode: String {
+        switch self {
+        case .next: "next"
+        case .last: "add"
+        }
+    }
+}
+
 /// The play queue for the active speaker's group leader. Reads run over two
 /// transports: `music_assistant.get_queue` (REST) for the queue id and the
 /// current track, and the Music Assistant WebSocket for the full upcoming list
@@ -46,28 +61,32 @@ extension MusicViewModel {
 
         let queueID: String?
         let restCurrent: MusicQueueItem?
+        let restNext: MusicQueueItem?
         do {
-            (queueID, restCurrent) = try await restAPIService.getQueue(on: targetID)
+            (queueID, restCurrent, restNext) = try await restAPIService.getQueue(on: targetID)
         } catch {
             Log.error("Failed to read queue: \(error)")
-            (queueID, restCurrent) = (nil, nil)
+            (queueID, restCurrent, restNext) = (nil, nil, nil)
         }
 
         let currentItem = restCurrent ?? currentItemFromSpeaker()
-        let upcoming = await upcomingItems(queueID: queueID, currentItem: currentItem)
+        let upcoming = await upcomingItems(queueID: queueID, currentItem: currentItem, nextItem: restNext)
         queue = MusicQueue(queueID: queueID, currentItem: currentItem, upcomingItems: upcoming)
     }
 
     /// The upcoming tracks: the socket's full ordered list sliced to whatever
-    /// follows the current item, or the session-enqueued fallback when the socket
-    /// returns nothing (server unreachable, e.g. away from home).
-    private func upcomingItems(queueID: String?, currentItem: MusicQueueItem?) async -> [MusicQueueItem] {
+    /// follows the current item, falling back to the REST-supplied next item plus
+    /// anything enqueued this session when the socket returns nothing (the socket
+    /// is LAN-only, so it's unreachable away from home).
+    private func upcomingItems(queueID: String?,
+                               currentItem: MusicQueueItem?,
+                               nextItem: MusicQueueItem?) async -> [MusicQueueItem] {
         guard let queueID else {
-            return sessionEnqueuedItems
+            return offlineUpcoming(nextItem: nextItem)
         }
         let items = await queueSocket.queueItems(queueID: queueID)
         guard items.isNotEmpty else {
-            return sessionEnqueuedItems
+            return offlineUpcoming(nextItem: nextItem)
         }
         guard let currentItem,
               let currentIndex = items.firstIndex(where: { $0.queueItemID == currentItem.queueItemID }) else {
@@ -76,6 +95,17 @@ extension MusicViewModel {
             return items.filter { $0.uri == nil || $0.uri != currentItem?.uri }
         }
         return Array(items[(currentIndex + 1)...])
+    }
+
+    /// The "Näst på tur" list when the socket can't supply the full queue: at least
+    /// the immediate next track (from `get_queue` over REST, which works remotely),
+    /// then anything enqueued this session, never showing the next track twice.
+    private func offlineUpcoming(nextItem: MusicQueueItem?) -> [MusicQueueItem] {
+        guard let nextItem else {
+            return sessionEnqueuedItems
+        }
+        let rest = sessionEnqueuedItems.filter { $0.uri == nil || $0.uri != nextItem.uri }
+        return [nextItem] + rest
     }
 
     /// Builds a "Spelas nu" item from the speaker's now-playing metadata, used
@@ -93,22 +123,25 @@ extension MusicViewModel {
 
     // MARK: - Add
 
-    func addToQueue(_ track: MusicPlaylistTrack) async {
-        await addToQueue(uri: track.uri, title: track.title, artist: nil, imageURL: track.imageURL)
+    func addToQueue(_ track: MusicPlaylistTrack, placement: QueuePlacement = .last) async {
+        await addToQueue(uri: track.uri, title: track.title, artist: nil, imageURL: track.imageURL, placement: placement)
     }
 
-    func addToQueue(_ item: MusicSearchItem) async {
-        await addToQueue(uri: item.uri, title: item.name, artist: item.artist, imageURL: item.imageURL)
+    func addToQueue(_ item: MusicSearchItem, placement: QueuePlacement = .last) async {
+        await addToQueue(uri: item.uri, title: item.name, artist: item.artist, imageURL: item.imageURL, placement: placement)
     }
 
-    /// Appends a track to the active speaker's queue. Optimistically adds it to
-    /// "Näst på tur" and the session fallback; banners on failure.
-    func addToQueue(uri: String, title: String, artist: String?, imageURL: String?) async {
+    /// Adds a track to the active speaker's queue, either right after the current
+    /// track (`.next`) or at the end (`.last`). Optimistically inserts it into
+    /// "Näst på tur" and the session fallback; banners on failure. This goes over
+    /// REST (`play_media`), so it works away from home too — unlike reading the
+    /// full upcoming list, which needs the LAN-only socket.
+    func addToQueue(uri: String, title: String, artist: String?, imageURL: String?, placement: QueuePlacement = .last) async {
         guard let targetID = queueTargetID else {
             setErrorBannerText("Ingen högtalare vald", "Välj en högtalare innan du lägger till i kön")
             return
         }
-        let success = await restAPIService.playMedia(on: targetID, mediaID: uri, mediaType: .track, enqueue: "add")
+        let success = await restAPIService.playMedia(on: targetID, mediaID: uri, mediaType: .track, enqueue: placement.enqueueMode)
         guard success else {
             setErrorBannerText("Kunde inte lägga till i kön", "Det gick inte att lägga till låten i kön")
             return
@@ -121,10 +154,18 @@ extension MusicViewModel {
                                          title: title,
                                          artist: artist,
                                          imageURL: imageURL)
-        sessionEnqueuedItems.append(sessionItem)
-        queue = MusicQueue(queueID: queue.queueID,
-                           currentItem: queue.currentItem,
-                           upcomingItems: queue.upcomingItems + [sessionItem])
+        switch placement {
+        case .next:
+            sessionEnqueuedItems.insert(sessionItem, at: 0)
+            queue = MusicQueue(queueID: queue.queueID,
+                               currentItem: queue.currentItem,
+                               upcomingItems: [sessionItem] + queue.upcomingItems)
+        case .last:
+            sessionEnqueuedItems.append(sessionItem)
+            queue = MusicQueue(queueID: queue.queueID,
+                               currentItem: queue.currentItem,
+                               upcomingItems: queue.upcomingItems + [sessionItem])
+        }
     }
 
     // MARK: - Remove

--- a/IntelliNest/Views/Music/MusicTrackControls.swift
+++ b/IntelliNest/Views/Music/MusicTrackControls.swift
@@ -27,10 +27,10 @@ struct SongFavoriteButton: View {
     }
 }
 
-/// The track context-menu actions: add to the play queue, add to one of the
-/// user's editable playlists, and (in an editable playlist) remove from it. Each
-/// action is shown only when it can function. Designed to live inside a
-/// `.contextMenu { … }`.
+/// The track context-menu actions: play next or add to the end of the play
+/// queue, add to one of the user's editable playlists, and (in an editable
+/// playlist) remove from it. Each action is shown only when it can function.
+/// Designed to live inside a `.contextMenu { … }`.
 struct TrackActionButtons: View {
     @ObservedObject var viewModel: MusicViewModel
     let uri: String
@@ -42,9 +42,15 @@ struct TrackActionButtons: View {
 
     var body: some View {
         Button {
-            Task { await viewModel.addToQueue(uri: uri, title: title, artist: artist, imageURL: imageURL) }
+            Task { await viewModel.addToQueue(uri: uri, title: title, artist: artist, imageURL: imageURL, placement: .next) }
         } label: {
-            Label("Lägg till i kö", systemImage: "text.line.last.and.arrowtriangle.forward")
+            Label("Spela härnäst", systemImage: "text.line.first.and.arrowtriangle.forward")
+        }
+
+        Button {
+            Task { await viewModel.addToQueue(uri: uri, title: title, artist: artist, imageURL: imageURL, placement: .last) }
+        } label: {
+            Label("Lägg till sist i kö", systemImage: "text.line.last.and.arrowtriangle.forward")
         }
 
         if viewModel.canAddTrackToPlaylist(uri: uri) {

--- a/IntelliNestTests/MusicQueueModelTests.swift
+++ b/IntelliNestTests/MusicQueueModelTests.swift
@@ -43,6 +43,28 @@ final class MusicQueueModelTests: XCTestCase {
         XCTAssertNil(result.currentItem)
     }
 
+    func testGetQueueParsesCurrentItemWithStringImage() {
+        // `get_queue` serializes `media_item.image` as a bare URL string (not the
+        // object the socket sends). A strict object decode threw and lost the whole
+        // queue, leaving queue_id nil and the upcoming list silently empty.
+        let json = """
+        {"service_response":{"media_player.kitchen":{"queue_id":"kitchen","current_item":{"queue_item_id":"item-1",
+        "media_item":{"uri":"spotify://track/abc","name":"Det sista jag behöver","artists":[{"name":"Darin"}],
+        "image":"https://i.scdn.co/image/cover.jpg"}}}}}
+        """
+        let result = MusicGetQueueParser.parse(Data(json.utf8))
+        XCTAssertEqual(result.queueID, "kitchen")
+        XCTAssertEqual(result.currentItem?.title, "Det sista jag behöver")
+        XCTAssertEqual(result.currentItem?.imageURL, "https://i.scdn.co/image/cover.jpg")
+    }
+
+    func testQueueItemDecodesObjectImageFromSocket() {
+        // The socket sends `image` as an object with a `path`; both shapes resolve.
+        let json = #"{"queue_item_id":"i1","image":{"path":"https://i.scdn.co/image/sock.jpg"},"media_item":{"name":"X"}}"#
+        let dto = try? JSONDecoder().decode(MusicQueueItemDTO.self, from: Data(json.utf8))
+        XCTAssertEqual(dto?.queueItem?.imageURL, "https://i.scdn.co/image/sock.jpg")
+    }
+
     func testQueueItemDropsNonHttpImage() {
         let json = """
         {"queue_item_id":"i1","media_item":{"uri":"spotify://track/x","name":"X",

--- a/IntelliNestTests/MusicQueueModelTests.swift
+++ b/IntelliNestTests/MusicQueueModelTests.swift
@@ -43,6 +43,22 @@ final class MusicQueueModelTests: XCTestCase {
         XCTAssertNil(result.currentItem)
     }
 
+    func testGetQueueParsesNextItem() {
+        let json = """
+        {"service_response":{"queue_id":"kitchen","current_item":{"queue_item_id":"cur","media_item":{"name":"Now"}},
+        "next_item":{"queue_item_id":"nxt","media_item":{"name":"Up Next","artists":[{"name":"Band"}]}}}}
+        """
+        let result = MusicGetQueueParser.parse(Data(json.utf8))
+        XCTAssertEqual(result.nextItem?.queueItemID, "nxt")
+        XCTAssertEqual(result.nextItem?.title, "Up Next")
+        XCTAssertEqual(result.nextItem?.artist, "Band")
+    }
+
+    func testQueuePlacementMapsToEnqueueMode() {
+        XCTAssertEqual(QueuePlacement.next.enqueueMode, "next")
+        XCTAssertEqual(QueuePlacement.last.enqueueMode, "add")
+    }
+
     func testGetQueueParsesCurrentItemWithStringImage() {
         // `get_queue` serializes `media_item.image` as a bare URL string (not the
         // object the socket sends). A strict object decode threw and lost the whole

--- a/IntelliNestTests/MusicViewModelQueueTests.swift
+++ b/IntelliNestTests/MusicViewModelQueueTests.swift
@@ -96,7 +96,35 @@ extension MusicViewModelTests {
         XCTAssertEqual(model.queue.upcomingItems.map(\.title), ["Enqueued"])
     }
 
+    func testLoadQueueShowsNextItemWhenSocketEmpty() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        // The socket is LAN-only; away from home it returns nothing. get_queue still
+        // carries next_item over REST, so the up-next list shows at least that.
+        let json = """
+        {"service_response":{"queue_id":"kitchen","current_item":{"queue_item_id":"cur","media_item":{"name":"Now"}},
+        "next_item":{"queue_item_id":"nxt","media_item":{"name":"Up Next"}}}}
+        """
+        stubGetQueue(json: json)
+        let model = makeViewModel(socket: StubMusicAssistantQueueSocket(items: []))
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.loadQueue()
+        XCTAssertEqual(model.queue.upcomingItems.map(\.queueItemID), ["nxt"])
+        XCTAssertEqual(model.queue.upcomingItems.map(\.title), ["Up Next"])
+    }
+
     // MARK: - Add
+
+    func testAddToQueueNextInsertsAtFront() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubPlayMedia(statusCode: 200)
+        let model = makeViewModel(socket: StubMusicAssistantQueueSocket())
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.addToQueue(uri: "spotify://track/a", title: "Last", artist: nil, imageURL: nil, placement: .last)
+        await model.addToQueue(uri: "spotify://track/b", title: "Next", artist: nil, imageURL: nil, placement: .next)
+        // .next jumps to the front of both the visible list and the session fallback.
+        XCTAssertEqual(model.queue.upcomingItems.map(\.title), ["Next", "Last"])
+        XCTAssertEqual(model.sessionEnqueuedItems.map(\.title), ["Next", "Last"])
+    }
 
     func testAddToQueueAppendsOptimisticallyOnSuccess() async {
         viewModel.selectSpeaker(.mediaPlayerKitchen)


### PR DESCRIPTION
Three related queue changes, each its own commit.

## 1. Fixed empty "Näst på tur" with a playlist playing (the original bug)

The two Music Assistant transports disagree on the `image` shape:

| Source | `media_item.image` |
|---|---|
| `player_queues/items` (socket) | object `{"path": "https://…"}` |
| `music_assistant.get_queue` (REST) | bare **string** URL |

`ImageDTO` only decoded the object form, so the string in `get_queue`'s `current_item` threw a `typeMismatch`. That bubbled up through `MusicQueueItemDTO` → `MusicQueueDTO` → got swallowed by `try?` in `MusicGetQueueParser`, so `queue_id` came back **nil**, the socket was never queried, and the up-next list was silently empty (the current track survived via the speaker-metadata fallback, which hid it). Verified against the live HA/MA server. `ImageDTO` now decodes both shapes.

## 2. Remote fallback for "Näst på tur"

The full up-next list comes from Music Assistant's own socket (`ws://…:8095`), which is LAN-only, so the list was blank away from home. `get_queue` also returns the immediate `next_item` over REST (which works remotely), so the up-next list now shows at least that next track plus anything enqueued this session.

## 3. Play-next / add-to-end queue actions

The track context menu now offers **"Spela härnäst"** (`enqueue: next`) and **"Lägg till sist i kö"** (`enqueue: add`) instead of a single add action, with optimistic insertion at the front or end respectively. These go over REST (`play_media`), so — unlike *reading* the full list — **adding works away from home too**, so no greying-out is needed.

## Tests
`MusicQueueModelTests` and `MusicViewModelQueueTests` cover: both image shapes, `next_item` parsing, the offline next-item fallback, the `enqueue` mapping, and play-next front-insertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)