### PR TITLE
Grouped queued tracks separately from playlist context like Spotify

### DIFF
--- a/IntelliNest/Model/MusicQueue.swift
+++ b/IntelliNest/Model/MusicQueue.swift
@@ -21,13 +21,31 @@ struct MusicQueueItem: Identifiable, Equatable {
 }
 
 /// The state the Queue screen renders: the queue's id (needed for the delete
-/// command), the track playing now, and the upcoming tracks.
+/// command), the track playing now, and the upcoming tracks. The upcoming tracks
+/// are split into the user's own queue ("I kö") and the playing context ("Nästa
+/// från: …"), the way Spotify separates the two.
 struct MusicQueue: Equatable {
     let queueID: String?
     let currentItem: MusicQueueItem?
     let upcomingItems: [MusicQueueItem]
+    /// Queue-item ids of upcoming tracks the user enqueued by hand (play next /
+    /// add to queue). Music Assistant's queue is flat and tags items with no
+    /// origin, so the app tracks this itself to group the user queue apart from
+    /// the playlist/album context. See `MusicViewModel.manualQueueItemIDs`.
+    let manualItemIDs: Set<String>
 
-    static let empty = MusicQueue(queueID: nil, currentItem: nil, upcomingItems: [])
+    static let empty = MusicQueue(queueID: nil, currentItem: nil, upcomingItems: [], manualItemIDs: [])
+
+    /// Upcoming tracks the user added by hand, in queue order ("I kö").
+    var manualUpcoming: [MusicQueueItem] {
+        upcomingItems.filter { manualItemIDs.contains($0.id) }
+    }
+
+    /// Upcoming tracks coming from the playing context — the rest of the playlist
+    /// or album ("Nästa från: …").
+    var contextUpcoming: [MusicQueueItem] {
+        upcomingItems.filter { !manualItemIDs.contains($0.id) }
+    }
 }
 
 /// Decodes a Music Assistant `QueueItem`, as returned both by the Home Assistant

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -163,6 +163,12 @@ extension MusicViewModel {
             speakers[activeSpeakerID]?.state = "playing"
             speakers[activeSpeakerID]?.mediaTitle = title
             speakers[activeSpeakerID]?.mediaArtist = artist
+            // A "replace" wipes the server queue, so the manual "I kö" tracking from
+            // the previous context no longer applies — clear it so leftover ids can't
+            // mislabel the new playlist's tracks.
+            if enqueue == "replace" {
+                clearManualQueueTracking()
+            }
             restAPIService.triggerRepeatReload(times: 3)
         } else {
             setErrorBannerText("Kunde inte spela", "Det gick inte att starta uppspelningen")

--- a/IntelliNest/ViewModels/MusicViewModel+Queue.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Queue.swift
@@ -153,6 +153,12 @@ extension MusicViewModel {
     func clearManualQueueTracking() {
         manualQueueItemIDs = []
         sessionEnqueuedItems = []
+        // Also drop the grouping on the already-published queue, so nothing shows
+        // under "I kö" in the window before the next loadQueue() rebuilds it.
+        queue = MusicQueue(queueID: queue.queueID,
+                           currentItem: queue.currentItem,
+                           upcomingItems: queue.upcomingItems,
+                           manualItemIDs: [])
     }
 
     // MARK: - Add
@@ -183,11 +189,12 @@ extension MusicViewModel {
         // A session-local id: these fallback rows have no server queue-item id,
         // so they are removed locally only. A queue reload replaces them with the
         // real items once the socket can read the live queue.
-        let sessionItem = MusicQueueItem(queueItemID: "session-\(uri)-\(sessionEnqueuedItems.count)",
+        let sessionItem = MusicQueueItem(queueItemID: "session-\(sessionEnqueueSequence)-\(uri)",
                                          uri: uri,
                                          title: title,
                                          artist: artist,
                                          imageURL: imageURL)
+        sessionEnqueueSequence += 1
         // The user added this by hand, so it belongs in "I kö" — track its id now;
         // reconciliation swaps the synthetic id for the real one on the next load.
         manualQueueItemIDs.insert(sessionItem.id)
@@ -224,7 +231,7 @@ extension MusicViewModel {
                            currentItem: queue.currentItem,
                            upcomingItems: previousUpcoming.filter { $0.id != item.id },
                            manualItemIDs: manualQueueItemIDs)
-        sessionEnqueuedItems.removeAll { $0.id == item.id }
+        removeSessionRow(matching: item)
 
         guard let queueID = queue.queueID, !isSessionOnly else {
             return
@@ -238,6 +245,18 @@ extension MusicViewModel {
                                manualItemIDs: manualQueueItemIDs)
             sessionEnqueuedItems = previousSession
             setErrorBannerText("Kunde inte ta bort från kön", "Det gick inte att ta bort låten från kön")
+        }
+    }
+
+    /// Drops the session-fallback row backing a removed item. Matches on the
+    /// synthetic id first; once an add has been reconciled, the live item carries
+    /// the real server id instead, so fall back to removing one row with the same
+    /// uri — otherwise the stale placeholder would linger in the offline fallback.
+    private func removeSessionRow(matching item: MusicQueueItem) {
+        if let index = sessionEnqueuedItems.firstIndex(where: { $0.id == item.id }) {
+            sessionEnqueuedItems.remove(at: index)
+        } else if let uri = item.uri, let index = sessionEnqueuedItems.firstIndex(where: { $0.uri == uri }) {
+            sessionEnqueuedItems.remove(at: index)
         }
     }
 }

--- a/IntelliNest/ViewModels/MusicViewModel+Queue.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Queue.swift
@@ -69,7 +69,10 @@ extension MusicViewModel {
 
         let currentItem = state.currentItem ?? currentItemFromSpeaker()
         let upcoming = await upcomingItems(queueID: state.queueID, currentItem: currentItem, nextItem: state.nextItem)
-        queue = MusicQueue(queueID: state.queueID, currentItem: currentItem, upcomingItems: upcoming)
+        queue = MusicQueue(queueID: state.queueID,
+                           currentItem: currentItem,
+                           upcomingItems: upcoming,
+                           manualItemIDs: manualQueueItemIDs)
     }
 
     /// The upcoming tracks: the socket's full ordered list sliced to whatever
@@ -86,13 +89,38 @@ extension MusicViewModel {
         guard items.isNotEmpty else {
             return offlineUpcoming(nextItem: nextItem)
         }
-        guard let currentItem,
-              let currentIndex = items.firstIndex(where: { $0.queueItemID == currentItem.queueItemID }) else {
+        let upcoming: [MusicQueueItem] = if let currentItem,
+                                            let currentIndex = items.firstIndex(where: { $0.queueItemID == currentItem.queueItemID }) {
+            Array(items[(currentIndex + 1)...])
+        } else {
             // Current track not located in the list — show the whole list rather
             // than nothing, minus any entry that is the current track by uri.
-            return items.filter { $0.uri == nil || $0.uri != currentItem?.uri }
+            items.filter { $0.uri == nil || $0.uri != currentItem?.uri }
         }
-        return Array(items[(currentIndex + 1)...])
+        reconcileManualIDs(against: upcoming)
+        return upcoming
+    }
+
+    /// Re-anchors the manual-queue id set to the live queue. Music Assistant gives
+    /// queued items no origin marker, so the synthetic session ids vanish once the
+    /// socket returns real server items. This keeps the real ids already known to
+    /// be manual (that still exist), then claims one live item per session-enqueued
+    /// uri not yet represented — matching by uri, each session add consuming one
+    /// row. Ids no longer in the queue (removed, or wiped by a new playlist) drop
+    /// out, so "I kö" keeps pointing at the right rows.
+    private func reconcileManualIDs(against upcoming: [MusicQueueItem]) {
+        let upcomingIDs = Set(upcoming.map(\.id))
+        var reconciled = manualQueueItemIDs.intersection(upcomingIDs)
+        var unclaimed = upcoming.filter { !reconciled.contains($0.id) }
+        for sessionItem in sessionEnqueuedItems {
+            guard let uri = sessionItem.uri,
+                  let matchIndex = unclaimed.firstIndex(where: { $0.uri == uri }) else {
+                continue
+            }
+            reconciled.insert(unclaimed[matchIndex].id)
+            unclaimed.remove(at: matchIndex)
+        }
+        manualQueueItemIDs = reconciled
     }
 
     /// The "Näst på tur" list when the socket can't supply the full queue: at least
@@ -117,6 +145,14 @@ extension MusicViewModel {
                               title: title,
                               artist: speaker.mediaArtist,
                               imageURL: speaker.entityPicture)
+    }
+
+    /// Forgets the manual-queue tracking (the "I kö" grouping and its session
+    /// fallback). Called when the queue is replaced wholesale, since the previous
+    /// manual adds are gone from the server queue.
+    func clearManualQueueTracking() {
+        manualQueueItemIDs = []
+        sessionEnqueuedItems = []
     }
 
     // MARK: - Add
@@ -152,17 +188,22 @@ extension MusicViewModel {
                                          title: title,
                                          artist: artist,
                                          imageURL: imageURL)
+        // The user added this by hand, so it belongs in "I kö" — track its id now;
+        // reconciliation swaps the synthetic id for the real one on the next load.
+        manualQueueItemIDs.insert(sessionItem.id)
         switch placement {
         case .next:
             sessionEnqueuedItems.insert(sessionItem, at: 0)
             queue = MusicQueue(queueID: queue.queueID,
                                currentItem: queue.currentItem,
-                               upcomingItems: [sessionItem] + queue.upcomingItems)
+                               upcomingItems: [sessionItem] + queue.upcomingItems,
+                               manualItemIDs: manualQueueItemIDs)
         case .last:
             sessionEnqueuedItems.append(sessionItem)
             queue = MusicQueue(queueID: queue.queueID,
                                currentItem: queue.currentItem,
-                               upcomingItems: queue.upcomingItems + [sessionItem])
+                               upcomingItems: queue.upcomingItems + [sessionItem],
+                               manualItemIDs: manualQueueItemIDs)
         }
     }
 
@@ -175,11 +216,14 @@ extension MusicViewModel {
     func removeFromQueue(_ item: MusicQueueItem) async {
         let previousUpcoming = queue.upcomingItems
         let previousSession = sessionEnqueuedItems
+        let previousManualIDs = manualQueueItemIDs
         let isSessionOnly = previousSession.contains { $0.id == item.id }
 
+        manualQueueItemIDs.remove(item.id)
         queue = MusicQueue(queueID: queue.queueID,
                            currentItem: queue.currentItem,
-                           upcomingItems: previousUpcoming.filter { $0.id != item.id })
+                           upcomingItems: previousUpcoming.filter { $0.id != item.id },
+                           manualItemIDs: manualQueueItemIDs)
         sessionEnqueuedItems.removeAll { $0.id == item.id }
 
         guard let queueID = queue.queueID, !isSessionOnly else {
@@ -187,7 +231,11 @@ extension MusicViewModel {
         }
         let success = await queueSocket.deleteItem(queueID: queueID, itemID: item.queueItemID)
         if !success {
-            queue = MusicQueue(queueID: queue.queueID, currentItem: queue.currentItem, upcomingItems: previousUpcoming)
+            manualQueueItemIDs = previousManualIDs
+            queue = MusicQueue(queueID: queue.queueID,
+                               currentItem: queue.currentItem,
+                               upcomingItems: previousUpcoming,
+                               manualItemIDs: manualQueueItemIDs)
             sessionEnqueuedItems = previousSession
             setErrorBannerText("Kunde inte ta bort från kön", "Det gick inte att ta bort låten från kön")
         }

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -81,6 +81,14 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// Tracks the app enqueued this session, newest last. Used as the "Näst på
     /// tur" fallback when the live queue contents can't be read over the socket.
     @Published var sessionEnqueuedItems: [MusicQueueItem] = []
+    /// Queue-item ids of tracks the user enqueued by hand (play next / add to
+    /// queue): synthetic session ids before the live queue is read, real server
+    /// ids after reconciliation. Drives the "I kö" grouping on the Queue screen.
+    /// Music Assistant's queue carries no origin marker, so the app tracks this
+    /// itself. Reconciled against the live queue on each load. Tracked per session
+    /// only — like `nowPlayingSourcePlaylist`, the grouping resets after a relaunch
+    /// rather than risk mislabelling playlist tracks from stale persisted state.
+    var manualQueueItemIDs: Set<String> = []
     /// One section per configured personal account that currently has public
     /// playlists, in configured order, rendered below "Favoriter". Accounts with
     /// no playlists (empty/failed fetch, or logged out) are kept off the list.

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -89,6 +89,10 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// only — like `nowPlayingSourcePlaylist`, the grouping resets after a relaunch
     /// rather than risk mislabelling playlist tracks from stale persisted state.
     var manualQueueItemIDs: Set<String> = []
+    /// Monotonic sequence for synthetic session-item ids. Never decreases, so a
+    /// remove-then-re-add of the same track can't reuse an id still in the list
+    /// (a plain count would collide).
+    var sessionEnqueueSequence = 0
     /// One section per configured personal account that currently has public
     /// playlists, in configured order, rendered below "Favoriter". Accounts with
     /// no playlists (empty/failed fetch, or logged out) are kept off the list.

--- a/IntelliNest/Views/Music/QueueView.swift
+++ b/IntelliNest/Views/Music/QueueView.swift
@@ -73,30 +73,61 @@ struct QueueView: View {
                 sectionHeader("Spelas nu")
             }
 
-            Section {
-                if viewModel.queue.upcomingItems.isEmpty {
+            // The user's own additions ("I kö") and the playing context ("Nästa
+            // från: …") are shown as separate groups, the way Spotify splits them.
+            let manual = viewModel.queue.manualUpcoming
+            let context = viewModel.queue.contextUpcoming
+
+            if manual.isEmpty, context.isEmpty {
+                Section {
                     Text("Inga kommande låtar")
                         .foregroundStyle(.white.opacity(0.6))
                         .listRowBackground(Color.clear)
-                } else {
-                    ForEach(viewModel.queue.upcomingItems) { item in
-                        QueueRow(viewModel: viewModel, item: item)
-                            .listRowBackground(Color.clear)
-                            .swipeActions(edge: .trailing) {
-                                Button(role: .destructive) {
-                                    Task { await viewModel.removeFromQueue(item) }
-                                } label: {
-                                    Label("Ta bort", systemImage: "trash")
-                                }
-                            }
+                } header: {
+                    sectionHeader("Näst på tur")
+                }
+            } else {
+                if !manual.isEmpty {
+                    Section {
+                        upcomingRows(manual)
+                    } header: {
+                        sectionHeader("I kö")
                     }
                 }
-            } header: {
-                sectionHeader("Näst på tur")
+                if !context.isEmpty {
+                    Section {
+                        upcomingRows(context)
+                    } header: {
+                        sectionHeader(contextHeaderTitle)
+                    }
+                }
             }
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
+    }
+
+    /// The header for the context group: names the source playlist when playback
+    /// was started from one this session, otherwise the generic "Näst på tur".
+    private var contextHeaderTitle: String {
+        if let name = viewModel.nowPlayingSourcePlaylist?.name {
+            return "Nästa från: \(name)"
+        }
+        return "Näst på tur"
+    }
+
+    @ViewBuilder private func upcomingRows(_ items: [MusicQueueItem]) -> some View {
+        ForEach(items) { item in
+            QueueRow(viewModel: viewModel, item: item)
+                .listRowBackground(Color.clear)
+                .swipeActions(edge: .trailing) {
+                    Button(role: .destructive) {
+                        Task { await viewModel.removeFromQueue(item) }
+                    } label: {
+                        Label("Ta bort", systemImage: "trash")
+                    }
+                }
+        }
     }
 
     private func sectionHeader(_ title: String) -> some View {

--- a/IntelliNestTests/MusicViewModelQueueTests.swift
+++ b/IntelliNestTests/MusicViewModelQueueTests.swift
@@ -19,6 +19,12 @@ actor StubMusicAssistantQueueSocket: MusicAssistantQueueSocket {
 
     func queueItems(queueID _: String) async -> [MusicQueueItem] { items }
 
+    /// Replaces the items a later `queueItems` read returns, so a test can model
+    /// the live queue changing between two `loadQueue` calls.
+    func setItems(_ newItems: [MusicQueueItem]) {
+        items = newItems
+    }
+
     func deleteItem(queueID _: String, itemID: String) async -> Bool {
         deletedItemIDs.append(itemID)
         return deleteSucceeds
@@ -186,6 +192,77 @@ extension MusicViewModelTests {
         await model.removeFromQueue(target)
         XCTAssertEqual(model.queue.upcomingItems.map(\.queueItemID), ["next1"])
         XCTAssertTrue(bannerTitles.contains("Kunde inte ta bort från kön"))
+    }
+
+    // MARK: - Grouping (I kö vs. playlist context)
+
+    func testManualAddGroupsSeparatelyFromContext() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubGetQueue(json: getQueueJSON)
+        stubPlayMedia(statusCode: 200)
+        let socket = StubMusicAssistantQueueSocket(items: [
+            queueItem("cur", title: "Now"),
+            queueItem("ctx1", uri: "spotify://track/c1", title: "Context One"),
+            queueItem("ctx2", uri: "spotify://track/c2", title: "Context Two")
+        ])
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.loadQueue()
+        await model.addToQueue(uri: "spotify://track/m1", title: "Mine", artist: nil, imageURL: nil, placement: .last)
+        // The hand-added track lands in "I kö"; the playlist tracks stay in context.
+        XCTAssertEqual(model.queue.manualUpcoming.map(\.title), ["Mine"])
+        XCTAssertEqual(model.queue.contextUpcoming.map(\.title), ["Context One", "Context Two"])
+    }
+
+    func testReconcileMapsSessionAddToRealQueueItemByURI() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubGetQueue(json: getQueueJSON)
+        stubPlayMedia(statusCode: 200)
+        let socket = StubMusicAssistantQueueSocket(items: [
+            queueItem("cur", title: "Now"),
+            queueItem("ctx1", uri: "spotify://track/c1", title: "Context One")
+        ])
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.loadQueue()
+        await model.addToQueue(uri: "spotify://track/m1", title: "Mine", artist: nil, imageURL: nil, placement: .last)
+        // The server now reports the manual add as a real queue item with a server id.
+        await socket.setItems([
+            queueItem("cur", title: "Now"),
+            queueItem("ctx1", uri: "spotify://track/c1", title: "Context One"),
+            queueItem("real-m1", uri: "spotify://track/m1", title: "Mine")
+        ])
+        await model.loadQueue()
+        // The synthetic session id is swapped for the real one, so "I kö" still
+        // points at the user's track and the playlist track stays in context.
+        XCTAssertEqual(model.queue.manualUpcoming.map(\.queueItemID), ["real-m1"])
+        XCTAssertEqual(model.queue.contextUpcoming.map(\.queueItemID), ["ctx1"])
+    }
+
+    func testStartingNewPlaybackClearsManualGrouping() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubPlayMedia(statusCode: 200)
+        let model = makeViewModel(socket: StubMusicAssistantQueueSocket())
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.addToQueue(uri: "spotify://track/m1", title: "Mine", artist: nil, imageURL: nil)
+        XCTAssertFalse(model.manualQueueItemIDs.isEmpty)
+        // Playing something new replaces the queue, so the manual grouping is dropped.
+        let playlist = MusicSearchItem(uri: "spotify://playlist/p", name: "P", mediaType: .playlist, imageURL: nil, artist: nil)
+        await model.play(item: playlist)
+        XCTAssertTrue(model.manualQueueItemIDs.isEmpty)
+        XCTAssertTrue(model.sessionEnqueuedItems.isEmpty)
+    }
+
+    func testRemovingManualTrackDropsItFromGroup() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubPlayMedia(statusCode: 200)
+        let model = makeViewModel(socket: StubMusicAssistantQueueSocket())
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.addToQueue(uri: "spotify://track/m1", title: "Mine", artist: nil, imageURL: nil)
+        let manualTrack = model.queue.manualUpcoming[0]
+        await model.removeFromQueue(manualTrack)
+        XCTAssertTrue(model.queue.manualUpcoming.isEmpty)
+        XCTAssertFalse(model.manualQueueItemIDs.contains(manualTrack.id))
     }
 
     func testRemoveSessionItemIsLocalOnlyNoSocketCall() async {

--- a/IntelliNestTests/MusicViewModelQueueTests.swift
+++ b/IntelliNestTests/MusicViewModelQueueTests.swift
@@ -265,6 +265,32 @@ extension MusicViewModelTests {
         XCTAssertFalse(model.manualQueueItemIDs.contains(manualTrack.id))
     }
 
+    func testRemovingReconciledManualTrackPrunesSessionRow() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubGetQueue(json: getQueueJSON)
+        stubPlayMedia(statusCode: 200)
+        let socket = StubMusicAssistantQueueSocket(items: [])
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        await model.addToQueue(uri: "spotify://track/m1", title: "Mine", artist: nil, imageURL: nil)
+        // The server now reports the manual add as a real queue item; a reload
+        // reconciles the synthetic session id to that server id.
+        await socket.setItems([
+            queueItem("cur", title: "Now"),
+            queueItem("real-m1", uri: "spotify://track/m1", title: "Mine")
+        ])
+        await model.loadQueue()
+        let reconciled = model.queue.manualUpcoming[0]
+        XCTAssertEqual(reconciled.queueItemID, "real-m1")
+        // Removing the reconciled (real-id) item must also prune the stale session
+        // row, which still carries the synthetic id, so it can't haunt the fallback.
+        await model.removeFromQueue(reconciled)
+        XCTAssertTrue(model.queue.manualUpcoming.isEmpty)
+        XCTAssertTrue(model.sessionEnqueuedItems.isEmpty)
+        let deleted = await socket.deletedItemIDs
+        XCTAssertEqual(deleted, ["real-m1"])
+    }
+
     func testRemoveSessionItemIsLocalOnlyNoSocketCall() async {
         viewModel.selectSpeaker(.mediaPlayerKitchen)
         stubPlayMedia(statusCode: 200)


### PR DESCRIPTION
## What

The Queue sheet now splits upcoming tracks into two labeled groups, the way Spotify does:

- **I kö** — tracks the user added by hand (play next / add to queue)
- **Nästa från: \<spellista\>** — the rest of the playing playlist/album context (falls back to **Näst på tur** when the source playlist is unknown)

## Why it needed app-side tracking

Music Assistant's queue is a flat list — queue items carry no origin marker, so there's no native way to tell a manual add apart from a context track. The app now tracks the manually-enqueued item ids itself (`MusicViewModel.manualQueueItemIDs`) and reconciles them against the live queue on each load: the synthetic session id created on add is swapped for the real server id by matching on uri, ids no longer in the queue are pruned, and a wholesale "replace" (starting new playback) clears the tracking.

Tracking is **session-only** — like `nowPlayingSourcePlaylist`, the grouping resets after a relaunch rather than risk mislabelling playlist tracks from stale persisted state. Because MA gives nothing to anchor on, the split is a best-effort reconstruction: it matches Spotify in the normal flow but isn't bulletproof against external clients editing the same queue.

## Changes

- `MusicQueue` gains `manualItemIDs` plus `manualUpcoming` / `contextUpcoming` accessors
- `MusicViewModel+Queue`: reconciliation, manual-id bookkeeping on add/remove, `clearManualQueueTracking()`
- `MusicViewModel+Playback`: clears tracking when a "replace" wipes the queue
- `QueueView`: renders the two grouped sections with a dynamic context header
- Tests: grouping, uri reconciliation, replace-clears, manual-remove

## Verification

- Music test suite green (incl. 4 new grouping tests)
- SwiftFormat + SwiftLint `--strict`: clean
- Rendered all four states (both groups / manual-only / context-only / empty) — grouping, ordering, and Swedish copy verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue now organizes tracks into two distinct sections: user-added items ("I kö") and tracks derived from playlists.
  * Context sections display their source, showing "Nästa från: [playlist name]" when available.
  * Improved tracking distinguishes manually enqueued tracks from automatically generated queue items.

* **Bug Fixes**
  * Queue state now correctly clears manual queue tracking when starting new playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->