### PR TITLE
Fixed house consumption counting solar exported to the grid

### DIFF
--- a/IntelliNest/Utils/Constants/EntityId.swift
+++ b/IntelliNest/Utils/Constants/EntityId.swift
@@ -44,6 +44,7 @@ enum EntityId: String, Decodable, CaseIterable {
     /* Electricity */
     case nordPool = "sensor.nordpool_kwh_se4_sek_2_10_025"
     case pulsePower = "sensor.pulse_power"
+    case pulsePowerProduction = "sensor.pulse_power_production"
     case tibberPrice = "sensor.electricity_price_hem"
     case tibberCostToday = "sensor.accumulated_cost_hem"
     case pulseConsumptionToday = "sensor.pulse_consumption_today"

--- a/IntelliNest/ViewModels/ElectricityViewModel.swift
+++ b/IntelliNest/ViewModels/ElectricityViewModel.swift
@@ -4,12 +4,14 @@ import Foundation
 class ElectricityViewModel: ObservableObject, Reloadable {
     @Published var nordPool = NordPoolEntity(entityId: .nordPool)
     @Published private var pulsePowerEntity = Entity(entityId: .pulsePower)
+    @Published private var pulsePowerProductionEntity = Entity(entityId: .pulsePowerProduction)
     @Published private var solarPowerEntity = Entity(entityId: .solarPower)
     @Published var tibberCostToday = Entity(entityId: .tibberCostToday)
     @Published var pulseConsumptionToday = Entity(entityId: .pulseConsumptionToday)
 
     let entityIDs: [EntityId] = [
         .pulsePower,
+        .pulsePowerProduction,
         .tibberCostToday,
         .pulseConsumptionToday,
         .solarPower,
@@ -22,9 +24,21 @@ class ElectricityViewModel: ObservableObject, Reloadable {
         Double(solarPowerEntity.state) ?? 0
     }
 
+    // The Tibber Pulse exposes import and export as two separate, always-non-negative
+    // sensors: pulse_power measures grid import, pulse_power_production measures grid
+    // export. It never reports a negative value, so the signed net grid power has to be
+    // reconstructed from the difference.
+    var gridImport: Double {
+        Double(pulsePowerEntity.state) ?? 0
+    }
+
+    var gridExport: Double {
+        Double(pulsePowerProductionEntity.state) ?? 0
+    }
+
     // Positive = importing from grid, negative = exporting to grid
     var gridPower: Double {
-        Double(pulsePowerEntity.state) ?? 0
+        gridImport - gridExport
     }
 
     var housePower: Double {
@@ -32,11 +46,11 @@ class ElectricityViewModel: ObservableObject, Reloadable {
     }
 
     var isSolarToGrid: Bool {
-        solarPower.toKW > 0 && gridPower.toKW < 0
+        solarPower.toKW > 0 && gridExport.toKW > 0
     }
 
     var isSolarToHouse: Bool {
-        solarPower.toKW > 0 && gridPower < housePower
+        solarPower.toKW > 0
     }
 
     var isGridToHouse: Bool {
@@ -97,6 +111,7 @@ class ElectricityViewModel: ObservableObject, Reloadable {
 
     private lazy var entityKeyPaths: [EntityId: ReferenceWritableKeyPath<ElectricityViewModel, Entity>] = [
         .pulsePower: \.pulsePowerEntity,
+        .pulsePowerProduction: \.pulsePowerProductionEntity,
         .tibberCostToday: \.tibberCostToday,
         .pulseConsumptionToday: \.pulseConsumptionToday,
         .solarPower: \.solarPowerEntity

--- a/IntelliNestTests/ElectricityViewModelTests.swift
+++ b/IntelliNestTests/ElectricityViewModelTests.swift
@@ -120,58 +120,74 @@ class ElectricityViewModelTests: XCTestCase {
 
     // MARK: - Computed Property: gridPower
 
-    func testGridPower_isDirectPulseSensorReading() {
-        // Given: house consumes 3 kW, solar produces 1 kW → grid imports 2 kW
-        // pulsePower sensor reads the net grid power directly
+    func testGridPower_isImportMinusExport() {
+        // Given: house consumes 3 kW, solar produces 1 kW → grid imports 2 kW.
+        // The Tibber Pulse reports import on pulse_power and export on
+        // pulse_power_production; neither is ever negative.
         viewModel.reload(entityID: .pulsePower, state: "2000")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "0")
         viewModel.reload(entityID: .solarPower, state: "1000")
-        // Then: gridPower equals the pulse sensor reading (2 kW imported from grid)
+        // Then: net grid power = import - export = 2000 - 0 (2 kW imported)
         XCTAssertEqual(viewModel.gridPower, 2000)
     }
 
     func testGridPower_isNegativeWhenSolarExceedsConsumption() {
-        // Given: house consumes 1 kW, solar produces 4 kW → grid exports 3 kW
-        // pulsePower sensor reads -3000 (negative = exporting to grid)
-        viewModel.reload(entityID: .pulsePower, state: "-3000")
+        // Given: house consumes 1 kW, solar produces 4 kW → grid exports 3 kW.
+        // pulse_power stays at 0 (no import), pulse_power_production reads 3000.
+        viewModel.reload(entityID: .pulsePower, state: "0")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "3000")
         viewModel.reload(entityID: .solarPower, state: "4000")
-        // Then
+        // Then: net grid power = 0 - 3000 (3 kW exported)
         XCTAssertEqual(viewModel.gridPower, -3000)
     }
 
-    func testHousePower_isSolarPlusPulsePowerSensorReading() {
+    func testHousePower_isSolarPlusImportMinusExport() {
         // Given: solar produces 1 kW, grid imports 2 kW → house consumes 3 kW total
         viewModel.reload(entityID: .pulsePower, state: "2000")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "0")
         viewModel.reload(entityID: .solarPower, state: "1000")
         // Then
         XCTAssertEqual(viewModel.housePower, 3000)
     }
 
+    func testHousePower_excludesExportedSolar() {
+        // Given: solar produces 1.12 kW, nothing imported, 0.49 kW exported to grid.
+        // Regression for the bug where exported solar was counted as house load:
+        // house = solar + import - export = 1120 + 0 - 494 = 626 W (not 1120 W).
+        viewModel.reload(entityID: .solarPower, state: "1120")
+        viewModel.reload(entityID: .pulsePower, state: "0")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "494")
+        // Then
+        XCTAssertEqual(viewModel.housePower, 626)
+    }
+
     // MARK: - Computed Property: isSolarToGrid
 
     func testIsSolarToGrid_whenSolarExceedsHouseConsumption() {
-        // Given: solar produces 5 kW, house consumes 1 kW → exporting 4 kW to grid
-        // pulsePower sensor reads -4000 (negative = exporting to grid)
+        // Given: solar produces 5 kW, house consumes 1 kW → exporting 4 kW to grid.
+        // pulse_power_production reads 4000, pulse_power stays at 0.
         viewModel.reload(entityID: .solarPower, state: "5000")
-        viewModel.reload(entityID: .pulsePower, state: "-4000")
+        viewModel.reload(entityID: .pulsePower, state: "0")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "4000")
         // Then
         XCTAssertTrue(viewModel.isSolarToGrid)
     }
 
     func testIsSolarToGrid_whenSolarIsBelowHouseConsumption() {
         // Given: solar produces 1 kW, house consumes 3 kW → drawing 2 kW from grid
-        // pulsePower sensor reads +2000 (positive = importing from grid)
         viewModel.reload(entityID: .solarPower, state: "1000")
         viewModel.reload(entityID: .pulsePower, state: "2000")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "0")
         // Then
         XCTAssertFalse(viewModel.isSolarToGrid)
     }
 
     func testIsSolarToGrid_whenSolarPartiallyCoversConsumption() {
         // Given: solar produces 1.5 kW, house consumes 3 kW → drawing 1.5 kW from grid (not exporting!)
-        // pulsePower sensor reads +1500 (positive = importing from grid)
-        // This is the key regression scenario: solar active but nothing exported to grid
+        // This is the key regression scenario: solar active but nothing exported to grid.
         viewModel.reload(entityID: .solarPower, state: "1500")
         viewModel.reload(entityID: .pulsePower, state: "1500")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "0")
         // Then: solar is covering part of the load, none exported to grid
         XCTAssertFalse(viewModel.isSolarToGrid)
     }
@@ -180,6 +196,7 @@ class ElectricityViewModelTests: XCTestCase {
         // Given: no solar production
         viewModel.reload(entityID: .solarPower, state: "0")
         viewModel.reload(entityID: .pulsePower, state: "2000")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "0")
         // Then
         XCTAssertFalse(viewModel.isSolarToGrid)
     }
@@ -188,18 +205,18 @@ class ElectricityViewModelTests: XCTestCase {
 
     func testIsSolarToHouse_whenSolarPartiallyCoversConsumption() {
         // Given: solar covers 1.5 kW of a 3 kW load, grid provides remaining 1.5 kW
-        // pulsePower sensor reads +1500 (positive = importing 1.5 kW from grid)
         viewModel.reload(entityID: .solarPower, state: "1500")
         viewModel.reload(entityID: .pulsePower, state: "1500")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "0")
         // Then
         XCTAssertTrue(viewModel.isSolarToHouse)
     }
 
     func testIsSolarToHouse_whenSolarFullyCoversPlusExports() {
         // Given: solar produces 5 kW, house consumes 1 kW → exporting 4 kW to grid
-        // pulsePower sensor reads -4000 (negative = exporting to grid)
         viewModel.reload(entityID: .solarPower, state: "5000")
-        viewModel.reload(entityID: .pulsePower, state: "-4000")
+        viewModel.reload(entityID: .pulsePower, state: "0")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "4000")
         // Then
         XCTAssertTrue(viewModel.isSolarToHouse)
     }
@@ -208,6 +225,7 @@ class ElectricityViewModelTests: XCTestCase {
         // Given: no solar production
         viewModel.reload(entityID: .solarPower, state: "0")
         viewModel.reload(entityID: .pulsePower, state: "2000")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "0")
         // Then
         XCTAssertFalse(viewModel.isSolarToHouse)
     }
@@ -223,19 +241,20 @@ class ElectricityViewModelTests: XCTestCase {
     }
 
     func testIsGridToHouse_whenSolarCoversAllConsumption() {
-        // Given: solar produces 5 kW, house consumes 1 kW → exporting 4 kW to grid
-        // pulsePower sensor reads -4000 (negative = exporting, not importing from grid)
+        // Given: solar produces 5 kW, house consumes 1 kW → exporting 4 kW to grid.
+        // Net grid power is negative, so nothing is being imported.
         viewModel.reload(entityID: .solarPower, state: "5000")
-        viewModel.reload(entityID: .pulsePower, state: "-4000")
+        viewModel.reload(entityID: .pulsePower, state: "0")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "4000")
         // Then
         XCTAssertFalse(viewModel.isGridToHouse)
     }
 
     func testIsGridToHouse_whenSolarPartiallyCoversConsumption() {
         // Given: solar covers 1 kW but house needs 3 kW → drawing 2 kW from grid
-        // pulsePower sensor reads +2000 (positive = importing 2 kW from grid)
         viewModel.reload(entityID: .solarPower, state: "1000")
         viewModel.reload(entityID: .pulsePower, state: "2000")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "0")
         // Then
         XCTAssertTrue(viewModel.isGridToHouse)
     }
@@ -246,6 +265,7 @@ class ElectricityViewModelTests: XCTestCase {
         // Given: stub all non-NordPool entity URLs
         let entityStates: [EntityId: String] = [
             .pulsePower: "2000",
+            .pulsePowerProduction: "0",
             .tibberCostToday: "55.0",
             .pulseConsumptionToday: "20.5",
             .solarPower: "1000"


### PR DESCRIPTION
## Problem

`housePower = solarPower + gridPower` is correct arithmetic, but `gridPower` was wrong during solar export.

PR #113 set `gridPower = sensor.pulse_power` with the assumption it goes **negative when exporting**. Checking the live hardware via `hass-llm` shows it never does:

| Sensor | 24h range | meaning |
|---|---|---|
| `sensor.pulse_power` | 0 → 6086 W, **never negative** | grid **import** only |
| `sensor.pulse_power_production` | 0 → 4793 W | grid **export** (separate sensor) |
| `sensor.solaredge_current_power` | 0 → 5406 W | solar |

The Tibber Pulse splits import and export into two always-non-negative sensors; the app only read the import one. So during any solar surplus:

- House consumption was **overcounted by the exported amount** (live snapshot: app showed 1120 W, actual was 626 W with 494 W exported).
- `isSolarToGrid` (needs `gridPower < 0`) was **always false** → the solar→grid arrow never animated, even while selling 4.8 kW.

The import-only case was always correct, which is why it looked fine.

## Fix

- Added `EntityId.pulsePowerProduction` (`sensor.pulse_power_production`).
- `gridPower = gridImport - gridExport` → reconstructs the signed net grid power.
- `housePower = solarPower + gridPower` now correctly excludes exported solar.
- `isSolarToGrid` keys off `gridExport > 0`; simplified `isSolarToHouse` (its old `gridPower < housePower` term was always true → dead code).

## Tests

Rewrote `ElectricityViewModelTests` against real sensor behavior (the old tests fed negative `pulse_power` values the hardware never produces) and added a regression for exported solar no longer inflating house consumption. All 27 tests pass.

## Screenshots

Verified with rendered `ElectricityFlowView`: solar-export now shows grid −4.0 kW + house 1.0 kW with the solar→grid arrow; import-only and mixed scenarios render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate power export tracking to provide clearer visibility into power generation.

* **Improvements**
  * Grid power calculations refactored to display import and export as distinct non-negative values.
  * Solar routing logic refined to accurately reflect power distribution between grid and household consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->