### PR TITLE
Improved electricity flow arrows to travel and scale with power

### DIFF
--- a/IntelliNest/Views/Electricity/ElectricityFlowView.swift
+++ b/IntelliNest/Views/Electricity/ElectricityFlowView.swift
@@ -37,14 +37,14 @@ struct ElectricityFlowView: View {
             PowerView(text: viewModel.solarPower.toKWString, imageName: .solarPanel)
                 .overlay(alignment: .bottomLeading) {
                     FlowIndicatorView(isFlowing: viewModel.isSolarToGrid,
-                                      flowIntensity: abs(viewModel.solarPower.toKW) >= 3 ? 2.0 : 1.0,
+                                      flowIntensity: flowSpeed(forKW: viewModel.solarPower.toKW),
                                       arrowCount: 4)
                         .rotationEffect(.degrees(120))
                         .offset(x: -50, y: 35)
                 }
                 .overlay(alignment: .bottomTrailing) {
                     FlowIndicatorView(isFlowing: viewModel.isSolarToHouse,
-                                      flowIntensity: abs(viewModel.solarPower.toKW) >= 3 ? 2.0 : 1.0,
+                                      flowIntensity: flowSpeed(forKW: viewModel.solarPower.toKW),
                                       arrowCount: 4)
                         .rotationEffect(.degrees(70))
                         .offset(x: 40, y: 35)
@@ -53,7 +53,7 @@ struct ElectricityFlowView: View {
                 PowerView(text: viewModel.gridPower.toKWString, imageName: .powerGrid)
                     .overlay(alignment: .bottomLeading) {
                         FlowIndicatorView(isFlowing: viewModel.isGridToHouse,
-                                          flowIntensity: abs(viewModel.gridPower.toKW) >= 3 ? 2.0 : 1.0,
+                                          flowIntensity: flowSpeed(forKW: viewModel.gridPower.toKW),
                                           arrowCount: 4)
                             .offset(x: 50, y: -20)
                     }
@@ -62,6 +62,13 @@ struct ElectricityFlowView: View {
             }
             .padding(.top, 65)
         }
+    }
+
+    /// Maps power to arrow speed (cycles/sec): a trickle drifts, a high flow zips. Scales linearly
+    /// with magnitude up to 7 kW, where it saturates so very high readings don't blur into a streak.
+    private func flowSpeed(forKW kilowatts: Double) -> Double {
+        let clamped = min(abs(kilowatts), 7)
+        return 1.0 + clamped / 7 * 2.0
     }
 }
 

--- a/IntelliNest/Views/Electricity/FlowIndicatorView.swift
+++ b/IntelliNest/Views/Electricity/FlowIndicatorView.swift
@@ -2,31 +2,44 @@ import SwiftUI
 
 struct FlowIndicatorView: View {
     let isFlowing: Bool
+    /// Cycles per second — how fast each arrow travels the full track. Scaled by power upstream.
     var flowIntensity: Double
     let arrowCount: Int
+
+    private let arrowWidth: CGFloat = 12
+    private let arrowSpacing: CGFloat = 8
+
+    private var trackWidth: CGFloat {
+        CGFloat(max(arrowCount, 1)) * (arrowWidth + arrowSpacing)
+    }
 
     var body: some View {
         if isFlowing {
             TimelineView(.animation(minimumInterval: nil)) { timeline in
-                let date = timeline.date.timeIntervalSinceReferenceDate
-                let phase = date * flowIntensity
+                let phase = timeline.date.timeIntervalSinceReferenceDate * flowIntensity
 
-                HStack {
+                ZStack {
                     ForEach(0 ..< arrowCount, id: \.self) { index in
+                        let progress = arrowProgress(phase: phase, index: index)
                         ArrowShape()
-                            .frame(width: 12, height: 6)
+                            .frame(width: arrowWidth, height: 6)
                             .foregroundStyle(.yellow)
-                            .opacity(arrowOpacity(phase: phase, index: index))
+                            // Travel the length of the track and fade in/out at the ends so an arrow
+                            // never pops into or out of existence mid-flow.
+                            .offset(x: (progress - 0.5) * trackWidth)
+                            .opacity(sin(progress * .pi))
                     }
                 }
+                .frame(width: trackWidth, height: 6)
             }
         }
     }
 
-    private func arrowOpacity(phase: Double, index: Int) -> Double {
+    /// Each arrow is offset along the cycle by an even fraction so they form a continuous stream.
+    private func arrowProgress(phase: Double, index: Int) -> Double {
         guard arrowCount > 0 else { return 0 }
-        let position = (phase - Double(index) / Double(arrowCount)).truncatingRemainder(dividingBy: 1.0)
-        return max(0, sin(position * 2 * .pi))
+        let raw = (phase + Double(index) / Double(arrowCount)).truncatingRemainder(dividingBy: 1.0)
+        return raw < 0 ? raw + 1 : raw
     }
 }
 


### PR DESCRIPTION
## What

Reworked the animated flow arrows on the electricity dashboard (`FlowIndicatorView`).

**Before:** arrows sat at fixed positions in an `HStack` and only pulsed their opacity in a sine wave — the flow read as blinking in place rather than moving along the wire. Speed was a crude binary step: `flowIntensity = abs(kW) >= 3 ? 2.0 : 1.0`.

**After:**
- Arrows physically **travel** the length of the track (offset along the flow direction) and fade in at the start / out at the end, so an arrow never pops in or out mid-flow — a real conveyor effect.
- Speed **scales continuously with power** instead of the two-tier step: `flowSpeed = 1.0 + min(|kW|, 7) / 7 * 2.0` → ~1 cycle/sec at idle ramping to ~3 at 7 kW+, where it saturates so very high readings don't blur into a streak.

## Notes

Pure SwiftUI view change, no view-model or data logic touched. Verified by rendering the strip across phase values (arrows march + fade) and in-context on the flow tile (arrows stay on the wires, no clipping). The felt speed is best judged live — easy to tune the `1.0 / 2.0 / 7` constants if a different feel is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)