### PR TITLE
Fixed now-playing title and the single-speaker volume subtitle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,29 @@ entities conform to `Reloadable` (`Model/Reloadable.swift`); a `reload()` re-fet
 `/api/states/{entityId}`) and republishes. A few services that return a body (e.g. Music Assistant search) use a
 dedicated `return_response` request path rather than the fire-and-forget POST used for most service calls.
 
+### Music: Music Assistant + Sonos hardware twins
+
+The music controller drives speakers through **Music Assistant** `media_player.*` queue entities
+(e.g. `media_player.vardagsrummet`). All control — play/pause, transport, volume, grouping — routes through the
+MA entity, even when the speaker is a Sonos. The four Sonos rooms *also* expose a **native Sonos hardware entity**
+("hardware twin", e.g. `media_player.arc`), mapped to its MA entity in `MusicViewModel.hardwareTwinIDs`.
+
+**Which entity knows the now-playing track depends on what's playing:**
+
+- **Sonos playing MA's universal flow stream (the normal case).** The MA queue entity holds the real track; the
+  Sonos hardware twin shows the generic placeholder title `"Music Assistant"` with no artist and a `…/flow/…`
+  `media_content_id`. So for flow playback **the MA entity is authoritative** and the twin carries nothing useful.
+- **Sonos playing a native source MA doesn't drive** (AirPlay, Spotify Connect, TV). The MA queue entity freezes on
+  its last queued track while the hardware twin reflects what's actually audible — here **the twin is authoritative**.
+
+The now-playing card reads `displayedActiveSpeaker` / `displayedSpeaker(_:)` (`MusicViewModel+HardwareMirror`), which
+mirrors the MA entity against its live twin only when the twin `hasMirrorableNowPlaying` — i.e. it has live audio
+*and* is not merely rendering the MA flow (`isRenderingMusicAssistantFlow`, detected by a `/flow/` content id). A
+flow-only twin is ignored so it can't clobber the real MA title with `"Music Assistant"`. MA entity and Sonos twin
+share no comparable content id (MA exposes a Spotify URI, the Sonos a stream URL), so track identity is matched on
+title+artist via `isSameTrack`. The queue screen (`get_queue`, a `return_response` call) reads the real track
+directly and bypasses the mirror entirely, so it stays correct regardless of which entity the card trusts.
+
 ### Models
 
 `EntityProtocol` is the base for all Home Assistant entities. It carries `state`, `entityId`, and timestamps. Concrete types (`LightEntity`, `LockEntity`, `HeaterEntity`, etc.) add domain-specific decoded properties.

--- a/IntelliNest/Model/MediaPlayerEntity.swift
+++ b/IntelliNest/Model/MediaPlayerEntity.swift
@@ -47,6 +47,23 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
         state == "playing" || state == "paused"
     }
 
+    /// Whether this entity is only rendering Music Assistant's own universal flow
+    /// stream rather than a source it has real metadata for. A Sonos playing the
+    /// MA flow reports the generic "Music Assistant" title with no artist and a
+    /// `…/flow/…` stream as its content id, while the MA queue entity holds the
+    /// real track — so in that case the twin must not override the MA now-playing.
+    var isRenderingMusicAssistantFlow: Bool {
+        mediaContentID?.contains("/flow/") == true
+    }
+
+    /// Whether this hardware twin carries a now-playing worth mirroring onto its
+    /// Music Assistant entity: it's driving audio for a source it actually has
+    /// metadata for (native AirPlay, Spotify Connect, TV), not merely rendering
+    /// the MA flow stream the MA queue entity already describes.
+    var hasMirrorableNowPlaying: Bool {
+        hasLiveAudio && !isRenderingMusicAssistantFlow
+    }
+
     /// Whether this entity and another are confidently on the same track, compared
     /// by title and artist. The Music Assistant entity and its native Sonos twin
     /// share no comparable content id (MA exposes a Spotify URI, the Sonos a stream

--- a/IntelliNest/ViewModels/MusicViewModel+HardwareMirror.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+HardwareMirror.swift
@@ -41,11 +41,11 @@ extension MusicViewModel {
     /// twin is the source of truth. Group members are listed by Music Assistant id,
     /// which is exactly how `hardwareTwins` is keyed.
     private func liveTwin(for speaker: MediaPlayerEntity) -> MediaPlayerEntity? {
-        if let own = hardwareTwins[speaker.entityId], own.hasLiveAudio {
+        if let own = hardwareTwins[speaker.entityId], own.hasMirrorableNowPlaying {
             return own
         }
         for memberID in speaker.groupMembers where memberID != speaker.entityId {
-            if let memberTwin = hardwareTwins[memberID], memberTwin.hasLiveAudio {
+            if let memberTwin = hardwareTwins[memberID], memberTwin.hasMirrorableNowPlaying {
                 return memberTwin
             }
         }

--- a/IntelliNest/Views/Music/GroupVolumeView.swift
+++ b/IntelliNest/Views/Music/GroupVolumeView.swift
@@ -16,13 +16,12 @@ struct GroupVolumeView: View {
     @ObservedObject var viewModel: MusicViewModel
     @State private var isExpanded = false
 
-    /// The grouped speakers as a one-line summary, primary first
-    /// (e.g. "Kitchen, Matbord-ute"), shown under the collapsed slider so the
-    /// group is visible without expanding. Empty when nothing is grouped.
+    /// The speakers the volume slider controls, as a one-line summary with the
+    /// primary first (e.g. "Köket, Matbord-ute"), shown under the collapsed slider
+    /// so it's clear which speaker — or group — is being controlled. A single
+    /// ungrouped speaker shows just its own name; empty only when no speaker is
+    /// selected.
     private var groupSummary: String {
-        guard viewModel.isGroupActive else {
-            return ""
-        }
         let primaryName = viewModel.availableSpeakers
             .first { $0.entityId == viewModel.activeSpeakerID }?.friendlyName
         let followerNames = viewModel.groupedSpeakers
@@ -49,9 +48,10 @@ struct GroupVolumeView: View {
                     .accessibilityLabel(viewModel.isGroupActive ? "Gruppvolym" : "Volym")
             }
 
-            // While collapsed, name the grouped speakers under the slider — the same
-            // summary the old grouping card showed — so the group is legible at a
-            // glance. Aligned with the slider (past the chevron) and kept to one line.
+            // While collapsed, name the speaker(s) the slider controls under it — the
+            // same summary the old grouping card showed for a group, or just the
+            // single speaker's name on its own — so it's legible without expanding.
+            // Aligned with the slider (past the chevron) and kept to one line.
             if !isExpanded, groupSummary.isNotEmpty {
                 Text(groupSummary)
                     .font(.caption)
@@ -59,7 +59,7 @@ struct GroupVolumeView: View {
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.leading, 26)
-                    .accessibilityLabel("Grupperade högtalare: \(groupSummary)")
+                    .accessibilityLabel("\(viewModel.isGroupActive ? "Grupperade högtalare" : "Högtalare"): \(groupSummary)")
             }
 
             if isExpanded {

--- a/IntelliNestTests/MusicViewModelHardwareMirrorTests.swift
+++ b/IntelliNestTests/MusicViewModelHardwareMirrorTests.swift
@@ -119,6 +119,58 @@ extension MusicViewModelTests {
         XCTAssertEqual(displayed?.mediaContentID, trackURI)
     }
 
+    func testTwinRenderingMusicAssistantFlowDoesNotOverrideMAQueue() async {
+        // The Sonos is rendering Music Assistant's own universal flow stream, so it
+        // reports the generic "Music Assistant" title with no artist and a /flow/
+        // stream id. The MA queue entity holds the real track, so the now-playing
+        // card must keep the MA metadata rather than the placeholder twin.
+        stubAllSpeakers()
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "playing",
+                                      friendlyName: "Vardagsrummet",
+                                      title: trackName,
+                                      artist: trackArtist,
+                                      contentID: trackURI))
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: "Music Assistant",
+                 contentID: "aac://http://192.168.1.205:8097/flow/TpckjpsZ/RINCON_F0F6C1705FFD01400/abc.aac")
+        await viewModel.reload()
+
+        let displayed = viewModel.displayedSpeaker(.mediaPlayerLivingRoom)
+        XCTAssertEqual(displayed?.mediaTitle, trackName)
+        XCTAssertEqual(displayed?.mediaArtist, trackArtist)
+        XCTAssertEqual(displayed?.mediaContentID, trackURI)
+        XCTAssertTrue(displayed?.isPlaying == true)
+    }
+
+    func testSourcePlaylistKeptWhenTwinOnlyRendersMusicAssistantFlow() async {
+        // The flow twin's "Music Assistant" title never matches the MA track, but it
+        // isn't a real divergence — the Sonos is just playing the MA queue. The
+        // "Spelas från <spellista>" breadcrumb must survive, not be dropped.
+        stubAllSpeakers(playing: .mediaPlayerLivingRoom)
+        stubSpeaker(.mediaPlayerLivingRoom,
+                    data: speakerJSON(entityID: .mediaPlayerLivingRoom,
+                                      state: "playing",
+                                      friendlyName: "Vardagsrummet",
+                                      title: trackName,
+                                      artist: trackArtist))
+        stubTwin(for: .mediaPlayerLivingRoom,
+                 state: "playing",
+                 title: "Music Assistant",
+                 contentID: "aac://http://192.168.1.205:8097/flow/TpckjpsZ/RINCON_F0F6C1705FFD01400/abc.aac")
+        viewModel.activeSpeakerID = .mediaPlayerLivingRoom
+        let playlist = MusicSearchItem(uri: "spotify://playlist/9",
+                                       name: "Låtar som går och går",
+                                       mediaType: .playlist,
+                                       imageURL: nil,
+                                       artist: nil)
+        viewModel.nowPlayingSourcePlaylist = playlist
+        await viewModel.reload()
+        XCTAssertEqual(viewModel.nowPlayingSourcePlaylist?.uri, playlist.uri)
+    }
+
     func testAirPlayRoomHasNoTwinAndShowsMAState() async {
         // The spa is AirPlay — no hardware twin — so it always shows the MA entity.
         stubAllSpeakers()


### PR DESCRIPTION
Two fixes to the now-playing music card, both regressions/gaps from the recent grouping + mirroring work (#162–#164).

## 1. Card showed "Music Assistant" instead of the playing song
The #162 hardware-twin mirror assumed the native Sonos entity is always more truthful than the Music Assistant queue entity. For Sonos rooms playing MA's **universal flow stream** the opposite is true: the Sonos reports the generic `"Music Assistant"` title with no artist (its content id is a `…/flow/…` stream), while the MA queue entity holds the real track. The mirror clobbered the good MA title with the placeholder.

Confirmed against live HA state — `media_player.vardagsrummet` had the real track, `media_player.arc` showed `"Music Assistant"` with an `aac://…/flow/…` content id.

Fix: a twin that's only rendering the MA flow (`isRenderingMusicAssistantFlow`) no longer counts as a mirrorable source, so the MA queue entity stays authoritative. Native AirPlay / Spotify Connect / TV playback (real metadata, non-flow content id) still mirrors as before. This also stops `dropSourcePlaylistIfDiverged` from wrongly clearing the "Spelas från …" breadcrumb, since the flow twin's title never matched the MA track.

## 2. Volume subtitle vanished for a single speaker
`GroupVolumeView`'s collapsed subtitle (added in #164) was gated on `isGroupActive` (group size > 1), so an ungrouped speaker showed no subtitle. It now shows the active speaker's own name — consistent with the grouped case, which already lists the primary first.

## Tests
- `testTwinRenderingMusicAssistantFlowDoesNotOverrideMAQueue` — flow twin doesn't override the MA track.
- `testSourcePlaylistKeptWhenTwinOnlyRendersMusicAssistantFlow` — breadcrumb survives a flow twin.
- All existing music tests still pass; SwiftFormat + SwiftLint (`--strict`) clean.

## Screenshots
Single-speaker subtitle ("Vardagsrummet") and grouped subtitle ("Köket, Lekrummet, Matbord-ute") verified via ImageRenderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved now-playing mirroring so playback details stay accurate when a speaker is only rendering a shared music flow.
  - Collapsed group volume display now shows the active speaker name when a group isn’t active, instead of appearing blank.
  - Accessibility text for the collapsed volume view now reflects whether playback is grouped or single-speaker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->