### PR TITLE
Fixed house and grid power when the solar sensor lags the Pulse

### DIFF
--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		CC0000001000000000000001 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000002000000000000002 /* TestHelpers.swift */; };
 		CC0000003000000000000003 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000004000000000000004 /* HomeViewModelTests.swift */; };
 		CC0000005000000000000005 /* ElectricityViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000006000000000000006 /* ElectricityViewModelTests.swift */; };
+		CC0000007000000000000007 /* ElectricityViewModelSensorLagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000008000000000000008 /* ElectricityViewModelSensorLagTests.swift */; };
 		BB0000001000000000000001 /* HeatersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000002000000000000002 /* HeatersViewModelTests.swift */; };
 		DD0000001000000000000001 /* LynkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000002000000000000002 /* LynkViewModelTests.swift */; };
 		BB0000003000000000000003 /* LightsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000004000000000000004 /* LightsViewModelTests.swift */; };
@@ -360,6 +361,7 @@
 		CC0000002000000000000002 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		CC0000004000000000000004 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		CC0000006000000000000006 /* ElectricityViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElectricityViewModelTests.swift; sourceTree = "<group>"; };
+		CC0000008000000000000008 /* ElectricityViewModelSensorLagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElectricityViewModelSensorLagTests.swift; sourceTree = "<group>"; };
 		BB0000002000000000000002 /* HeatersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatersViewModelTests.swift; sourceTree = "<group>"; };
 		DD0000002000000000000002 /* LynkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LynkViewModelTests.swift; sourceTree = "<group>"; };
 		BB0000004000000000000004 /* LightsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightsViewModelTests.swift; sourceTree = "<group>"; };
@@ -581,6 +583,7 @@
 			CC0000002000000000000002 /* TestHelpers.swift */,
 			CC0000004000000000000004 /* HomeViewModelTests.swift */,
 			CC0000006000000000000006 /* ElectricityViewModelTests.swift */,
+			CC0000008000000000000008 /* ElectricityViewModelSensorLagTests.swift */,
 			BB0000002000000000000002 /* HeatersViewModelTests.swift */,
 			DD0000002000000000000002 /* LynkViewModelTests.swift */,
 			BB0000004000000000000004 /* LightsViewModelTests.swift */,
@@ -1254,6 +1257,7 @@
 			CC0000001000000000000001 /* TestHelpers.swift in Sources */,
 			CC0000003000000000000003 /* HomeViewModelTests.swift in Sources */,
 			CC0000005000000000000005 /* ElectricityViewModelTests.swift in Sources */,
+			CC0000007000000000000007 /* ElectricityViewModelSensorLagTests.swift in Sources */,
 			BB0000001000000000000001 /* HeatersViewModelTests.swift in Sources */,
 			DD0000001000000000000001 /* LynkViewModelTests.swift in Sources */,
 				EE000011000000000000000B /* MusicViewModelTests.swift in Sources */,

--- a/IntelliNest/ViewModels/ElectricityViewModel.swift
+++ b/IntelliNest/ViewModels/ElectricityViewModel.swift
@@ -20,8 +20,18 @@ class ElectricityViewModel: ObservableObject, Reloadable {
     var isReloading = false
     private let restAPIService: RestAPIService
 
+    // The SolarEdge cloud sensor lags ~13 minutes behind real time (its API is rate-limited),
+    // while the Tibber Pulse reports grid flow in near real time. With no home battery the house
+    // can never export more than the panels generate, so the live net export is a lower bound on
+    // current solar production. When the Pulse reading is newer than the inverter's, trust whichever
+    // value is higher — this lifts a stale-low solar reading during a fast morning ramp so the
+    // dashboard never shows the house exporting more power than the panels are making.
     var solarPower: Double {
-        Double(solarPowerEntity.state) ?? 0
+        let inverterSolar = Double(solarPowerEntity.state) ?? 0
+        guard pulsePowerProductionEntity.lastUpdated > solarPowerEntity.lastUpdated else {
+            return inverterSolar
+        }
+        return max(inverterSolar, gridExport - gridImport)
     }
 
     // The Tibber Pulse exposes import and export as two separate, always-non-negative
@@ -41,8 +51,11 @@ class ElectricityViewModel: ObservableObject, Reloadable {
         gridImport - gridExport
     }
 
+    // A house only ever consumes power; it never feeds the grid on its own. Clamp at zero so the
+    // transient negative values that appear when the laggy solar reading trails a fresh Pulse export
+    // never surface as the house "producing" power.
     var housePower: Double {
-        solarPower + gridPower
+        max(0, solarPower + gridPower)
     }
 
     var isSolarToGrid: Bool {
@@ -105,7 +118,7 @@ class ElectricityViewModel: ObservableObject, Reloadable {
             nordPool = newNordPool
         }
         for (entityID, entity) in entityUpdates {
-            reload(entityID: entityID, state: entity.state)
+            reload(entityID: entityID, entity: entity)
         }
     }
 
@@ -123,5 +136,15 @@ class ElectricityViewModel: ObservableObject, Reloadable {
             return
         }
         self[keyPath: keyPath].state = state
+    }
+
+    // Replaces the whole entity rather than just its state so the decoded last_updated timestamp
+    // flows through — solarPower relies on it to tell a stale inverter reading from a fresh one.
+    func reload(entityID: EntityId, entity: Entity) {
+        guard let keyPath = entityKeyPaths[entityID] else {
+            Log.error("ElectricityViewModel doesn't reload entityID: \(entityID)")
+            return
+        }
+        self[keyPath: keyPath] = entity
     }
 }

--- a/IntelliNestTests/ElectricityViewModelSensorLagTests.swift
+++ b/IntelliNestTests/ElectricityViewModelSensorLagTests.swift
@@ -1,0 +1,121 @@
+@testable import IntelliNest
+import XCTest
+
+/// Covers how ElectricityViewModel reconciles the real-time Tibber Pulse against the laggy SolarEdge
+/// cloud sensor: solar is lifted to the live net export when the inverter reading is stale, and house
+/// power is clamped so the laggy data never makes the house look like it is exporting power.
+@MainActor
+class ElectricityViewModelSensorLagTests: XCTestCase {
+    private var viewModel: ElectricityViewModel!
+    private var restAPIService: RestAPIService!
+    private var urlCreator: URLCreator!
+
+    private let staleTimestamp = "2023-06-17T13:30:00.000000+00:00"
+    private let freshTimestamp = "2023-06-17T13:43:00.000000+00:00"
+
+    override func setUp() async throws {
+        URLProtocolStub.startInterceptingRequests()
+        let stubbedSession = URLProtocolStub.createStubbedURLSession()
+        urlCreator = URLCreator(session: stubbedSession)
+        urlCreator.connectionState = .local
+        restAPIService = RestAPIService(
+            urlCreator: urlCreator,
+            session: stubbedSession,
+            setErrorBannerText: { _, _ in },
+            repeatReloadAction: { _ in }
+        )
+        viewModel = ElectricityViewModel(restAPIService: restAPIService)
+    }
+
+    override func tearDown() async throws {
+        URLProtocolStub.stopInterceptingRequests()
+        viewModel = nil
+        restAPIService = nil
+        urlCreator = nil
+    }
+
+    // MARK: - House clamp (no timestamps needed)
+
+    func testHousePower_clampsToZeroWhenExportExceedsSolar() {
+        // Given: a fresh Pulse export of 5 kW against a 3 kW solar reading (equal timestamps, so no
+        // recency lift). solar + gridPower = 3000 + (0 - 5000) = -2000, which is physically
+        // impossible — a house never exports on its own.
+        viewModel.reload(entityID: .solarPower, state: "3000")
+        viewModel.reload(entityID: .pulsePower, state: "0")
+        viewModel.reload(entityID: .pulsePowerProduction, state: "5000")
+        // Then: clamped to zero rather than shown as the house producing 2 kW
+        XCTAssertEqual(viewModel.housePower, 0)
+    }
+
+    // MARK: - Solar lift across sensor lag
+
+    func testSolarPower_liftsStaleSolarToFreshExport() async {
+        // Given: the screenshot scenario — SolarEdge stuck at a stale 3.2 kW while the Pulse freshly
+        // reports 5.7 kW exported and nothing imported. The panels must be making at least what is
+        // being exported, so solar is lifted to the live net export.
+        await reload(
+            solar: ("3200", staleTimestamp),
+            gridImport: ("0", freshTimestamp),
+            gridExport: ("5700", freshTimestamp)
+        )
+        // Then: solar reflects the live export, grid stays accurate, house settles at ~0 (all exported)
+        XCTAssertEqual(viewModel.solarPower, 5700)
+        XCTAssertEqual(viewModel.gridPower, -5700)
+        XCTAssertEqual(viewModel.housePower, 0)
+    }
+
+    func testSolarPower_keepsInverterValueWhenItIsFresher() async {
+        // Given: the inverter reading is the newer of the two, so a stale-high export must not drag
+        // the solar figure up — the fresh inverter value is authoritative.
+        await reload(
+            solar: ("3200", freshTimestamp),
+            gridImport: ("0", staleTimestamp),
+            gridExport: ("5700", staleTimestamp)
+        )
+        // Then: solar stays at the inverter value; house is still clamped away from negative
+        XCTAssertEqual(viewModel.solarPower, 3200)
+        XCTAssertEqual(viewModel.gridPower, -5700)
+        XCTAssertEqual(viewModel.housePower, 0)
+    }
+
+    func testSolarPower_doesNotLiftWhenImporting() async {
+        // Given: a fresher Pulse but the house is importing 2 kW (net export negative), so the lower
+        // bound never exceeds the inverter reading and solar is left untouched.
+        await reload(
+            solar: ("1000", staleTimestamp),
+            gridImport: ("2000", freshTimestamp),
+            gridExport: ("0", freshTimestamp)
+        )
+        // Then: solar unchanged, house = solar + import = 3 kW
+        XCTAssertEqual(viewModel.solarPower, 1000)
+        XCTAssertEqual(viewModel.gridPower, 2000)
+        XCTAssertEqual(viewModel.housePower, 3000)
+    }
+
+    // MARK: - Helpers
+
+    /// Stubs the power trio with explicit timestamps plus the remaining entities, then reloads.
+    private func reload(
+        solar: (state: String, lastUpdated: String),
+        gridImport: (state: String, lastUpdated: String),
+        gridExport: (state: String, lastUpdated: String)
+    ) async {
+        stubEntityURL(entityID: .solarPower, state: solar.state, lastUpdated: solar.lastUpdated)
+        stubEntityURL(entityID: .pulsePower, state: gridImport.state, lastUpdated: gridImport.lastUpdated)
+        stubEntityURL(entityID: .pulsePowerProduction, state: gridExport.state, lastUpdated: gridExport.lastUpdated)
+        stubEntityURL(entityID: .tibberCostToday, state: "0")
+        stubEntityURL(entityID: .pulseConsumptionToday, state: "0")
+        stubEntityURL(entityID: .nordPool, data: nordPoolStub)
+        await viewModel.reload()
+    }
+
+    private var nordPoolStub: Data {
+        Data("""
+        {
+            "entity_id": "\(EntityId.nordPool.rawValue)",
+            "state": "100",
+            "attributes": { "today": [100], "tomorrow": [], "tomorrow_valid": false }
+        }
+        """.utf8)
+    }
+}

--- a/IntelliNestTests/ElectricityViewModelSensorLagTests.swift
+++ b/IntelliNestTests/ElectricityViewModelSensorLagTests.swift
@@ -37,6 +37,9 @@ class ElectricityViewModelSensorLagTests: XCTestCase {
     // MARK: - House clamp (no timestamps needed)
 
     func testHousePower_clampsToZeroWhenExportExceedsSolar() {
+        // Baseline: everything starts at zero before any state arrives.
+        XCTAssertEqual(viewModel.housePower, 0)
+
         // Given: a fresh Pulse export of 5 kW against a 3 kW solar reading (equal timestamps, so no
         // recency lift). solar + gridPower = 3000 + (0 - 5000) = -2000, which is physically
         // impossible — a house never exports on its own.
@@ -50,6 +53,7 @@ class ElectricityViewModelSensorLagTests: XCTestCase {
     // MARK: - Solar lift across sensor lag
 
     func testSolarPower_liftsStaleSolarToFreshExport() async {
+        assertZeroBaseline()
         // Given: the screenshot scenario — SolarEdge stuck at a stale 3.2 kW while the Pulse freshly
         // reports 5.7 kW exported and nothing imported. The panels must be making at least what is
         // being exported, so solar is lifted to the live net export.
@@ -65,6 +69,7 @@ class ElectricityViewModelSensorLagTests: XCTestCase {
     }
 
     func testSolarPower_keepsInverterValueWhenItIsFresher() async {
+        assertZeroBaseline()
         // Given: the inverter reading is the newer of the two, so a stale-high export must not drag
         // the solar figure up — the fresh inverter value is authoritative.
         await reload(
@@ -79,6 +84,7 @@ class ElectricityViewModelSensorLagTests: XCTestCase {
     }
 
     func testSolarPower_doesNotLiftWhenImporting() async {
+        assertZeroBaseline()
         // Given: a fresher Pulse but the house is importing 2 kW (net export negative), so the lower
         // bound never exceeds the inverter reading and solar is left untouched.
         await reload(
@@ -93,6 +99,13 @@ class ElectricityViewModelSensorLagTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// Every derived power reads zero until the first reload delivers state.
+    private func assertZeroBaseline(file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(viewModel.solarPower, 0, file: file, line: line)
+        XCTAssertEqual(viewModel.gridPower, 0, file: file, line: line)
+        XCTAssertEqual(viewModel.housePower, 0, file: file, line: line)
+    }
 
     /// Stubs the power trio with explicit timestamps plus the remaining entities, then reloads.
     private func reload(

--- a/IntelliNestTests/TestHelpers.swift
+++ b/IntelliNestTests/TestHelpers.swift
@@ -26,11 +26,29 @@ func makeEntityJSON(entityId: String, state: String, attributes: [String: Any]) 
     return (try? JSONSerialization.data(withJSONObject: dict)) ?? Data()
 }
 
+func makeEntityJSON(entityId: String, state: String, lastUpdated: String) -> Data {
+    Data("""
+    {
+        "entity_id": "\(entityId)",
+        "state": "\(state)",
+        "last_changed": "\(lastUpdated)",
+        "last_updated": "\(lastUpdated)"
+    }
+    """.utf8)
+}
+
 func stubEntityURL(entityID: EntityId, state: String, delay: TimeInterval = 0) {
     let url = entityStateURL(for: entityID)
     let data = makeEntityJSON(entityId: entityID.rawValue, state: state)
     let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
     URLProtocolStub.setStub(for: url, data: data, response: response, error: nil, delay: delay)
+}
+
+func stubEntityURL(entityID: EntityId, state: String, lastUpdated: String) {
+    let url = entityStateURL(for: entityID)
+    let data = makeEntityJSON(entityId: entityID.rawValue, state: state, lastUpdated: lastUpdated)
+    let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    URLProtocolStub.setStub(for: url, data: data, response: response, error: nil)
 }
 
 func stubEntityURL(entityID: EntityId, data: Data) {


### PR DESCRIPTION
## Problem

On the electricity dashboard the house power showed an impossible **negative** value (e.g. −2.5 kW) and the grid export looked larger than the panels could possibly generate.

## Root cause

It's a sensor-latency mismatch, not a math error:

- `sensor.pulse_power_production` (Tibber Pulse grid export) is **real-time** — updates every few seconds.
- `sensor.solaredge_current_power` (SolarEdge solar) **lags ~13 minutes** because the SolarEdge cloud API is rate-limited.

During a fast morning ramp the Pulse reports a fresh, high export while SolarEdge is still serving a stale, low solar value. `housePower = solar + (import − export)` then subtracts a fresh export from stale solar → negative house, and the grid magnitude exceeds the displayed solar.

I confirmed the Pulse is the trustworthy one: when solar was *freshly* high (6494 W) the export tracked it almost exactly (~6500 W); the array genuinely peaks at ~9 kW.

## Fix

- **`solarPower`** — when the Pulse production reading is newer than the inverter's, lift solar to at least the live net export. With no home battery the house can never export more than the panels make, so net export is a valid real-time lower bound. This corrects the stale-low solar tile.
- **`housePower`** — clamped at zero. A house only consumes; it never feeds the grid on its own.
- The reload path now populates the whole decoded `Entity` (not just `state`) so the `last_updated` timestamp flows through for the recency comparison.

## Tests

4 new tests in `ElectricityViewModelSensorLagTests` (stale-solar lift, inverter-fresher case, importing case, house clamp). All 27 existing electricity tests still pass.

## Screenshots

Rendered the flow tile for the reported scenario and two no-regression cases — solar lifts to 5.7 kW, grid stays −5.7 kW, house clamps to 0 kW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced solar power calculations to account for sensor lag by comparing timestamp recency between different data sources and reconciling stale readings
  * Fixed house power display to clamp values at zero, preventing transient negative readings

* **Tests**
  * Added test suite validating solar and house power behavior under sensor lag and timestamp skew conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->