### PR TITLE
Mirrored native Sonos now-playing when the MA queue goes stale

### DIFF
--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		FE0000000000000000000007 /* MusicQueueModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000007 /* MusicQueueModelTests.swift */; };
 		EE0000040000000000000004 /* MusicViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000040000000000000004 /* MusicViewModel.swift */; };
 		EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00000400000000000000F1 /* MusicViewModel+Playback.swift */; };
+		EE0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift */; };
 		FE0000000000000000000004 /* MusicViewModel+Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000004 /* MusicViewModel+Queue.swift */; };
 		FE000000000000000000FA01 /* MusicViewModel+Favourites.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD000000000000000000FA01 /* MusicViewModel+Favourites.swift */; };
 		FE00000000000000000000F5 /* MusicViewModel+Grouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD00000000000000000000F5 /* MusicViewModel+Grouping.swift */; };
@@ -302,6 +303,7 @@
 		FD0000000000000000000007 /* MusicQueueModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicQueueModelTests.swift; sourceTree = "<group>"; };
 		EF0000040000000000000004 /* MusicViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModel.swift; sourceTree = "<group>"; };
 		EF00000400000000000000F1 /* MusicViewModel+Playback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Playback.swift"; sourceTree = "<group>"; };
+		EF0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+HardwareMirror.swift"; sourceTree = "<group>"; };
 		FD0000000000000000000004 /* MusicViewModel+Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Queue.swift"; sourceTree = "<group>"; };
 		FD000000000000000000FA01 /* MusicViewModel+Favourites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Favourites.swift"; sourceTree = "<group>"; };
 		FD00000000000000000000F5 /* MusicViewModel+Grouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Grouping.swift"; sourceTree = "<group>"; };
@@ -640,6 +642,7 @@
 				D89BCA06BE3A45F2A8E3DAE4 /* LynkViewModelHelpers.swift */,
 				EF0000040000000000000004 /* MusicViewModel.swift */,
 				EF00000400000000000000F1 /* MusicViewModel+Playback.swift */,
+				EF0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift */,
 				FD0000000000000000000004 /* MusicViewModel+Queue.swift */,
 				FD000000000000000000FA01 /* MusicViewModel+Favourites.swift */,
 				FD00000000000000000000F5 /* MusicViewModel+Grouping.swift */,
@@ -1228,6 +1231,7 @@
 				FE0000000000000000000002 /* MusicAssistantSocketService.swift in Sources */,
 				EE0000040000000000000004 /* MusicViewModel.swift in Sources */,
 				EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */,
+				EE0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift in Sources */,
 				FE0000000000000000000004 /* MusicViewModel+Queue.swift in Sources */,
 				FE000000000000000000FA01 /* MusicViewModel+Favourites.swift in Sources */,
 				FE00000000000000000000F5 /* MusicViewModel+Grouping.swift in Sources */,

--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		FE0000000000000000FA0201 /* MusicViewModelPlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000FA0201 /* MusicViewModelPlaybackTests.swift */; };
 		FE0000000000000000FA0202 /* MusicViewModelPersonalSectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000FA0202 /* MusicViewModelPersonalSectionsTests.swift */; };
 		FE0000000000000000FA0203 /* MusicViewModelGroupVolumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000FA0203 /* MusicViewModelGroupVolumeTests.swift */; };
+		FE0000000000000000FA0299 /* MusicViewModelHardwareMirrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000FA0299 /* MusicViewModelHardwareMirrorTests.swift */; };
 		FE0000000000000000000007 /* MusicQueueModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000007 /* MusicQueueModelTests.swift */; };
 		EE0000040000000000000004 /* MusicViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000040000000000000004 /* MusicViewModel.swift */; };
 		EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00000400000000000000F1 /* MusicViewModel+Playback.swift */; };
@@ -297,6 +298,7 @@
 		FD0000000000000000FA0201 /* MusicViewModelPlaybackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelPlaybackTests.swift; sourceTree = "<group>"; };
 		FD0000000000000000FA0202 /* MusicViewModelPersonalSectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelPersonalSectionsTests.swift; sourceTree = "<group>"; };
 		FD0000000000000000FA0203 /* MusicViewModelGroupVolumeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelGroupVolumeTests.swift; sourceTree = "<group>"; };
+		FD0000000000000000FA0299 /* MusicViewModelHardwareMirrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelHardwareMirrorTests.swift; sourceTree = "<group>"; };
 		FD0000000000000000000007 /* MusicQueueModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicQueueModelTests.swift; sourceTree = "<group>"; };
 		EF0000040000000000000004 /* MusicViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModel.swift; sourceTree = "<group>"; };
 		EF00000400000000000000F1 /* MusicViewModel+Playback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Playback.swift"; sourceTree = "<group>"; };
@@ -606,6 +608,7 @@
 				FD0000000000000000FA0201 /* MusicViewModelPlaybackTests.swift */,
 				FD0000000000000000FA0202 /* MusicViewModelPersonalSectionsTests.swift */,
 				FD0000000000000000FA0203 /* MusicViewModelGroupVolumeTests.swift */,
+				FD0000000000000000FA0299 /* MusicViewModelHardwareMirrorTests.swift */,
 				FD0000000000000000000007 /* MusicQueueModelTests.swift */,
 			);
 			path = IntelliNestTests;
@@ -1274,6 +1277,7 @@
 				FE0000000000000000FA0201 /* MusicViewModelPlaybackTests.swift in Sources */,
 				FE0000000000000000FA0202 /* MusicViewModelPersonalSectionsTests.swift in Sources */,
 				FE0000000000000000FA0203 /* MusicViewModelGroupVolumeTests.swift in Sources */,
+				FE0000000000000000FA0299 /* MusicViewModelHardwareMirrorTests.swift in Sources */,
 				FE0000000000000000000007 /* MusicQueueModelTests.swift in Sources */,
 			BB0000003000000000000003 /* LightsViewModelTests.swift in Sources */,
 			BB0000007000000000000007 /* LockableTests.swift in Sources */,

--- a/IntelliNest/Model/MediaPlayerEntity.swift
+++ b/IntelliNest/Model/MediaPlayerEntity.swift
@@ -40,6 +40,45 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
         state == "playing"
     }
 
+    /// Whether the speaker is actually driving audio (playing or paused on a
+    /// track), as opposed to idle or unavailable. Used to decide when a hardware
+    /// twin's now-playing should override the Music Assistant queue entity's.
+    var hasLiveAudio: Bool {
+        state == "playing" || state == "paused"
+    }
+
+    /// Whether this entity and another are on the same track, compared by title
+    /// and artist. The Music Assistant entity and its native Sonos twin share no
+    /// comparable content id (MA exposes a Spotify URI, the Sonos a stream URL),
+    /// so the track identity is matched on the human-readable metadata instead.
+    func isSameTrack(as other: MediaPlayerEntity) -> Bool {
+        mediaTitle == other.mediaTitle && mediaArtist == other.mediaArtist
+    }
+
+    /// Returns a copy of this Music Assistant entity with its now-playing display
+    /// (state, track metadata, album art) replaced by the hardware twin's whenever
+    /// the twin is driving audio. Keeps every control-relevant field — id, group
+    /// members, volume, shuffle, repeat — from the MA entity, since playback
+    /// commands still route through Music Assistant. When the twin is playing a
+    /// track the MA queue doesn't know about, the MA content id (a Spotify URI) no
+    /// longer matches what's audible, so it's cleared to keep the favourite star
+    /// and playlist-jump from acting on the wrong track.
+    func mirroring(_ twin: MediaPlayerEntity?) -> MediaPlayerEntity {
+        guard let twin, twin.hasLiveAudio else {
+            return self
+        }
+        var mirrored = self
+        mirrored.state = twin.state
+        mirrored.mediaTitle = twin.mediaTitle
+        mirrored.mediaArtist = twin.mediaArtist
+        mirrored.mediaAlbumName = twin.mediaAlbumName
+        mirrored.entityPicture = twin.entityPicture
+        if !twin.isSameTrack(as: self) {
+            mirrored.mediaContentID = nil
+        }
+        return mirrored
+    }
+
     /// The speaker that playback and queue commands must target. When this
     /// speaker is synced into a group, Music Assistant only accepts transport
     /// and play commands on the group leader (the first group member); a

--- a/IntelliNest/Model/MediaPlayerEntity.swift
+++ b/IntelliNest/Model/MediaPlayerEntity.swift
@@ -47,12 +47,18 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
         state == "playing" || state == "paused"
     }
 
-    /// Whether this entity and another are on the same track, compared by title
-    /// and artist. The Music Assistant entity and its native Sonos twin share no
-    /// comparable content id (MA exposes a Spotify URI, the Sonos a stream URL),
-    /// so the track identity is matched on the human-readable metadata instead.
+    /// Whether this entity and another are confidently on the same track, compared
+    /// by title and artist. The Music Assistant entity and its native Sonos twin
+    /// share no comparable content id (MA exposes a Spotify URI, the Sonos a stream
+    /// URL), so the track identity is matched on the human-readable metadata.
+    /// A missing title can't confirm identity, so it counts as *not* the same track
+    /// — otherwise two metadata-less entities would match and a stale MA URI would
+    /// be wrongly preserved.
     func isSameTrack(as other: MediaPlayerEntity) -> Bool {
-        mediaTitle == other.mediaTitle && mediaArtist == other.mediaArtist
+        guard let title = mediaTitle, title.isNotEmpty else {
+            return false
+        }
+        return title == other.mediaTitle && mediaArtist == other.mediaArtist
     }
 
     /// Returns a copy of this Music Assistant entity with its now-playing display

--- a/IntelliNest/Utils/Constants/EntityId.swift
+++ b/IntelliNest/Utils/Constants/EntityId.swift
@@ -141,6 +141,15 @@ enum EntityId: String, Decodable, CaseIterable {
     case mediaPlayerOutdoorTable = "media_player.matbord_ute"
     case mediaPlayerSpa = "media_player.spa"
 
+    /* Native Sonos hardware entities backing four of the Music Assistant speakers
+     above (same physical device). The MA queue entity freezes on its last track
+     when playback starts outside the app's queue; its hardware twin always
+     reflects what's actually audible, so the now-playing display reads the twin. */
+    case mediaPlayerLivingRoomSonos = "media_player.arc"
+    case mediaPlayerKitchenSonos = "media_player.unnamed_room"
+    case mediaPlayerGuestRoomSonos = "media_player.move"
+    case mediaPlayerPlayroomSonos = "media_player.playbase"
+
     /* Yale Access token */
     case yaleAccessTokenPart1 = "input_text.yale_access_token_part1"
     case yaleAccessTokenPart2 = "input_text.yale_access_token_part2"

--- a/IntelliNest/ViewModels/MusicViewModel+HardwareMirror.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+HardwareMirror.swift
@@ -1,0 +1,97 @@
+//
+//  MusicViewModel+HardwareMirror.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-18.
+//
+
+import Foundation
+
+/// Mirroring the controllable Music Assistant speakers against their native Sonos
+/// hardware entities, split out of `MusicViewModel` to keep that file under the
+/// file-length limit. The MA queue entity freezes on its last track when playback
+/// starts outside the app's queue; the hardware twin always reflects what's
+/// actually audible, so the now-playing display reads the twin. Control still
+/// routes through Music Assistant.
+extension MusicViewModel {
+    /// The active speaker as it should be shown: the MA entity mirroring its
+    /// hardware twin. Drives the now-playing card's track, art, and play/pause
+    /// state so they stay honest when playback was started outside the app.
+    var displayedActiveSpeaker: MediaPlayerEntity? {
+        guard let activeSpeakerID else {
+            return nil
+        }
+        return displayedSpeaker(activeSpeakerID)
+    }
+
+    /// A speaker mirrored against its live hardware twin (when one applies).
+    /// Returns the MA entity unchanged for an AirPlay room playing on its own, or
+    /// when no twin is driving audio.
+    func displayedSpeaker(_ speakerID: EntityId) -> MediaPlayerEntity? {
+        guard let speaker = speakers[speakerID] else {
+            return nil
+        }
+        return speaker.mirroring(liveTwin(for: speaker))
+    }
+
+    /// The hardware twin that reflects what this speaker is actually playing: its
+    /// own twin first, then — when it has none playing — a grouped member's twin.
+    /// The fallback covers an AirPlay leader synced with a Sonos: the leader has no
+    /// twin of its own, but the group's audio is real on the Sonos member, so its
+    /// twin is the source of truth. Group members are listed by Music Assistant id,
+    /// which is exactly how `hardwareTwins` is keyed.
+    private func liveTwin(for speaker: MediaPlayerEntity) -> MediaPlayerEntity? {
+        if let own = hardwareTwins[speaker.entityId], own.hasLiveAudio {
+            return own
+        }
+        for memberID in speaker.groupMembers where memberID != speaker.entityId {
+            if let memberTwin = hardwareTwins[memberID], memberTwin.hasLiveAudio {
+                return memberTwin
+            }
+        }
+        return nil
+    }
+
+    /// Re-fetches the native Sonos entities that back the four Sonos rooms, keyed
+    /// by the Music Assistant speaker they belong to. A failed fetch keeps the
+    /// last-known twin (matching `reloadSpeakers`) so a transient blip doesn't flip
+    /// the room back to the stale MA now-playing; the next loop corrects it.
+    func reloadHardwareTwins() async {
+        let service = restAPIService
+        await withTaskGroup(of: (EntityId, MediaPlayerEntity)?.self) { group in
+            for (speakerID, twinID) in Self.hardwareTwinIDs {
+                group.addTask {
+                    do {
+                        let twin = try await service.reload(entityId: twinID, entityType: MediaPlayerEntity.self)
+                        return (speakerID, twin)
+                    } catch {
+                        Log.error("Failed to reload hardware twin: \(twinID): \(error)")
+                        return nil
+                    }
+                }
+            }
+
+            for await result in group {
+                if let (speakerID, twin) = result {
+                    self.hardwareTwins[speakerID] = twin
+                }
+            }
+        }
+    }
+
+    /// Clears the "Spelas från <spellista>" breadcrumb once the active speaker's
+    /// hardware twin reports a different track than the Music Assistant queue. That
+    /// happens when playback was taken over from outside the app — the in-app
+    /// playlist the breadcrumb points at is no longer what's playing, so jumping to
+    /// it would mislead.
+    func dropSourcePlaylistIfDiverged() {
+        guard nowPlayingSourcePlaylist != nil,
+              let activeSpeakerID,
+              let speaker = speakers[activeSpeakerID],
+              let twin = liveTwin(for: speaker),
+              !twin.isSameTrack(as: speaker) else {
+            return
+        }
+        nowPlayingSourcePlaylist = nil
+    }
+}

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -281,8 +281,12 @@ extension MusicViewModel {
         guard let activeSpeaker, let targetID = playbackTargetID else {
             return
         }
-        let action: Action = activeSpeaker.isPlaying ? .mediaPause : .mediaPlay
-        speakers[activeSpeaker.entityId]?.state = activeSpeaker.isPlaying ? "paused" : "playing"
+        // Decide from the mirrored state the card actually shows (the hardware
+        // twin's when it diverges), so the button does what its icon implies. The
+        // command still routes to the Music Assistant group leader.
+        let isPlaying = displayedActiveSpeaker?.isPlaying ?? activeSpeaker.isPlaying
+        let action: Action = isPlaying ? .mediaPause : .mediaPlay
+        speakers[activeSpeaker.entityId]?.state = isPlaying ? "paused" : "playing"
         restAPIService.mediaTransport(entityID: targetID, action: action)
     }
 

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -30,7 +30,21 @@ class MusicViewModel: ObservableObject, Reloadable {
         .mediaPlayerSpa
     ]
 
+    /// Maps four of the controllable speakers to their native Sonos hardware
+    /// entity (same physical device). The two AirPlay rooms (outdoor table, spa)
+    /// have no separate hardware entity and so can't diverge — they're absent here.
+    static let hardwareTwinIDs: [EntityId: EntityId] = [
+        .mediaPlayerLivingRoom: .mediaPlayerLivingRoomSonos,
+        .mediaPlayerKitchen: .mediaPlayerKitchenSonos,
+        .mediaPlayerGuestRoom: .mediaPlayerGuestRoomSonos,
+        .mediaPlayerPlayroom: .mediaPlayerPlayroomSonos
+    ]
+
     @Published var speakers: [EntityId: MediaPlayerEntity]
+    /// The native Sonos hardware entities, keyed by the Music Assistant speaker
+    /// they back. Read as the source of truth for the now-playing display when the
+    /// MA queue entity has gone stale (playback started outside the app's queue).
+    @Published var hardwareTwins: [EntityId: MediaPlayerEntity] = [:]
     @Published var activeSpeakerID: EntityId?
     @Published var searchText = ""
     @Published var searchSections: [MusicSearchSection] = []
@@ -145,17 +159,42 @@ class MusicViewModel: ObservableObject, Reloadable {
     let loadLastSpeaker: @MainActor () -> EntityId?
     let saveLastSpeaker: @MainActor (EntityId) -> Void
 
-    /// Speakers that are reachable right now (anything not `unavailable`),
-    /// in the fixed display order.
+    /// Speakers that are reachable right now (anything not `unavailable`), in the
+    /// fixed display order, each mirroring its hardware twin so the now-playing
+    /// metadata and play indicator reflect what's actually audible. Safe for the
+    /// picker, grouping, and default-selection: the mirror only touches display
+    /// fields, leaving id, group members, and volume from the MA entity.
     var availableSpeakers: [MediaPlayerEntity] {
-        Self.speakerIDs.compactMap { speakers[$0] }.filter { !$0.isUnavailable }
+        Self.speakerIDs.compactMap { displayedSpeaker($0) }.filter { !$0.isUnavailable }
     }
 
+    /// The raw Music Assistant entity for the active speaker. Used by the playback,
+    /// grouping, and volume commands, which must target the MA entity — not the
+    /// mirrored display copy. The now-playing card reads `displayedActiveSpeaker`.
     var activeSpeaker: MediaPlayerEntity? {
         guard let activeSpeakerID else {
             return nil
         }
         return speakers[activeSpeakerID]
+    }
+
+    /// The active speaker as it should be shown: the MA entity mirroring its
+    /// hardware twin. Drives the now-playing card's track, art, and play/pause
+    /// state so they stay honest when playback was started outside the app.
+    var displayedActiveSpeaker: MediaPlayerEntity? {
+        guard let activeSpeakerID else {
+            return nil
+        }
+        return displayedSpeaker(activeSpeakerID)
+    }
+
+    /// A speaker mirrored against its hardware twin (when it has one). Returns the
+    /// MA entity unchanged for the AirPlay rooms or when the twin is idle.
+    func displayedSpeaker(_ speakerID: EntityId) -> MediaPlayerEntity? {
+        guard let speaker = speakers[speakerID] else {
+            return nil
+        }
+        return speaker.mirroring(hardwareTwins[speakerID])
     }
 
     init(restAPIService: RestAPIService,
@@ -191,6 +230,7 @@ class MusicViewModel: ObservableObject, Reloadable {
             await self.reloadSpeakers()
             self.selectDefaultSpeakerIfNeeded()
             self.dropActiveSpeakerIfUnavailable()
+            self.dropSourcePlaylistIfDiverged()
         }
         await loadLibraryPlaylistsIfNeeded()
         await refreshQueueIfShowing()
@@ -221,6 +261,34 @@ class MusicViewModel: ObservableObject, Reloadable {
                 }
             }
         }
+        await reloadHardwareTwins()
+    }
+
+    /// Re-fetches the native Sonos entities that back the four Sonos rooms, keyed
+    /// by the Music Assistant speaker they belong to. A failed fetch drops that
+    /// twin (the room then falls back to the MA entity's own now-playing) rather
+    /// than blocking the rest of the reload.
+    private func reloadHardwareTwins() async {
+        let service = restAPIService
+        await withTaskGroup(of: (EntityId, MediaPlayerEntity)?.self) { group in
+            for (speakerID, twinID) in Self.hardwareTwinIDs {
+                group.addTask {
+                    do {
+                        let twin = try await service.reload(entityId: twinID, entityType: MediaPlayerEntity.self)
+                        return (speakerID, twin)
+                    } catch {
+                        Log.error("Failed to reload hardware twin: \(twinID): \(error)")
+                        return nil
+                    }
+                }
+            }
+
+            for await result in group {
+                if let (speakerID, twin) = result {
+                    self.hardwareTwins[speakerID] = twin
+                }
+            }
+        }
     }
 
     /// On the first reload after the view appears, default the active speaker to
@@ -244,6 +312,23 @@ class MusicViewModel: ObservableObject, Reloadable {
         if let activeSpeakerID, speakers[activeSpeakerID]?.isUnavailable == true {
             self.activeSpeakerID = nil
         }
+    }
+
+    /// Clears the "Spelas från <spellista>" breadcrumb once the active speaker's
+    /// hardware twin reports a different track than the Music Assistant queue. That
+    /// happens when playback was taken over from outside the app — the in-app
+    /// playlist the breadcrumb points at is no longer what's playing, so jumping to
+    /// it would mislead.
+    private func dropSourcePlaylistIfDiverged() {
+        guard nowPlayingSourcePlaylist != nil,
+              let activeSpeakerID,
+              let speaker = speakers[activeSpeakerID],
+              let twin = hardwareTwins[activeSpeakerID],
+              twin.hasLiveAudio,
+              !twin.isSameTrack(as: speaker) else {
+            return
+        }
+        nowPlayingSourcePlaylist = nil
     }
 
     func selectSpeaker(_ entityID: EntityId) {

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -159,13 +159,16 @@ class MusicViewModel: ObservableObject, Reloadable {
     let loadLastSpeaker: @MainActor () -> EntityId?
     let saveLastSpeaker: @MainActor (EntityId) -> Void
 
-    /// Speakers that are reachable right now (anything not `unavailable`), in the
-    /// fixed display order, each mirroring its hardware twin so the now-playing
-    /// metadata and play indicator reflect what's actually audible. Safe for the
-    /// picker, grouping, and default-selection: the mirror only touches display
-    /// fields, leaving id, group members, and volume from the MA entity.
+    /// Speakers that are reachable right now, in the fixed display order, each
+    /// mirroring its hardware twin so the now-playing metadata and play indicator
+    /// reflect what's actually audible. Reachability is judged on the raw Music
+    /// Assistant entity (the control path) — never the mirrored copy, whose twin
+    /// could otherwise paint an `unavailable` MA entity as playing and make an
+    /// uncontrollable speaker look selectable.
     var availableSpeakers: [MediaPlayerEntity] {
-        Self.speakerIDs.compactMap { displayedSpeaker($0) }.filter { !$0.isUnavailable }
+        Self.speakerIDs
+            .filter { speakers[$0]?.isUnavailable == false }
+            .compactMap { displayedSpeaker($0) }
     }
 
     /// The raw Music Assistant entity for the active speaker. Used by the playback,
@@ -176,44 +179,6 @@ class MusicViewModel: ObservableObject, Reloadable {
             return nil
         }
         return speakers[activeSpeakerID]
-    }
-
-    /// The active speaker as it should be shown: the MA entity mirroring its
-    /// hardware twin. Drives the now-playing card's track, art, and play/pause
-    /// state so they stay honest when playback was started outside the app.
-    var displayedActiveSpeaker: MediaPlayerEntity? {
-        guard let activeSpeakerID else {
-            return nil
-        }
-        return displayedSpeaker(activeSpeakerID)
-    }
-
-    /// A speaker mirrored against its live hardware twin (when one applies).
-    /// Returns the MA entity unchanged for an AirPlay room playing on its own, or
-    /// when no twin is driving audio.
-    func displayedSpeaker(_ speakerID: EntityId) -> MediaPlayerEntity? {
-        guard let speaker = speakers[speakerID] else {
-            return nil
-        }
-        return speaker.mirroring(liveTwin(for: speaker))
-    }
-
-    /// The hardware twin that reflects what this speaker is actually playing: its
-    /// own twin first, then — when it has none playing — a grouped member's twin.
-    /// The fallback covers an AirPlay leader synced with a Sonos: the leader has no
-    /// twin of its own, but the group's audio is real on the Sonos member, so its
-    /// twin is the source of truth. Group members are listed by Music Assistant id,
-    /// which is exactly how `hardwareTwins` is keyed.
-    private func liveTwin(for speaker: MediaPlayerEntity) -> MediaPlayerEntity? {
-        if let own = hardwareTwins[speaker.entityId], own.hasLiveAudio {
-            return own
-        }
-        for memberID in speaker.groupMembers where memberID != speaker.entityId {
-            if let memberTwin = hardwareTwins[memberID], memberTwin.hasLiveAudio {
-                return memberTwin
-            }
-        }
-        return nil
     }
 
     init(restAPIService: RestAPIService,
@@ -283,33 +248,6 @@ class MusicViewModel: ObservableObject, Reloadable {
         await reloadHardwareTwins()
     }
 
-    /// Re-fetches the native Sonos entities that back the four Sonos rooms, keyed
-    /// by the Music Assistant speaker they belong to. A failed fetch drops that
-    /// twin (the room then falls back to the MA entity's own now-playing) rather
-    /// than blocking the rest of the reload.
-    private func reloadHardwareTwins() async {
-        let service = restAPIService
-        await withTaskGroup(of: (EntityId, MediaPlayerEntity)?.self) { group in
-            for (speakerID, twinID) in Self.hardwareTwinIDs {
-                group.addTask {
-                    do {
-                        let twin = try await service.reload(entityId: twinID, entityType: MediaPlayerEntity.self)
-                        return (speakerID, twin)
-                    } catch {
-                        Log.error("Failed to reload hardware twin: \(twinID): \(error)")
-                        return nil
-                    }
-                }
-            }
-
-            for await result in group {
-                if let (speakerID, twin) = result {
-                    self.hardwareTwins[speakerID] = twin
-                }
-            }
-        }
-    }
-
     /// On the first reload after the view appears, default the active speaker to
     /// whatever is currently playing, falling back to the last speaker the user
     /// controlled (if it's reachable). If neither applies, leave it unselected so
@@ -331,22 +269,6 @@ class MusicViewModel: ObservableObject, Reloadable {
         if let activeSpeakerID, speakers[activeSpeakerID]?.isUnavailable == true {
             self.activeSpeakerID = nil
         }
-    }
-
-    /// Clears the "Spelas från <spellista>" breadcrumb once the active speaker's
-    /// hardware twin reports a different track than the Music Assistant queue. That
-    /// happens when playback was taken over from outside the app — the in-app
-    /// playlist the breadcrumb points at is no longer what's playing, so jumping to
-    /// it would mislead.
-    private func dropSourcePlaylistIfDiverged() {
-        guard nowPlayingSourcePlaylist != nil,
-              let activeSpeakerID,
-              let speaker = speakers[activeSpeakerID],
-              let twin = liveTwin(for: speaker),
-              !twin.isSameTrack(as: speaker) else {
-            return
-        }
-        nowPlayingSourcePlaylist = nil
     }
 
     func selectSpeaker(_ entityID: EntityId) {

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -188,13 +188,32 @@ class MusicViewModel: ObservableObject, Reloadable {
         return displayedSpeaker(activeSpeakerID)
     }
 
-    /// A speaker mirrored against its hardware twin (when it has one). Returns the
-    /// MA entity unchanged for the AirPlay rooms or when the twin is idle.
+    /// A speaker mirrored against its live hardware twin (when one applies).
+    /// Returns the MA entity unchanged for an AirPlay room playing on its own, or
+    /// when no twin is driving audio.
     func displayedSpeaker(_ speakerID: EntityId) -> MediaPlayerEntity? {
         guard let speaker = speakers[speakerID] else {
             return nil
         }
-        return speaker.mirroring(hardwareTwins[speakerID])
+        return speaker.mirroring(liveTwin(for: speaker))
+    }
+
+    /// The hardware twin that reflects what this speaker is actually playing: its
+    /// own twin first, then — when it has none playing — a grouped member's twin.
+    /// The fallback covers an AirPlay leader synced with a Sonos: the leader has no
+    /// twin of its own, but the group's audio is real on the Sonos member, so its
+    /// twin is the source of truth. Group members are listed by Music Assistant id,
+    /// which is exactly how `hardwareTwins` is keyed.
+    private func liveTwin(for speaker: MediaPlayerEntity) -> MediaPlayerEntity? {
+        if let own = hardwareTwins[speaker.entityId], own.hasLiveAudio {
+            return own
+        }
+        for memberID in speaker.groupMembers where memberID != speaker.entityId {
+            if let memberTwin = hardwareTwins[memberID], memberTwin.hasLiveAudio {
+                return memberTwin
+            }
+        }
+        return nil
     }
 
     init(restAPIService: RestAPIService,
@@ -323,8 +342,7 @@ class MusicViewModel: ObservableObject, Reloadable {
         guard nowPlayingSourcePlaylist != nil,
               let activeSpeakerID,
               let speaker = speakers[activeSpeakerID],
-              let twin = hardwareTwins[activeSpeakerID],
-              twin.hasLiveAudio,
+              let twin = liveTwin(for: speaker),
               !twin.isSameTrack(as: speaker) else {
             return
         }

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -23,7 +23,7 @@ struct MusicView: View {
 
             ScrollView {
                 VStack(spacing: 16) {
-                    if let activeSpeaker = viewModel.activeSpeaker {
+                    if let activeSpeaker = viewModel.displayedActiveSpeaker {
                         NowPlayingView(speaker: activeSpeaker, viewModel: viewModel)
                         SpeakerGroupingView(viewModel: viewModel)
                         LibraryPlaylistsSection(title: "Senast spelade",

--- a/IntelliNestTests/MusicViewModelHardwareMirrorTests.swift
+++ b/IntelliNestTests/MusicViewModelHardwareMirrorTests.swift
@@ -115,6 +115,61 @@ extension MusicViewModelTests {
         XCTAssertEqual(displayed?.mediaContentID, trackURI)
     }
 
+    func testAirPlayLeaderMirrorsGroupedSonosMemberTwin() async {
+        // Spa (AirPlay, no twin of its own) leads a group with the living-room
+        // Sonos. The spa MA entity is stale; the Sonos member's hardware twin
+        // carries the real track, so the leader's card must mirror it.
+        let group = [EntityId.mediaPlayerSpa.rawValue, EntityId.mediaPlayerLivingRoom.rawValue]
+        stubAllSpeakers()
+        stubSpeaker(.mediaPlayerSpa,
+                    data: speakerJSON(entityID: .mediaPlayerSpa,
+                                      state: "idle",
+                                      friendlyName: "Spa",
+                                      title: "Bara Bada Bastu",
+                                      artist: "KAJ",
+                                      contentID: trackURI,
+                                      groupMembers: group))
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "idle",
+                                      friendlyName: "Vardagsrummet",
+                                      title: "Bara Bada Bastu",
+                                      artist: "KAJ",
+                                      groupMembers: group))
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: "Sankta Lucia",
+                 artist: "Lucia Choir")
+        await viewModel.reload()
+
+        let displayed = viewModel.displayedSpeaker(.mediaPlayerSpa)
+        XCTAssertEqual(displayed?.mediaTitle, "Sankta Lucia")
+        XCTAssertTrue(displayed?.isPlaying == true)
+        XCTAssertNil(displayed?.mediaContentID)
+    }
+
+    func testUngroupedAirPlayLeaderIsNotMirroredFromOtherRoom() async {
+        // A live Sonos in a *different*, ungrouped room must not bleed into the
+        // spa's card — the fallback only follows the leader's own group members.
+        stubAllSpeakers()
+        stubSpeaker(.mediaPlayerSpa,
+                    data: speakerJSON(entityID: .mediaPlayerSpa,
+                                      state: "playing",
+                                      friendlyName: "Spa",
+                                      title: trackName,
+                                      artist: trackArtist,
+                                      contentID: trackURI))
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: "Sankta Lucia",
+                 artist: "Lucia Choir")
+        await viewModel.reload()
+
+        let displayed = viewModel.displayedSpeaker(.mediaPlayerSpa)
+        XCTAssertEqual(displayed?.mediaTitle, trackName)
+        XCTAssertEqual(displayed?.mediaContentID, trackURI)
+    }
+
     func testDefaultSelectionPicksRoomPlayingOnlyOnHardwareTwin() async {
         // Every MA queue entity is idle, but the living-room Sonos is playing —
         // the default selection must still land on that room.

--- a/IntelliNestTests/MusicViewModelHardwareMirrorTests.swift
+++ b/IntelliNestTests/MusicViewModelHardwareMirrorTests.swift
@@ -45,16 +45,38 @@ extension MusicViewModelTests {
                  artist: "Lucia Choir",
                  album: "Lucia",
                  entityPicture: "/api/media_player_proxy/media_player.arc")
+        // Before the reload the twin is unknown, so the room shows its MA state.
+        XCTAssertNil(viewModel.displayedSpeaker(.mediaPlayerLivingRoom)?.mediaTitle)
         await viewModel.reload()
 
         let displayed = viewModel.displayedSpeaker(.mediaPlayerLivingRoom)
         XCTAssertEqual(displayed?.mediaTitle, "Sankta Lucia")
         XCTAssertEqual(displayed?.mediaArtist, "Lucia Choir")
         XCTAssertEqual(displayed?.mediaAlbumName, "Lucia")
+        XCTAssertEqual(displayed?.entityPicture, "/api/media_player_proxy/media_player.arc")
         XCTAssertTrue(displayed?.isPlaying == true)
         // The MA Spotify URI no longer matches what's audible, so it's dropped —
         // the favourite star and playlist-jump must not act on the wrong track.
         XCTAssertNil(displayed?.mediaContentID)
+    }
+
+    func testUnavailableMAEntityIsNotSelectableEvenWhenTwinPlays() async {
+        // The MA control entity is unavailable, but its hardware twin is playing.
+        // The room must stay out of the reachable list — control routes through the
+        // dead MA entity, so it can't be selected even though audio is coming out.
+        stubAllSpeakers()
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "unavailable",
+                                      friendlyName: "Vardagsrummet"))
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: "Sankta Lucia",
+                 artist: "Lucia Choir")
+        await viewModel.reload()
+
+        let availableIDs = viewModel.availableSpeakers.map(\.entityId)
+        XCTAssertFalse(availableIDs.contains(.mediaPlayerLivingRoom))
     }
 
     func testTwinKeepsMAContentIDWhenSameTrack() async {

--- a/IntelliNestTests/MusicViewModelHardwareMirrorTests.swift
+++ b/IntelliNestTests/MusicViewModelHardwareMirrorTests.swift
@@ -1,0 +1,174 @@
+@testable import IntelliNest
+import XCTest
+
+@MainActor
+extension MusicViewModelTests {
+    // MARK: - Hardware twin mirroring
+
+    /// Stubs the native Sonos entity that backs `speakerID`. Asserts the room has a
+    /// twin so a typo can't silently make the stub unreachable.
+    func stubTwin(for speakerID: EntityId,
+                  state: String,
+                  title: String? = nil,
+                  artist: String? = nil,
+                  album: String? = nil,
+                  contentID: String? = nil,
+                  entityPicture: String? = nil) {
+        guard let twinID = MusicViewModel.hardwareTwinIDs[speakerID] else {
+            XCTFail("\(speakerID) has no hardware twin")
+            return
+        }
+        stubSpeaker(twinID, data: speakerJSON(entityID: twinID,
+                                              state: state,
+                                              friendlyName: twinID.rawValue,
+                                              title: title,
+                                              artist: artist,
+                                              album: album,
+                                              contentID: contentID,
+                                              entityPicture: entityPicture))
+    }
+
+    func testTwinMirrorsNowPlayingWhenMAQueueIsStale() async {
+        // The MA queue entity is frozen on its last track, idle; the real Sonos is
+        // playing something else that was started outside the app's queue.
+        stubAllSpeakers()
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "idle",
+                                      friendlyName: "Vardagsrummet",
+                                      title: "Bara Bada Bastu",
+                                      artist: "KAJ",
+                                      contentID: trackURI))
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: "Sankta Lucia",
+                 artist: "Lucia Choir",
+                 album: "Lucia",
+                 entityPicture: "/api/media_player_proxy/media_player.arc")
+        await viewModel.reload()
+
+        let displayed = viewModel.displayedSpeaker(.mediaPlayerLivingRoom)
+        XCTAssertEqual(displayed?.mediaTitle, "Sankta Lucia")
+        XCTAssertEqual(displayed?.mediaArtist, "Lucia Choir")
+        XCTAssertEqual(displayed?.mediaAlbumName, "Lucia")
+        XCTAssertTrue(displayed?.isPlaying == true)
+        // The MA Spotify URI no longer matches what's audible, so it's dropped —
+        // the favourite star and playlist-jump must not act on the wrong track.
+        XCTAssertNil(displayed?.mediaContentID)
+    }
+
+    func testTwinKeepsMAContentIDWhenSameTrack() async {
+        // Normal in-app playback: MA and the Sonos agree on the track, so the MA
+        // Spotify URI is preserved for the favourite star.
+        stubAllSpeakers()
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "playing",
+                                      friendlyName: "Vardagsrummet",
+                                      title: trackName,
+                                      artist: trackArtist,
+                                      contentID: trackURI))
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: trackName,
+                 artist: trackArtist)
+        await viewModel.reload()
+
+        let displayed = viewModel.displayedSpeaker(.mediaPlayerLivingRoom)
+        XCTAssertEqual(displayed?.mediaContentID, trackURI)
+        XCTAssertTrue(displayed?.isPlaying == true)
+    }
+
+    func testIdleTwinLeavesMAEntityUntouched() async {
+        // When the Sonos is idle, the MA entity's own now-playing stands.
+        stubAllSpeakers()
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "playing",
+                                      friendlyName: "Vardagsrummet",
+                                      title: trackName,
+                                      artist: trackArtist,
+                                      contentID: trackURI))
+        stubTwin(for: .mediaPlayerLivingRoom, state: "idle")
+        await viewModel.reload()
+
+        let displayed = viewModel.displayedSpeaker(.mediaPlayerLivingRoom)
+        XCTAssertEqual(displayed?.mediaTitle, trackName)
+        XCTAssertEqual(displayed?.mediaContentID, trackURI)
+    }
+
+    func testAirPlayRoomHasNoTwinAndShowsMAState() async {
+        // The spa is AirPlay — no hardware twin — so it always shows the MA entity.
+        stubAllSpeakers()
+        stubSpeaker(.mediaPlayerSpa,
+                    data: speakerJSON(entityID: .mediaPlayerSpa,
+                                      state: "playing",
+                                      friendlyName: "Spa",
+                                      title: trackName,
+                                      artist: trackArtist,
+                                      contentID: trackURI))
+        await viewModel.reload()
+
+        XCTAssertNil(MusicViewModel.hardwareTwinIDs[.mediaPlayerSpa])
+        let displayed = viewModel.displayedSpeaker(.mediaPlayerSpa)
+        XCTAssertEqual(displayed?.mediaTitle, trackName)
+        XCTAssertEqual(displayed?.mediaContentID, trackURI)
+    }
+
+    func testDefaultSelectionPicksRoomPlayingOnlyOnHardwareTwin() async {
+        // Every MA queue entity is idle, but the living-room Sonos is playing —
+        // the default selection must still land on that room.
+        stubAllSpeakers(playing: nil)
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: "Sankta Lucia",
+                 artist: "Lucia Choir")
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.activeSpeakerID, .mediaPlayerLivingRoom)
+    }
+
+    func testSourcePlaylistClearedWhenTwinDiverges() async {
+        stubAllSpeakers(playing: .mediaPlayerLivingRoom)
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "playing",
+                                      friendlyName: "Vardagsrummet",
+                                      title: "Bara Bada Bastu",
+                                      artist: "KAJ"))
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: "Sankta Lucia",
+                 artist: "Lucia Choir")
+        viewModel.activeSpeakerID = .mediaPlayerLivingRoom
+        viewModel.nowPlayingSourcePlaylist = MusicSearchItem(uri: "spotify://playlist/9",
+                                                             name: "Låtar som går och går",
+                                                             mediaType: .playlist,
+                                                             imageURL: nil,
+                                                             artist: nil)
+        await viewModel.reload()
+        XCTAssertNil(viewModel.nowPlayingSourcePlaylist)
+    }
+
+    func testSourcePlaylistKeptWhenTwinMatches() async {
+        stubAllSpeakers(playing: .mediaPlayerLivingRoom)
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "playing",
+                                      friendlyName: "Vardagsrummet",
+                                      title: trackName,
+                                      artist: trackArtist))
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: trackName,
+                 artist: trackArtist)
+        viewModel.activeSpeakerID = .mediaPlayerLivingRoom
+        let playlist = MusicSearchItem(uri: "spotify://playlist/9",
+                                       name: "Låtar som går och går",
+                                       mediaType: .playlist,
+                                       imageURL: nil,
+                                       artist: nil)
+        viewModel.nowPlayingSourcePlaylist = playlist
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.nowPlayingSourcePlaylist?.uri, playlist.uri)
+    }
+}

--- a/IntelliNestTests/MusicViewModelTests.swift
+++ b/IntelliNestTests/MusicViewModelTests.swift
@@ -58,6 +58,9 @@ class MusicViewModelTests: XCTestCase {
                      volume: Double = 0.3,
                      title: String? = nil,
                      artist: String? = nil,
+                     album: String? = nil,
+                     contentID: String? = nil,
+                     entityPicture: String? = nil,
                      groupMembers: [String] = [],
                      shuffle: Bool = false,
                      repeatMode: String = "off") -> Data {
@@ -70,6 +73,9 @@ class MusicViewModelTests: XCTestCase {
         ]
         if let title { attributes["media_title"] = title }
         if let artist { attributes["media_artist"] = artist }
+        if let album { attributes["media_album_name"] = album }
+        if let contentID { attributes["media_content_id"] = contentID }
+        if let entityPicture { attributes["entity_picture"] = entityPicture }
         return makeEntityJSON(entityId: entityID.rawValue, state: state, attributes: attributes)
     }
 


### PR DESCRIPTION
## Problem

The Musik screen showed a stale, wrong track. In the reported case "Bara Bada Bastu" / KAJ was shown (with a *play* button), while "Sankta Lucia" was actually coming out of the living-room speaker.

Root cause is architectural, not a refresh bug. The app reads only the **Music Assistant queue entities** (`media_player.vardagsrummet`, `media_player.kitchen`, …). Those entities freeze on their last track and report `idle`/`paused` whenever playback is started *outside* the app's MA queue (Spotify Connect, the Sonos app, or another queue). The real, current playback lives on the native **Sonos** entities (`media_player.arc`, …), which the app ignored.

Confirmed live against HA: the MA living-room entity read `idle` / "Bara Bada Bastu" while the actual Arc was `playing` a different track.

## Fix — mirror the hardware truth (display only)

Four of the six rooms are Sonos with a native hardware twin (same HA device); the other two are AirPlay and can't diverge:

| App speaker (Music Assistant) | Native hardware twin |
|---|---|
| `media_player.vardagsrummet` | `media_player.arc` |
| `media_player.kitchen` | `media_player.unnamed_room` |
| `media_player.gastrummet` | `media_player.move` |
| `media_player.lekrummet` | `media_player.playbase` |

- Reload now also fetches the twins (`reloadHardwareTwins`).
- `MediaPlayerEntity.mirroring(_:)` produces the display entity: when the twin is driving audio, its state / title / artist / album / art replace the MA entity's. Every control field (id, group members, volume, shuffle, repeat) stays from the MA entity — **playback commands still route through Music Assistant.**
- When the twin plays a track the MA queue doesn't know about, the MA Spotify URI no longer matches what's audible, so it's dropped (no favourite-star / playlist-jump on the wrong track).
- Default speaker selection now lands on a room playing only on its hardware twin.
- The "Spelas från <spellista>" breadcrumb is cleared once the twin diverges from the MA queue.
- `togglePlayPause` derives its action from the mirrored state so the button does what its icon shows.

## Tests

Added `MusicViewModelHardwareMirrorTests` (extends `MusicViewModelTests`): stale-mirror, same-track URI preservation, idle-twin passthrough, AirPlay no-twin, twin-only default selection, and breadcrumb clear/keep on divergence. Full suite green; SwiftFormat + SwiftLint `--strict` clean.

## Note on screenshots

The now-playing card layout is unchanged — only the data feeding it. Verifying the fix visually needs a real divergence (a track started outside the app on the Sonos), so it's best confirmed on-device against live HA rather than a rendered sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sonos hardware state mirroring to display actual playback across speaker zones.

* **Bug Fixes**
  * Improved accuracy of now-playing display when hardware state diverges from the app's tracked state.
  * Fixed playback controls to use the displayed speaker state for accurate transport commands.

* **Tests**
  * Added comprehensive tests for hardware mirroring behavior across speaker types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->