### PR TITLE
Showed Music Assistant favourites in Favoriter even before the Spotify follow syncs

### DIFF
--- a/IntelliNest/ViewModels/MusicViewModel+Favourites.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Favourites.swift
@@ -51,7 +51,11 @@ extension MusicViewModel {
         return id.isNotEmpty ? id : nil
     }
 
-    private func normalizedName(_ name: String) -> String {
+    /// Lowercased, trimmed playlist name used to match across sources: MA
+    /// favourites are `library://` items while the Spotify listing is `spotify://`,
+    /// so they can only be reconciled by name. Internal so the playlist loader can
+    /// dedupe the favourites union against the Spotify library.
+    func normalizedName(_ name: String) -> String {
         name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -66,12 +66,22 @@ extension MusicViewModel {
             return
         }
         let personalAccountIDs = Set(personalAccounts.map(\.userID))
-        favoritePlaylists = playlists.filter { playlist in
+        let spotifyFavorites = playlists.filter { playlist in
             guard let ownerID = playlist.ownerID else {
                 return true
             }
             return !personalAccountIDs.contains(ownerID)
         }
+        // MA is the favourite store, so surface any starred playlist the Spotify
+        // library doesn't carry yet — MA's 2-way follow sync can lag a fresh star,
+        // and without this the playlist shows only in recently-played until the
+        // follow propagates and the next `/me/playlists` fetch picks it up. Matched
+        // by name since MA favourites are `library://` items while the listing is
+        // `spotify://`; deduping against the whole library (not just the favourites)
+        // keeps a personal-account favourite in its own section, not Favoriter.
+        let spotifyLibraryNames = Set(playlists.map { normalizedName($0.name) })
+        let starredOnlyInMA = maFavorites.filter { !spotifyLibraryNames.contains(normalizedName($0.name)) }
+        favoritePlaylists = spotifyFavorites + starredOnlyInMA
         // Show the viewer's own section first; the rest keep configured order.
         // Every section is titled by its owner's name (e.g. "Tobias spellistor").
         let viewer = currentUser()

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -58,8 +58,10 @@ class MusicViewModel: ObservableObject, Reloadable {
     @Published var openedPlaylist: MusicSearchItem?
     @Published var playlistTracks: [MusicPlaylistTrack] = []
     @Published var isLoadingPlaylist = false
-    /// The user's favourite Spotify playlists, shown for quick launch in place of
-    /// the speaker list. Loaded on the first reload.
+    /// The favourites shown for quick launch in place of the speaker list: the
+    /// huset Spotify library (minus the per-person sections) unioned with any
+    /// Music Assistant favourite not yet mirrored into that library, so a freshly
+    /// starred playlist appears here at once. Loaded on the first reload.
     @Published var favoritePlaylists: [MusicSearchItem] = []
     /// The most recently played playlists (Music Assistant `last_played` order),
     /// shown above the favourites. Refreshed whenever a playlist is launched.

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -309,6 +309,46 @@ extension MusicViewModelTests {
         XCTAssertEqual(stub.accountPlaylistsCallCount, 0)
     }
 
+    // MARK: - Favourites union with the Music Assistant favourite store
+
+    func testFavoritesUnionWithMusicAssistantFavouriteStore() async {
+        struct UnionCase {
+            let description: String
+            let spotifyLibrary: [MusicSearchItem]
+            let maFavorites: [MusicSearchItem]
+            let expectedFavorites: [String]
+            let expectedPersonal: [String]
+        }
+        // The huset Spotify library minus the per-person sections, unioned with any
+        // MA favourite the library doesn't carry yet (matched by name).
+        let cases = [
+            UnionCase(description: "MA favourite not yet followed on Spotify surfaces in Favoriter",
+                      spotifyLibrary: [playlistItem(uri: "spotify://playlist/h1", name: "Husets", ownerID: "huset")],
+                      maFavorites: [playlistItem(uri: "library://playlist/24", name: "Pippi Långstrump - Alla sånger")],
+                      expectedFavorites: ["Husets", "Pippi Långstrump - Alla sånger"],
+                      expectedPersonal: []),
+            UnionCase(description: "MA favourite already in the Spotify library is not duplicated",
+                      spotifyLibrary: [playlistItem(uri: "spotify://playlist/h1", name: "Sommarklassiker", ownerID: "huset")],
+                      maFavorites: [playlistItem(uri: "library://playlist/21", name: "Sommarklassiker")],
+                      expectedFavorites: ["Sommarklassiker"],
+                      expectedPersonal: []),
+            UnionCase(description: "MA favourite owned by a personal account stays in that section, not Favoriter",
+                      spotifyLibrary: [playlistItem(uri: "spotify://playlist/p1", name: "Vigsel Laross 2019", ownerID: "tobiasc91")],
+                      maFavorites: [playlistItem(uri: "library://playlist/16", name: "Vigsel Laross 2019")],
+                      expectedFavorites: [],
+                      expectedPersonal: ["Vigsel Laross 2019"])
+        ]
+        for unionCase in cases {
+            let stub = StubSpotifyPlaylistService(accountPlaylistItems: unionCase.spotifyLibrary)
+            let model = makeViewModel(spotify: stub)
+            model.maFavorites = unionCase.maFavorites
+            await model.refreshSpotifyPlaylists()
+            XCTAssertEqual(model.favoritePlaylists.map(\.name), unionCase.expectedFavorites, unionCase.description)
+            XCTAssertEqual(model.personalPlaylistSections.flatMap(\.playlists).map(\.name),
+                           unionCase.expectedPersonal, unionCase.description)
+        }
+    }
+
     func testToggleRefreshesListing() async {
         let item = MusicSearchItem(uri: "spotify://playlist/x", name: "Ny",
                                    mediaType: .playlist, imageURL: nil, artist: nil)

--- a/IntelliNestTests/MusicViewModelSpotifyTests.swift
+++ b/IntelliNestTests/MusicViewModelSpotifyTests.swift
@@ -356,7 +356,10 @@ extension MusicViewModelTests {
         let model = makeViewModel(spotify: stub, socket: StubMusicAssistantQueueSocket())
         // A successful favourite refreshes the listing (which 2-way sync may change).
         await model.toggleFavorite(spotifyPlaylist())
-        XCTAssertEqual(model.favoritePlaylists.map(\.name), ["Ny"])
+        // The refreshed Spotify listing ("Ny") plus the just-favourited playlist,
+        // which surfaces immediately via the MA favourite store even before the
+        // Spotify follow syncs into the library.
+        XCTAssertEqual(model.favoritePlaylists.map(\.name), ["Ny", "Lugnt & Skönt"])
         XCTAssertGreaterThanOrEqual(stub.accountPlaylistsCallCount, 1)
     }
 


### PR DESCRIPTION
## What

A playlist starred in the app (e.g. *Pippi Långstrump – Alla sånger*) showed up only in **Senast spelade**, never in **Favoriter**.

## Why

The star writes a **Music Assistant favourite** (`queueSocket.addFavorite`) — MA is the favourite store, since Spotify writes are 403-blocked for this dev-mode app. But the **Favoriter** section was built solely from the huset Spotify library (`/me/playlists`). A freshly-starred playlist only reaches that list *after* MA's 2-way sync follows it on Spotify **and** the app re-fetches — until then it appeared only in **Senast spelade** (MA-sourced). That propagation lag is the bug.

Confirmed against live MA: *Pippi* is `library://playlist/24`, `favorite=true`, backed by the Spotify provider.

## Change

`refreshSpotifyPlaylists()` now sets `favoritePlaylists` to the **union** of the Spotify library (minus the per-person sections) and any MA favourite the library doesn't carry yet, matched by normalised name. Deduping against the *whole* library keeps a personal-account favourite (e.g. *Vigsel Laross 2019*) in its own section instead of duplicating it into Favoriter. Anything starred now appears in Favoriter immediately, regardless of follow-sync lag.

## Tests

Added a parameterised test (`testFavoritesUnionWithMusicAssistantFavouriteStore`) covering: MA-only favourite surfaces; MA favourite already in the Spotify library isn't duplicated; MA favourite owned by a personal account stays in that section only.

## Verification note

The app and full test target compile cleanly and SwiftFormat/SwiftLint pass. I could **not** run the unit tests or capture screenshots locally — this machine's CoreSimulator service is wedged (every `simctl` call hangs, no iOS runtime resolves). Relying on CI to run the suite. The change is data-composition only; the Favoriter row UI is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Favorite playlists now include both Spotify favorites and Music Assistant favorites that aren’t already in the Spotify library, so newly starred playlists can appear sooner after a refresh.

* **Documentation**
  * Updated the in-app code comments to better describe how favorite playlists are combined and displayed.

* **Tests**
  * Added coverage for playlist merging, duplicate prevention, and preserving personal playlist sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->