### PR TITLE
Added drag-to-reorder within the queue groups

### DIFF
--- a/IntelliNest/Services/MusicAssistantSocketService.swift
+++ b/IntelliNest/Services/MusicAssistantSocketService.swift
@@ -17,6 +17,10 @@ protocol MusicAssistantQueueSocket: Sendable {
     func queueItems(queueID: String) async -> [MusicQueueItem]
     /// Removes the item from the queue. Returns whether the command succeeded.
     func deleteItem(queueID: String, itemID: String) async -> Bool
+    /// Moves the item `positions` slots within the queue: a positive value moves
+    /// it later (towards the end), a negative value earlier. Returns whether the
+    /// command succeeded.
+    func moveItem(queueID: String, itemID: String, positions: Int) async -> Bool
     /// Adds the media item (by uri, e.g. `spotify://playlist/<id>`) to the Music
     /// Assistant library favourites. With MA's Spotify 2-way sync on, this also
     /// follows the playlist on Spotify. Returns whether the command succeeded.
@@ -62,6 +66,11 @@ final class MusicAssistantSocketService: MusicAssistantQueueSocket {
     func deleteItem(queueID: String, itemID: String) async -> Bool {
         await send(command: "player_queues/delete_item",
                    args: ["queue_id": queueID, "item_id_or_index": itemID]) != nil
+    }
+
+    func moveItem(queueID: String, itemID: String, positions: Int) async -> Bool {
+        await send(command: "player_queues/move_item",
+                   args: ["queue_id": queueID, "queue_item_id": itemID, "pos_shift": positions]) != nil
     }
 
     func addFavorite(uri: String) async -> Bool {
@@ -201,6 +210,7 @@ final class MusicAssistantSocketService: MusicAssistantQueueSocket {
 struct DisabledMusicAssistantQueueSocket: MusicAssistantQueueSocket {
     func queueItems(queueID _: String) async -> [MusicQueueItem] { [] }
     func deleteItem(queueID _: String, itemID _: String) async -> Bool { false }
+    func moveItem(queueID _: String, itemID _: String, positions _: Int) async -> Bool { false }
     func addFavorite(uri _: String) async -> Bool { false }
     func removeFavorite(mediaType _: String, libraryItemID _: String) async -> Bool { false }
 }

--- a/IntelliNest/ViewModels/MusicViewModel+Queue.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Queue.swift
@@ -301,6 +301,7 @@ extension MusicViewModel {
         // queue's existing grouping rather than re-deriving it.
         let manualIDs = queue.manualItemIDs
         let previousUpcoming = queue.upcomingItems
+        let previousSession = sessionEnqueuedItems
         var newUpcoming = queue.upcomingItems
         for (offset, slot) in slots.enumerated() {
             newUpcoming[slot] = reorderedGroup[offset]
@@ -309,8 +310,11 @@ extension MusicViewModel {
                            currentItem: queue.currentItem,
                            upcomingItems: newUpcoming,
                            manualItemIDs: manualIDs)
+        // Keep the session fallback in the same order, so an offline reload (which
+        // rebuilds the upcoming list from it) doesn't undo the drag.
+        reorderSessionItems(toMatch: newUpcoming)
 
-        let isSessionOnly = sessionEnqueuedItems.contains { $0.id == movedItem.id }
+        let isSessionOnly = previousSession.contains { $0.id == movedItem.id }
         guard let queueID = queue.queueID, !isSessionOnly else {
             return
         }
@@ -320,8 +324,20 @@ extension MusicViewModel {
                                currentItem: queue.currentItem,
                                upcomingItems: previousUpcoming,
                                manualItemIDs: manualIDs)
+            sessionEnqueuedItems = previousSession
             setErrorBannerText("Kunde inte flytta låten", "Det gick inte att ändra ordningen i kön")
         }
+    }
+
+    /// Re-sorts the session-fallback rows to match their order in the reordered
+    /// upcoming list, leaving any session rows not currently visible (e.g. while
+    /// the live socket queue is shown) at the end in their existing order.
+    private func reorderSessionItems(toMatch upcoming: [MusicQueueItem]) {
+        let sessionIDs = Set(sessionEnqueuedItems.map(\.id))
+        let visible = upcoming.filter { sessionIDs.contains($0.id) }
+        let visibleIDs = Set(visible.map(\.id))
+        let hidden = sessionEnqueuedItems.filter { !visibleIDs.contains($0.id) }
+        sessionEnqueuedItems = visible + hidden
     }
 
     private func upcomingItems(in section: QueueSection) -> [MusicQueueItem] {

--- a/IntelliNest/ViewModels/MusicViewModel+Queue.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Queue.swift
@@ -22,6 +22,14 @@ enum QueuePlacement {
     }
 }
 
+/// One of the two reorderable upcoming groups on the Queue screen. Drag-reorder
+/// is confined within a single group (the displayed groups split by origin, not
+/// by play order, so dragging across them has no backend meaning).
+enum QueueSection {
+    case manual
+    case context
+}
+
 /// The play queue for the active speaker's group leader. Reads run over two
 /// transports: `music_assistant.get_queue` (REST) for the queue id and the
 /// current track, and the Music Assistant WebSocket for the full upcoming list
@@ -258,5 +266,92 @@ extension MusicViewModel {
         } else if let uri = item.uri, let index = sessionEnqueuedItems.firstIndex(where: { $0.uri == uri }) {
             sessionEnqueuedItems.remove(at: index)
         }
+    }
+
+    // MARK: - Reorder
+
+    /// Reorders a track within one upcoming group in response to a drag. The drag
+    /// is group-local (SwiftUI confines `onMove` to one section), so the new order
+    /// is mapped back onto the real flat queue: the group's items keep the same
+    /// slots, reassigned in the dragged order, and the moved item is shifted that
+    /// many positions on the server via `move_item`. Optimistic; reverts + banners
+    /// on socket failure. A session-only row (no server id, or offline) is reordered
+    /// locally only, since there is no live queue to move it in.
+    func moveUpcoming(_ section: QueueSection, fromOffsets: IndexSet, toOffset: Int) async {
+        let groupItems = upcomingItems(in: section)
+        guard let sourceIndex = fromOffsets.first, groupItems.indices.contains(sourceIndex) else {
+            return
+        }
+        let reorderedGroup = Self.applyingMove(to: groupItems, fromOffsets: fromOffsets, toOffset: toOffset)
+        let movedItem = groupItems[sourceIndex]
+        guard let destinationIndex = reorderedGroup.firstIndex(where: { $0.id == movedItem.id }),
+              destinationIndex != sourceIndex else {
+            return
+        }
+
+        // The real-queue indices this group occupies, ascending; slot k holds
+        // group item k, so the move stays inside the group's own positions.
+        let slots = queue.upcomingItems.indices.filter { isInSection(section, item: queue.upcomingItems[$0]) }
+        guard slots.count == groupItems.count else {
+            return
+        }
+        let positionShift = slots[destinationIndex] - slots[sourceIndex]
+
+        // Reordering doesn't change which tracks are manual, so preserve the
+        // queue's existing grouping rather than re-deriving it.
+        let manualIDs = queue.manualItemIDs
+        let previousUpcoming = queue.upcomingItems
+        var newUpcoming = queue.upcomingItems
+        for (offset, slot) in slots.enumerated() {
+            newUpcoming[slot] = reorderedGroup[offset]
+        }
+        queue = MusicQueue(queueID: queue.queueID,
+                           currentItem: queue.currentItem,
+                           upcomingItems: newUpcoming,
+                           manualItemIDs: manualIDs)
+
+        let isSessionOnly = sessionEnqueuedItems.contains { $0.id == movedItem.id }
+        guard let queueID = queue.queueID, !isSessionOnly else {
+            return
+        }
+        let success = await queueSocket.moveItem(queueID: queueID, itemID: movedItem.queueItemID, positions: positionShift)
+        if !success {
+            queue = MusicQueue(queueID: queue.queueID,
+                               currentItem: queue.currentItem,
+                               upcomingItems: previousUpcoming,
+                               manualItemIDs: manualIDs)
+            setErrorBannerText("Kunde inte flytta låten", "Det gick inte att ändra ordningen i kön")
+        }
+    }
+
+    private func upcomingItems(in section: QueueSection) -> [MusicQueueItem] {
+        switch section {
+        case .manual: queue.manualUpcoming
+        case .context: queue.contextUpcoming
+        }
+    }
+
+    private func isInSection(_ section: QueueSection, item: MusicQueueItem) -> Bool {
+        // Use the published queue's grouping (the same source as manualUpcoming /
+        // contextUpcoming) so the slots line up with what's on screen.
+        let isManual = queue.manualItemIDs.contains(item.id)
+        return section == .manual ? isManual : !isManual
+    }
+
+    /// Replicates SwiftUI's `move(fromOffsets:toOffset:)` without importing
+    /// SwiftUI into the view model: removes the moved elements, then inserts them
+    /// at the destination adjusted for the elements removed ahead of it.
+    private static func applyingMove(to items: [MusicQueueItem],
+                                     fromOffsets: IndexSet,
+                                     toOffset: Int) -> [MusicQueueItem] {
+        let sources = fromOffsets.sorted()
+        let moving = sources.map { items[$0] }
+        var result = items
+        for index in sources.reversed() {
+            result.remove(at: index)
+        }
+        let insertionIndex = toOffset - sources.filter { $0 < toOffset }.count
+        result.insert(contentsOf: moving, at: insertionIndex)
+        return result
     }
 }

--- a/IntelliNest/Views/Music/QueueView.swift
+++ b/IntelliNest/Views/Music/QueueView.swift
@@ -89,14 +89,14 @@ struct QueueView: View {
             } else {
                 if !manual.isEmpty {
                     Section {
-                        upcomingRows(manual)
+                        upcomingRows(manual, section: .manual)
                     } header: {
                         sectionHeader("I kö")
                     }
                 }
                 if !context.isEmpty {
                     Section {
-                        upcomingRows(context)
+                        upcomingRows(context, section: .context)
                     } header: {
                         sectionHeader(contextHeaderTitle)
                     }
@@ -116,9 +116,9 @@ struct QueueView: View {
         return "Näst på tur"
     }
 
-    @ViewBuilder private func upcomingRows(_ items: [MusicQueueItem]) -> some View {
+    @ViewBuilder private func upcomingRows(_ items: [MusicQueueItem], section: QueueSection) -> some View {
         ForEach(items) { item in
-            QueueRow(viewModel: viewModel, item: item)
+            QueueRow(viewModel: viewModel, item: item, showsDragHandle: true)
                 .listRowBackground(Color.clear)
                 .swipeActions(edge: .trailing) {
                     Button(role: .destructive) {
@@ -127,6 +127,10 @@ struct QueueView: View {
                         Label("Ta bort", systemImage: "trash")
                     }
                 }
+        }
+        // Long-press a row to drag it within its group; reorders the live queue.
+        .onMove { fromOffsets, toOffset in
+            Task { await viewModel.moveUpcoming(section, fromOffsets: fromOffsets, toOffset: toOffset) }
         }
     }
 
@@ -137,11 +141,13 @@ struct QueueView: View {
     }
 }
 
-/// One queue row: album art, title, artist, and the Liked-Songs heart for
-/// Spotify tracks.
+/// One queue row: album art, title, artist, the Liked-Songs heart for Spotify
+/// tracks, and — for reorderable upcoming rows — a trailing drag handle hinting
+/// that the row can be long-pressed and dragged within its group.
 private struct QueueRow: View {
     @ObservedObject var viewModel: MusicViewModel
     let item: MusicQueueItem
+    var showsDragHandle = false
 
     var body: some View {
         HStack(spacing: 12) {
@@ -160,6 +166,12 @@ private struct QueueRow: View {
             Spacer()
             if let uri = item.uri, viewModel.canFavoriteSong(uri: uri) {
                 SongFavoriteButton(viewModel: viewModel, uri: uri)
+            }
+            if showsDragHandle {
+                Image(systemName: "line.3.horizontal")
+                    .font(.body)
+                    .foregroundStyle(.white.opacity(0.4))
+                    .accessibilityLabel("Dra för att ändra ordning")
             }
         }
         .listRowBackground(Color.clear)

--- a/IntelliNestTests/MusicViewModelQueueTests.swift
+++ b/IntelliNestTests/MusicViewModelQueueTests.swift
@@ -7,14 +7,17 @@ actor StubMusicAssistantQueueSocket: MusicAssistantQueueSocket {
     var items: [MusicQueueItem]
     var deleteSucceeds: Bool
     var favoriteSucceeds: Bool
+    var moveSucceeds: Bool
     private(set) var deletedItemIDs: [String] = []
+    private(set) var movedItems: [(itemID: String, positions: Int)] = []
     private(set) var addedFavoriteURIs: [String] = []
     private(set) var removedFavorites: [String] = []
 
-    init(items: [MusicQueueItem] = [], deleteSucceeds: Bool = true, favoriteSucceeds: Bool = true) {
+    init(items: [MusicQueueItem] = [], deleteSucceeds: Bool = true, favoriteSucceeds: Bool = true, moveSucceeds: Bool = true) {
         self.items = items
         self.deleteSucceeds = deleteSucceeds
         self.favoriteSucceeds = favoriteSucceeds
+        self.moveSucceeds = moveSucceeds
     }
 
     func queueItems(queueID _: String) async -> [MusicQueueItem] { items }
@@ -28,6 +31,11 @@ actor StubMusicAssistantQueueSocket: MusicAssistantQueueSocket {
     func deleteItem(queueID _: String, itemID: String) async -> Bool {
         deletedItemIDs.append(itemID)
         return deleteSucceeds
+    }
+
+    func moveItem(queueID _: String, itemID: String, positions: Int) async -> Bool {
+        movedItems.append((itemID, positions))
+        return moveSucceeds
     }
 
     func addFavorite(uri: String) async -> Bool {
@@ -304,5 +312,77 @@ extension MusicViewModelTests {
         XCTAssertTrue(model.sessionEnqueuedItems.isEmpty)
         let deleted = await socket.deletedItemIDs
         XCTAssertTrue(deleted.isEmpty)
+    }
+
+    // MARK: - Reorder
+
+    /// Builds a queue with three manual tracks ahead of two context tracks.
+    private func groupedQueue() -> MusicQueue {
+        MusicQueue(queueID: "kitchen",
+                   currentItem: queueItem("cur", title: "Now"),
+                   upcomingItems: [
+                       queueItem("m1", uri: "spotify://track/m1", title: "Mine One"),
+                       queueItem("m2", uri: "spotify://track/m2", title: "Mine Two"),
+                       queueItem("m3", uri: "spotify://track/m3", title: "Mine Three"),
+                       queueItem("c1", uri: "spotify://track/c1", title: "Context One"),
+                       queueItem("c2", uri: "spotify://track/c2", title: "Context Two")
+                   ],
+                   manualItemIDs: ["m1", "m2", "m3"])
+    }
+
+    func testMoveManualWithinGroupReordersAndShiftsServer() async {
+        let socket = StubMusicAssistantQueueSocket()
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        model.queue = groupedQueue()
+        // Drag the first manual track to the end of the manual group.
+        await model.moveUpcoming(.manual, fromOffsets: IndexSet(integer: 0), toOffset: 3)
+        XCTAssertEqual(model.queue.manualUpcoming.map(\.queueItemID), ["m2", "m3", "m1"])
+        // Context untouched; the real flat order keeps it after the manual slots.
+        XCTAssertEqual(model.queue.contextUpcoming.map(\.queueItemID), ["c1", "c2"])
+        let moves = await socket.movedItems
+        XCTAssertEqual(moves.map(\.itemID), ["m1"])
+        XCTAssertEqual(moves.first?.positions, 2)
+    }
+
+    func testMoveContextWithinGroupShiftsUpwardWithNegativePosition() async {
+        let socket = StubMusicAssistantQueueSocket()
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        model.queue = groupedQueue()
+        // Drag the second context track above the first.
+        await model.moveUpcoming(.context, fromOffsets: IndexSet(integer: 1), toOffset: 0)
+        XCTAssertEqual(model.queue.contextUpcoming.map(\.queueItemID), ["c2", "c1"])
+        XCTAssertEqual(model.queue.manualUpcoming.map(\.queueItemID), ["m1", "m2", "m3"])
+        let moves = await socket.movedItems
+        XCTAssertEqual(moves.map(\.itemID), ["c2"])
+        // c2 is one slot earlier than c1, so it shifts up by one.
+        XCTAssertEqual(moves.first?.positions, -1)
+    }
+
+    func testMoveFailureRevertsOrderAndBanners() async {
+        let socket = StubMusicAssistantQueueSocket(moveSucceeds: false)
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        model.queue = groupedQueue()
+        await model.moveUpcoming(.manual, fromOffsets: IndexSet(integer: 0), toOffset: 3)
+        // Reverts to the original order on a failed socket move.
+        XCTAssertEqual(model.queue.manualUpcoming.map(\.queueItemID), ["m1", "m2", "m3"])
+        XCTAssertTrue(bannerTitles.contains("Kunde inte flytta låten"))
+    }
+
+    func testMoveSessionOnlyItemIsLocalOnlyNoSocketCall() async {
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        stubPlayMedia(statusCode: 200)
+        let socket = StubMusicAssistantQueueSocket()
+        let model = makeViewModel(socket: socket)
+        model.selectSpeaker(.mediaPlayerKitchen)
+        // Two session-only adds (no live queue id), so a reorder is local only.
+        await model.addToQueue(uri: "spotify://track/a", title: "A", artist: nil, imageURL: nil, placement: .last)
+        await model.addToQueue(uri: "spotify://track/b", title: "B", artist: nil, imageURL: nil, placement: .last)
+        await model.moveUpcoming(.manual, fromOffsets: IndexSet(integer: 0), toOffset: 2)
+        XCTAssertEqual(model.queue.manualUpcoming.map(\.title), ["B", "A"])
+        let moves = await socket.movedItems
+        XCTAssertTrue(moves.isEmpty)
     }
 }

--- a/IntelliNestTests/MusicViewModelQueueTests.swift
+++ b/IntelliNestTests/MusicViewModelQueueTests.swift
@@ -382,6 +382,9 @@ extension MusicViewModelTests {
         await model.addToQueue(uri: "spotify://track/b", title: "B", artist: nil, imageURL: nil, placement: .last)
         await model.moveUpcoming(.manual, fromOffsets: IndexSet(integer: 0), toOffset: 2)
         XCTAssertEqual(model.queue.manualUpcoming.map(\.title), ["B", "A"])
+        // The session fallback must follow the new order too, so an offline reload
+        // (which rebuilds from it) doesn't undo the drag.
+        XCTAssertEqual(model.sessionEnqueuedItems.map(\.title), ["B", "A"])
         let moves = await socket.movedItems
         XCTAssertTrue(moves.isEmpty)
     }


### PR DESCRIPTION
## What

Long-press a row in the Queue sheet to drag-reorder it, in **both** upcoming groups ("I kö" and "Nästa från: \<spellista\>"). Each upcoming row shows a ≡ drag handle as the affordance. Reordering is **within a section only** (SwiftUI confines `onMove` to one ForEach), since the two groups split by origin, not play order — dragging across them has no backend meaning.

## How

- **Socket:** new `moveItem(queueID:itemID:positions:)` → `player_queues/move_item` with a relative `pos_shift` (positive = later, negative = earlier), following the existing one-command-per-call pattern.
- **VM (`moveUpcoming`):** the group-local drag is mapped onto the real flat queue — the group keeps its slots, reassigned in the dragged order, and the moved item is shifted that many positions on the server. Optimistic update; reverts + banners on socket failure. A session-only row (no server id, or offline) reorders locally only. Grouping membership is preserved across a reorder.
- **View:** `.onMove` per section + a ≡ handle (`line.3.horizontal`) on upcoming rows, coexisting with swipe-to-delete and the favourite heart.

## Caveat

Reorder targets the live MA queue; I couldn't verify the exact `move_item` arg/behaviour against the running server from here, so it's built to the documented schema and **degrades gracefully** (revert + banner) if it's off. Worth a quick on-device check.

## Tests

`StubMusicAssistantQueueSocket` records moves. New cases: manual reorder (server shift), context reorder (negative shift), failure-reverts-and-banners, and session-only local-only.

Music test suite green; SwiftFormat + SwiftLint `--strict` clean. Screenshot of the ≡ handles posted on the PR thread context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drag-and-drop reordering for upcoming queue items
  * Queue reordering changes are automatically saved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->