### PR TITLE
Stopped volume slider jumping on taps and showed primary speaker when ungrouped

### DIFF
--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -293,9 +293,10 @@ struct VolumeSliderView: View {
 }
 
 /// A fill slider mirroring `VerticalSlider`'s look (dark track, light fill, thin
-/// border). Tapping or dragging sets the value from the touch position; the
-/// change is reported live and committed on release. `axis` rotates it 90°:
-/// `.horizontal` fills left-to-right, `.vertical` fills bottom-to-top.
+/// border). Only a deliberate drag sets the value from the touch position — a
+/// plain tap is ignored so the volume can't jump (and blast) from an accidental
+/// touch. The change is reported live and committed on release. `axis` rotates
+/// it 90°: `.horizontal` fills left-to-right, `.vertical` fills bottom-to-top.
 private struct FillSlider: View {
     let fraction: Double
     var axis: Axis = .horizontal
@@ -321,7 +322,7 @@ private struct FillSlider: View {
             .overlay(RoundedRectangle(cornerRadius: radius).stroke(Color.black.opacity(0.5), lineWidth: 1))
             .contentShape(Rectangle())
             .gesture(
-                DragGesture(minimumDistance: 0)
+                DragGesture(minimumDistance: 10)
                     .onChanged { value in
                         let position: CGFloat = axis == .horizontal
                             ? value.location.x / width

--- a/IntelliNest/Views/Music/SpeakerGroupingView.swift
+++ b/IntelliNest/Views/Music/SpeakerGroupingView.swift
@@ -38,10 +38,11 @@ struct SpeakerGroupingView: View {
     }
 
     /// The collapsed summary lists the whole playback group, active speaker first
-    /// (e.g. "Kitchen, Gästrummet, Lekrummet"), or notes that nothing is grouped.
+    /// (e.g. "Kitchen, Gästrummet, Lekrummet"). When nothing is grouped it just
+    /// shows the primary speaker on its own rather than a "nothing grouped" note.
     private var summary: String {
         guard !groupedNames.isEmpty else {
-            return "Inga grupperade"
+            return activeSpeakerName ?? "Inga högtalare"
         }
         return ([activeSpeakerName].compactMap { $0 } + groupedNames).joined(separator: ", ")
     }


### PR DESCRIPTION
## What

Two small fixes to the music speaker controls:

1. **Volume slider no longer responds to taps.** The speaker volume control (`FillSlider` in `NowPlayingView`) used `DragGesture(minimumDistance: 0)`, so a bare tap registered as a drag at the touch location and instantly jumped the volume — easy to accidentally blast the sound. It now requires a deliberate drag (`minimumDistance: 10`); a plain tap does nothing.

2. **Light dimmers are untouched.** The light dimmer is a separate component (`VerticalSlider` in `Views/Light/`) and keeps its existing behavior: tap toggles the light on/off, drag adjusts brightness.

3. **Group control summary shows the primary speaker when nothing is grouped.** The collapsed "Gruppera högtalare" line read "Inga grupperade"; it now shows the primary speaker's name (e.g. "Vardagsrummet") instead, falling back to "Inga högtalare" only when there is no active speaker.

## Testing

Full test suite passes. UI verified by rendering `SpeakerGroupingView` (ungrouped and grouped) to PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slider interaction to prevent accidental taps from changing playback position; now requires intentional dragging to adjust values.
  * Enhanced speaker grouping display to show the active speaker's name when no speakers are grouped, providing clearer context instead of a generic message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->