### PR TITLE
Swapped plast and restavfall labels after bins changed kärl

### DIFF
--- a/IntelliNest/Utils/Extensions/HomeViewModelExtension.swift
+++ b/IntelliNest/Utils/Extensions/HomeViewModelExtension.swift
@@ -33,10 +33,10 @@ extension HomeViewModel {
         }
 
         if let generalWasteDescription = generalWasteDate.date.daysRemainingDescription() {
-            text.addNewLineAndAppend("Restavfall töms \(generalWasteDescription)")
+            text.addNewLineAndAppend("Plast töms \(generalWasteDescription)")
         }
         if let plasticWasteDescription = plasticWasteDate.date.daysRemainingDescription() {
-            text.addNewLineAndAppend("Plast töms \(plasticWasteDescription)")
+            text.addNewLineAndAppend("Restavfall töms \(plasticWasteDescription)")
         }
         if let gardenWasteDescription = gardenWasteDate.date.daysRemainingDescription() {
             text.addNewLineAndAppend("Trädgårdsavfall töms \(gardenWasteDescription)")


### PR DESCRIPTION
Plast and restavfall swapped containers (kärl), so each collection-date sensor now reports the schedule for the other fraction. Swapped the two display labels in the home summary so the names match reality:

- `generalWasteDate` now shows **Plast**
- `plasticWasteDate` now shows **Restavfall**

`Trädgårdsavfall` is unchanged. No test changes — the tests assert on entity state values, not the label strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected waste collection category labels that were previously misaligned with their scheduled collection dates. The general waste and plastic waste category labels now properly display with their corresponding scheduled dates throughout the app. This ensures users receive accurate and reliable waste collection information for effective household waste management and planning purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->