### PR TITLE
Showed the primary speaker in group control and added loading spinners

### DIFF
--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00000400000000000000F1 /* MusicViewModel+Playback.swift */; };
 		FE0000000000000000000004 /* MusicViewModel+Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000004 /* MusicViewModel+Queue.swift */; };
 		FE000000000000000000FA01 /* MusicViewModel+Favourites.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD000000000000000000FA01 /* MusicViewModel+Favourites.swift */; };
+		FE00000000000000000000F5 /* MusicViewModel+Grouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD00000000000000000000F5 /* MusicViewModel+Grouping.swift */; };
 		FE0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift */; };
 		EE0000050000000000000005 /* MusicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000050000000000000005 /* MusicView.swift */; };
 		EE0000060000000000000006 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000060000000000000006 /* NowPlayingView.swift */; };
@@ -300,6 +301,7 @@
 		EF00000400000000000000F1 /* MusicViewModel+Playback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Playback.swift"; sourceTree = "<group>"; };
 		FD0000000000000000000004 /* MusicViewModel+Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Queue.swift"; sourceTree = "<group>"; };
 		FD000000000000000000FA01 /* MusicViewModel+Favourites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Favourites.swift"; sourceTree = "<group>"; };
+		FD00000000000000000000F5 /* MusicViewModel+Grouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Grouping.swift"; sourceTree = "<group>"; };
 		FD0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+SpotifyTracks.swift"; sourceTree = "<group>"; };
 		EF0000050000000000000005 /* MusicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicView.swift; sourceTree = "<group>"; };
 		EF0000060000000000000006 /* NowPlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingView.swift; sourceTree = "<group>"; };
@@ -634,6 +636,7 @@
 				EF00000400000000000000F1 /* MusicViewModel+Playback.swift */,
 				FD0000000000000000000004 /* MusicViewModel+Queue.swift */,
 				FD000000000000000000FA01 /* MusicViewModel+Favourites.swift */,
+				FD00000000000000000000F5 /* MusicViewModel+Grouping.swift */,
 				FD0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift */,
 			);
 			path = ViewModels;
@@ -1221,6 +1224,7 @@
 				EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */,
 				FE0000000000000000000004 /* MusicViewModel+Queue.swift in Sources */,
 				FE000000000000000000FA01 /* MusicViewModel+Favourites.swift in Sources */,
+				FE00000000000000000000F5 /* MusicViewModel+Grouping.swift in Sources */,
 				FE0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift in Sources */,
 				EE0000050000000000000005 /* MusicView.swift in Sources */,
 				EE0000060000000000000006 /* NowPlayingView.swift in Sources */,

--- a/IntelliNest/ViewModels/MusicViewModel+Grouping.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Grouping.swift
@@ -1,0 +1,139 @@
+//
+//  MusicViewModel+Grouping.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-18.
+//
+
+import Foundation
+
+/// Speaker grouping and group-volume handling, split out of `MusicViewModel`
+/// to keep that file under the file-length limit.
+extension MusicViewModel {
+    // MARK: - Group volume
+
+    /// The speakers currently synced with the active speaker (leader plus any
+    /// followers), in the fixed display order. When the active speaker is
+    /// ungrouped this is just the active speaker on its own.
+    var groupedSpeakers: [MediaPlayerEntity] {
+        guard let activeSpeaker else {
+            return []
+        }
+        let memberIDs = activeSpeaker.groupMembers
+        guard memberIDs.count > 1 else {
+            return [activeSpeaker]
+        }
+        return Self.speakerIDs.filter { memberIDs.contains($0) }.compactMap { speakers[$0] }
+    }
+
+    /// Whether the active speaker is synced with at least one other speaker, so
+    /// the volume control should act on the whole group.
+    var isGroupActive: Bool {
+        groupedSpeakers.count > 1
+    }
+
+    /// The single value shown on the group-volume banner: the average volume
+    /// across every grouped speaker.
+    var groupVolume: Double {
+        let grouped = groupedSpeakers
+        guard grouped.isNotEmpty else {
+            return 0
+        }
+        let total = grouped.reduce(0.0) { $0 + $1.volumeLevel }
+        return total / Double(grouped.count)
+    }
+
+    /// Sets every grouped speaker to the same absolute volume. Individual
+    /// speakers can still be rebalanced afterwards via their own sliders.
+    func setGroupVolume(_ volume: Double) {
+        for speaker in groupedSpeakers {
+            setVolume(volume, for: speaker.entityId)
+        }
+    }
+
+    // MARK: - Grouping
+
+    /// Whether `speakerID` is currently grouped with the active speaker.
+    func isGrouped(_ speakerID: EntityId) -> Bool {
+        guard let activeSpeaker, speakerID != activeSpeaker.entityId else {
+            return false
+        }
+        return activeSpeaker.groupMembers.contains(speakerID)
+    }
+
+    /// Toggles `speakerID` into or out of the active speaker's group. The active
+    /// speaker stays the group leader (the `join` sync source). Surfaces an error
+    /// banner when Home Assistant rejects the group change, so a failed sync no
+    /// longer looks like a silent no-op. Marks the speaker pending while the call
+    /// and the confirming reload settle, so its row shows a spinner.
+    func toggleGroupMember(_ speakerID: EntityId) async {
+        guard let activeSpeakerID, speakerID != activeSpeakerID else {
+            return
+        }
+        pendingGroupingSpeakers.insert(speakerID)
+        defer { pendingGroupingSpeakers.remove(speakerID) }
+        let speakerName = speakers[speakerID]?.friendlyName ?? speakerID.rawValue
+        if isGrouped(speakerID) {
+            let success = await restAPIService.unjoinSpeaker(memberID: speakerID)
+            if success {
+                await reloadSpeakers()
+            } else {
+                setErrorBannerText("Kunde inte dela upp högtalare", "Det gick inte att ta bort \(speakerName) från gruppen")
+            }
+        } else {
+            // A speaker already synced into a different group (e.g. Spa paired with
+            // Matbord-ute) can't be moved by a plain join, so unjoin it from its
+            // current group first. groupMembers > 1 means it is grouped with someone
+            // other than the active leader, since the grouped-with-leader case is the
+            // unjoin branch above.
+            let isInOtherGroup = (speakers[speakerID]?.groupMembers.count ?? 0) > 1
+            let success = await restAPIService.joinSpeakers(leaderID: activeSpeakerID,
+                                                            memberIDs: [speakerID],
+                                                            unjoinFirst: isInOtherGroup)
+            if success {
+                await reloadSpeakers()
+            } else {
+                setErrorBannerText("Kunde inte gruppera högtalare", "Det gick inte att lägga till \(speakerName) i gruppen")
+            }
+        }
+    }
+
+    /// Promotes a grouped speaker to primary — the one shown and controlled as the
+    /// group's main speaker. Playback still routes through the live Music Assistant
+    /// group leader (`playbackTargetID`), so switching the primary never interrupts
+    /// what's playing. No-op for a speaker that isn't grouped with the active one.
+    func makePrimary(_ speakerID: EntityId) {
+        guard speakerID != activeSpeakerID, isGrouped(speakerID) else {
+            return
+        }
+        selectSpeaker(speakerID)
+    }
+
+    /// Removes the active (primary) speaker from its group and promotes the next
+    /// grouped speaker to active, so playback control follows the speakers that
+    /// keep playing. Music Assistant re-elects the real group leader on its own;
+    /// the new `activeSpeakerID` only needs to be a remaining member, since
+    /// playback commands are routed through the live group leader. No-op when the
+    /// active speaker isn't grouped with anyone.
+    func removeActiveSpeakerFromGroup() async {
+        guard let activeSpeakerID, let activeSpeaker else {
+            return
+        }
+        let remaining = Self.speakerIDs.filter { activeSpeaker.groupMembers.contains($0) && $0 != activeSpeakerID }
+        guard let newActiveID = remaining.first else {
+            return
+        }
+        pendingGroupingSpeakers.insert(activeSpeakerID)
+        defer { pendingGroupingSpeakers.remove(activeSpeakerID) }
+        let speakerName = activeSpeaker.friendlyName
+        let success = await restAPIService.unjoinSpeaker(memberID: activeSpeakerID)
+        if success {
+            await reloadSpeakers()
+            // Route through selectSpeaker so the promoted speaker is also persisted
+            // as the last-used one, like any other manual selection.
+            selectSpeaker(newActiveID)
+        } else {
+            setErrorBannerText("Kunde inte dela upp högtalare", "Det gick inte att ta bort \(speakerName) från gruppen")
+        }
+    }
+}

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -97,6 +97,12 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// playlists, in configured order, rendered below "Favoriter". Accounts with
     /// no playlists (empty/failed fetch, or logged out) are kept off the list.
     @Published var personalPlaylistSections: [PersonalPlaylistSection] = []
+    /// Speakers with an in-flight join/unjoin. Home Assistant applies a group
+    /// change a beat after the call returns, so each grouping row shows a small
+    /// spinner while its speaker is in this set — bridging the gap between the tap
+    /// and the refreshed membership. Mutated by the grouping calls in
+    /// `MusicViewModel+Grouping`.
+    @Published var pendingGroupingSpeakers: Set<EntityId> = []
 
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false
@@ -182,32 +188,39 @@ class MusicViewModel: ObservableObject, Reloadable {
 
     func reload() async {
         await withReloadGuard {
-            let service = self.restAPIService
-            await withTaskGroup(of: (EntityId, MediaPlayerEntity)?.self) { group in
-                for speakerID in Self.speakerIDs {
-                    group.addTask {
-                        do {
-                            let speaker = try await service.reload(entityId: speakerID, entityType: MediaPlayerEntity.self)
-                            return (speakerID, speaker)
-                        } catch {
-                            Log.error("Failed to reload speaker: \(speakerID): \(error)")
-                            return nil
-                        }
-                    }
-                }
-
-                for await result in group {
-                    if let (speakerID, speaker) = result {
-                        self.speakers[speakerID] = speaker
-                    }
-                }
-            }
-
+            await self.reloadSpeakers()
             self.selectDefaultSpeakerIfNeeded()
             self.dropActiveSpeakerIfUnavailable()
         }
         await loadLibraryPlaylistsIfNeeded()
         await refreshQueueIfShowing()
+    }
+
+    /// Re-fetches every speaker entity in parallel and republishes it. Split out
+    /// from `reload()` so a grouping change (in `MusicViewModel+Grouping`) can
+    /// confirm the new membership right away instead of waiting for the next
+    /// 5-second loop.
+    func reloadSpeakers() async {
+        let service = restAPIService
+        await withTaskGroup(of: (EntityId, MediaPlayerEntity)?.self) { group in
+            for speakerID in Self.speakerIDs {
+                group.addTask {
+                    do {
+                        let speaker = try await service.reload(entityId: speakerID, entityType: MediaPlayerEntity.self)
+                        return (speakerID, speaker)
+                    } catch {
+                        Log.error("Failed to reload speaker: \(speakerID): \(error)")
+                        return nil
+                    }
+                }
+            }
+
+            for await result in group {
+                if let (speakerID, speaker) = result {
+                    self.speakers[speakerID] = speaker
+                }
+            }
+        }
     }
 
     /// On the first reload after the view appears, default the active speaker to
@@ -279,122 +292,5 @@ class MusicViewModel: ObservableObject, Reloadable {
 
     var hasNoResults: Bool {
         hasSearched && !isSearching && searchSections.isEmpty
-    }
-
-    // MARK: - Group volume
-
-    /// The speakers currently synced with the active speaker (leader plus any
-    /// followers), in the fixed display order. When the active speaker is
-    /// ungrouped this is just the active speaker on its own.
-    var groupedSpeakers: [MediaPlayerEntity] {
-        guard let activeSpeaker else {
-            return []
-        }
-        let memberIDs = activeSpeaker.groupMembers
-        guard memberIDs.count > 1 else {
-            return [activeSpeaker]
-        }
-        return Self.speakerIDs.filter { memberIDs.contains($0) }.compactMap { speakers[$0] }
-    }
-
-    /// Whether the active speaker is synced with at least one other speaker, so
-    /// the volume control should act on the whole group.
-    var isGroupActive: Bool {
-        groupedSpeakers.count > 1
-    }
-
-    /// The single value shown on the group-volume banner: the average volume
-    /// across every grouped speaker.
-    var groupVolume: Double {
-        let grouped = groupedSpeakers
-        guard grouped.isNotEmpty else {
-            return 0
-        }
-        let total = grouped.reduce(0.0) { $0 + $1.volumeLevel }
-        return total / Double(grouped.count)
-    }
-
-    /// Sets every grouped speaker to the same absolute volume. Individual
-    /// speakers can still be rebalanced afterwards via their own sliders.
-    func setGroupVolume(_ volume: Double) {
-        for speaker in groupedSpeakers {
-            setVolume(volume, for: speaker.entityId)
-        }
-    }
-
-    // MARK: - Grouping
-
-    /// Whether `speakerID` is currently grouped with the active speaker.
-    func isGrouped(_ speakerID: EntityId) -> Bool {
-        guard let activeSpeaker, speakerID != activeSpeaker.entityId else {
-            return false
-        }
-        return activeSpeaker.groupMembers.contains(speakerID)
-    }
-
-    /// Toggles `speakerID` into or out of the active speaker's group. The active
-    /// speaker stays the group leader (the `join` sync source). Surfaces an error
-    /// banner when Home Assistant rejects the group change, so a failed sync no
-    /// longer looks like a silent no-op.
-    func toggleGroupMember(_ speakerID: EntityId) async {
-        guard let activeSpeakerID, speakerID != activeSpeakerID else {
-            return
-        }
-        let speakerName = speakers[speakerID]?.friendlyName ?? speakerID.rawValue
-        if isGrouped(speakerID) {
-            let success = await restAPIService.unjoinSpeaker(memberID: speakerID)
-            if !success {
-                setErrorBannerText("Kunde inte dela upp högtalare", "Det gick inte att ta bort \(speakerName) från gruppen")
-            }
-        } else {
-            // A speaker already synced into a different group (e.g. Spa paired with
-            // Matbord-ute) can't be moved by a plain join, so unjoin it from its
-            // current group first. groupMembers > 1 means it is grouped with someone
-            // other than the active leader, since the grouped-with-leader case is the
-            // unjoin branch above.
-            let isInOtherGroup = (speakers[speakerID]?.groupMembers.count ?? 0) > 1
-            let success = await restAPIService.joinSpeakers(leaderID: activeSpeakerID,
-                                                            memberIDs: [speakerID],
-                                                            unjoinFirst: isInOtherGroup)
-            if !success {
-                setErrorBannerText("Kunde inte gruppera högtalare", "Det gick inte att lägga till \(speakerName) i gruppen")
-            }
-        }
-    }
-
-    /// Promotes a grouped speaker to primary — the one shown and controlled as the
-    /// group's main speaker. Playback still routes through the live Music Assistant
-    /// group leader (`playbackTargetID`), so switching the primary never interrupts
-    /// what's playing. No-op for a speaker that isn't grouped with the active one.
-    func makePrimary(_ speakerID: EntityId) {
-        guard speakerID != activeSpeakerID, isGrouped(speakerID) else {
-            return
-        }
-        selectSpeaker(speakerID)
-    }
-
-    /// Removes the active (primary) speaker from its group and promotes the next
-    /// grouped speaker to active, so playback control follows the speakers that
-    /// keep playing. Music Assistant re-elects the real group leader on its own;
-    /// the new `activeSpeakerID` only needs to be a remaining member, since
-    /// playback commands are routed through the live group leader. No-op when the
-    /// active speaker isn't grouped with anyone.
-    func removeActiveSpeakerFromGroup() async {
-        guard let activeSpeakerID, let activeSpeaker else {
-            return
-        }
-        let remaining = Self.speakerIDs.filter { activeSpeaker.groupMembers.contains($0) && $0 != activeSpeakerID }
-        guard let newActiveID = remaining.first else {
-            return
-        }
-        let speakerName = activeSpeaker.friendlyName
-        let success = await restAPIService.unjoinSpeaker(memberID: activeSpeakerID)
-        if success {
-            // Route through selectSpeaker so the promoted speaker is also persisted
-            // as the last-used one, like any other manual selection.
-            selectSpeaker(newActiveID)
-        } else {
-            setErrorBannerText("Kunde inte dela upp högtalare", "Det gick inte att ta bort \(speakerName) från gruppen")
-        }
     }
 }

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -17,12 +17,12 @@ struct SpeakerGroupingView: View {
         viewModel.availableSpeakers.filter { $0.entityId != viewModel.activeSpeakerID }
     }
 
-    /// The rows to show: every available speaker, but the active (primary) one is
-    /// only listed while it's grouped with others — so it can be removed, which
-    /// promotes another speaker to primary. Alone, removing it would be a no-op,
-    /// so it stays out of the list.
+    /// The rows to show: every available speaker, including the active (primary)
+    /// one so it's always visible as the group's leader. While grouped, tapping it
+    /// removes it and promotes another speaker to primary; alone, the tap is a
+    /// harmless no-op.
     private var listedSpeakers: [MediaPlayerEntity] {
-        viewModel.availableSpeakers.filter { $0.entityId != viewModel.activeSpeakerID || viewModel.isGroupActive }
+        viewModel.availableSpeakers
     }
 
     /// Names of the speakers grouped with the active one, used for the collapsed
@@ -101,6 +101,12 @@ private struct SpeakerGroupingRow: View {
         isPrimary || viewModel.isGrouped(speaker.entityId)
     }
 
+    // A join/unjoin for this speaker is still settling, so show a spinner and hold
+    // off further taps until the membership refreshes.
+    private var isPending: Bool {
+        viewModel.pendingGroupingSpeakers.contains(speaker.entityId)
+    }
+
     private var toggleAccessibilityLabel: String {
         if isPrimary {
             return "Ta bort \(speaker.friendlyName) som primär högtalare ur gruppen"
@@ -115,11 +121,21 @@ private struct SpeakerGroupingRow: View {
             // stay aligned) otherwise. Not a control of its own.
             Button(action: toggle) {
                 HStack(spacing: 8) {
-                    Image(systemName: "checkmark")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.yellow)
-                        .opacity(grouped ? 1 : 0)
-                        .frame(width: 18)
+                    // Spinner while a join/unjoin settles, otherwise the grouped
+                    // checkmark (kept space-reserved when ungrouped so names align).
+                    Group {
+                        if isPending {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .tint(.yellow)
+                        } else {
+                            Image(systemName: "checkmark")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.yellow)
+                                .opacity(grouped ? 1 : 0)
+                        }
+                    }
+                    .frame(width: 18)
                     Text(speaker.friendlyName)
                     if speaker.isPlaying {
                         Image(systemName: "speaker.wave.2.fill")
@@ -138,8 +154,9 @@ private struct SpeakerGroupingRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .disabled(isPending)
             .accessibilityLabel(toggleAccessibilityLabel)
-            .accessibilityValue(grouped ? "Grupperad" : "Inte grupperad")
+            .accessibilityValue(isPending ? "Uppdaterar" : (grouped ? "Grupperad" : "Inte grupperad"))
 
             if grouped, !isPrimary {
                 Button {
@@ -148,6 +165,7 @@ private struct SpeakerGroupingRow: View {
                     primaryChip(filled: false)
                 }
                 .buttonStyle(.plain)
+                .disabled(isPending)
                 .accessibilityLabel("Gör \(speaker.friendlyName) till primär högtalare")
             }
         }

--- a/IntelliNestTests/MusicViewModelGroupingTests.swift
+++ b/IntelliNestTests/MusicViewModelGroupingTests.swift
@@ -19,6 +19,38 @@ extension MusicViewModelTests {
         await fulfillment(of: [expectation], timeout: 2.0)
     }
 
+    func testJoinRefreshesMembershipImmediatelyAndClearsPending() async {
+        // Kitchen is the active, ungrouped leader.
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        XCTAssertFalse(viewModel.isGrouped(.mediaPlayerGuestRoom))
+
+        // The join succeeds and the speakers now report the new group, so the
+        // confirming reload inside toggleGroupMember should reflect it right away —
+        // without waiting for the 5-second loop — and clear the pending spinner.
+        stubPostService(path: "/api/services/media_player/join")
+        let group = [EntityId.mediaPlayerKitchen.rawValue, EntityId.mediaPlayerGuestRoom.rawValue]
+        stubSpeaker(.mediaPlayerKitchen,
+                    data: speakerJSON(entityID: .mediaPlayerKitchen, state: "playing",
+                                      friendlyName: "Köket", groupMembers: group))
+        stubSpeaker(.mediaPlayerGuestRoom,
+                    data: speakerJSON(entityID: .mediaPlayerGuestRoom, state: "idle",
+                                      friendlyName: "Gästrummet", groupMembers: group))
+        await viewModel.toggleGroupMember(.mediaPlayerGuestRoom)
+
+        XCTAssertTrue(viewModel.isGrouped(.mediaPlayerGuestRoom))
+        XCTAssertTrue(viewModel.pendingGroupingSpeakers.isEmpty)
+    }
+
+    func testFailedJoinClearsPendingAndBanners() async {
+        stubAllSpeakers(playing: .mediaPlayerKitchen)
+        await viewModel.reload()
+        stubPostService(path: "/api/services/media_player/join", statusCode: 500)
+        await viewModel.toggleGroupMember(.mediaPlayerGuestRoom)
+        XCTAssertTrue(viewModel.pendingGroupingSpeakers.isEmpty)
+        XCTAssertTrue(bannerTitles.contains("Kunde inte gruppera högtalare"))
+    }
+
     func testUnjoinRemovesSpeakerFromGroup() async {
         // Living room is leader with Kitchen already grouped in.
         stubSpeaker(.mediaPlayerLivingRoom,


### PR DESCRIPTION
## What

The speaker **group control** hid the active/primary speaker unless it was already grouped with another speaker — so when a speaker was playing on its own, it never appeared in the expanded list. Now every available speaker is listed, with the primary always shown as the group leader (solid "Primär" chip).

Also added **small, non-blocking per-row loading spinners**: a join/unjoin has a delay between the tap and Home Assistant applying the group change. Each row now shows a mini spinner (in place of its checkmark) and ignores further taps while its grouping settles, then refreshes the membership immediately via a targeted speaker reload instead of waiting for the 5-second loop.

## Changes

- `SpeakerGroupingView` — list all speakers; swap the row checkmark for a spinner and disable the row while pending.
- `MusicViewModel` — added `pendingGroupingSpeakers`; split `reloadSpeakers()` out of `reload()` so grouping ops can confirm membership right away.
- Moved the group-volume + grouping logic into a new `MusicViewModel+Grouping.swift` extension to keep `MusicViewModel.swift` under the 400-line limit.
- Tests for immediate membership refresh + pending-clear on success and failure.

## Screenshots

Verified `SpeakerGroupingView` with `ImageRenderer`: ungrouped primary now visible, an active group of 3, and a pending row. (The pending spinner shows as a placeholder in the offline render — `ProgressView` is UIKit-backed — but the row correctly dims; it animates on device.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnWR45aKQHbKb4tw5vkRaP