### PR TITLE
Showed grouped speakers as a subtitle under the collapsed volume slider

### DIFF
--- a/IntelliNest/Views/Music/GroupVolumeView.swift
+++ b/IntelliNest/Views/Music/GroupVolumeView.swift
@@ -16,6 +16,21 @@ struct GroupVolumeView: View {
     @ObservedObject var viewModel: MusicViewModel
     @State private var isExpanded = false
 
+    /// The grouped speakers as a one-line summary, primary first
+    /// (e.g. "Kitchen, Matbord-ute"), shown under the collapsed slider so the
+    /// group is visible without expanding. Empty when nothing is grouped.
+    private var groupSummary: String {
+        guard viewModel.isGroupActive else {
+            return ""
+        }
+        let primaryName = viewModel.availableSpeakers
+            .first { $0.entityId == viewModel.activeSpeakerID }?.friendlyName
+        let followerNames = viewModel.groupedSpeakers
+            .filter { $0.entityId != viewModel.activeSpeakerID }
+            .map(\.friendlyName)
+        return ([primaryName].compactMap { $0 } + followerNames).joined(separator: ", ")
+    }
+
     var body: some View {
         VStack(spacing: 12) {
             HStack(spacing: 10) {
@@ -32,6 +47,19 @@ struct GroupVolumeView: View {
                 VolumeSliderView(volume: viewModel.groupVolume,
                                  onCommit: { viewModel.setGroupVolume($0) })
                     .accessibilityLabel(viewModel.isGroupActive ? "Gruppvolym" : "Volym")
+            }
+
+            // While collapsed, name the grouped speakers under the slider — the same
+            // summary the old grouping card showed — so the group is legible at a
+            // glance. Aligned with the slider (past the chevron) and kept to one line.
+            if !isExpanded, groupSummary.isNotEmpty {
+                Text(groupSummary)
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.6))
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading, 26)
+                    .accessibilityLabel("Grupperade högtalare: \(groupSummary)")
             }
 
             if isExpanded {


### PR DESCRIPTION
## What

Brings back the grouped-speakers summary line that the old "Gruppera högtalare" card had — now under the collapsed group-volume slider.

When the active speaker is grouped, the collapsed control shows a one-line subtitle naming the group (primary first, e.g. **"Kitchen, Matbord-ute"**), aligned under the slider. It truncates to a single line when the whole house is grouped, and is hidden entirely for a single ungrouped speaker.

## Changes
- `GroupVolumeView` gains a `groupSummary` (primary first, then followers in display order) and renders it as a caption under the slider while collapsed and `isGroupActive`.

## Verification
- Build + SwiftFormat/SwiftLint (`--strict`) clean.
- Rendered three collapsed states (two grouped, all six grouped → truncates, single → no subtitle) via ImageRenderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGnw8ubE1WSGtAgUy1pr4L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collapsed speaker groups now show a clear one-line summary of the active speakers below the volume slider.
  * Accessibility labels have been improved to better reflect grouped speakers when the panel is collapsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->