### PR TITLE
Added time-synced lyrics and a seek bar to the now-playing card

### DIFF
--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -74,6 +74,15 @@
 		FE0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift */; };
 		EE0000050000000000000005 /* MusicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000050000000000000005 /* MusicView.swift */; };
 		EE0000060000000000000006 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000060000000000000006 /* NowPlayingView.swift */; };
+		EE0000000000000000000A01 /* LyricsTimeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A01 /* LyricsTimeline.swift */; };
+		EE0000000000000000000A02 /* LyricsApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A02 /* LyricsApiService.swift */; };
+		EE0000000000000000000A03 /* MusicViewModel+Lyrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A03 /* MusicViewModel+Lyrics.swift */; };
+		EE0000000000000000000A04 /* SeekBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A04 /* SeekBarView.swift */; };
+		EE0000000000000000000A05 /* LyricsViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A05 /* LyricsViews.swift */; };
+		FE0000000000000000000B01 /* LyricsTimelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000B01 /* LyricsTimelineTests.swift */; };
+		FE0000000000000000000B02 /* MediaPlayerEntityLyricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000B02 /* MediaPlayerEntityLyricsTests.swift */; };
+		FE0000000000000000000B03 /* LyricsApiServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000B03 /* LyricsApiServiceTests.swift */; };
+		FE0000000000000000000B04 /* MusicViewModelSeekTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000B04 /* MusicViewModelSeekTests.swift */; };
 		EE0000070000000000000007 /* AlbumArtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000070000000000000007 /* AlbumArtView.swift */; };
 		EE0000080000000000000008 /* SpeakerPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000080000000000000008 /* SpeakerPickerView.swift */; };
 		EE0000090000000000000009 /* GroupVolumeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000090000000000000009 /* GroupVolumeView.swift */; };
@@ -310,6 +319,15 @@
 		FD0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+SpotifyTracks.swift"; sourceTree = "<group>"; };
 		EF0000050000000000000005 /* MusicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicView.swift; sourceTree = "<group>"; };
 		EF0000060000000000000006 /* NowPlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingView.swift; sourceTree = "<group>"; };
+		EF0000000000000000000A01 /* LyricsTimeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsTimeline.swift; sourceTree = "<group>"; };
+		EF0000000000000000000A02 /* LyricsApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsApiService.swift; sourceTree = "<group>"; };
+		EF0000000000000000000A03 /* MusicViewModel+Lyrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Lyrics.swift"; sourceTree = "<group>"; };
+		EF0000000000000000000A04 /* SeekBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeekBarView.swift; sourceTree = "<group>"; };
+		EF0000000000000000000A05 /* LyricsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsViews.swift; sourceTree = "<group>"; };
+		FD0000000000000000000B01 /* LyricsTimelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsTimelineTests.swift; sourceTree = "<group>"; };
+		FD0000000000000000000B02 /* MediaPlayerEntityLyricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerEntityLyricsTests.swift; sourceTree = "<group>"; };
+		FD0000000000000000000B03 /* LyricsApiServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsApiServiceTests.swift; sourceTree = "<group>"; };
+		FD0000000000000000000B04 /* MusicViewModelSeekTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModelSeekTests.swift; sourceTree = "<group>"; };
 		EF0000070000000000000007 /* AlbumArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumArtView.swift; sourceTree = "<group>"; };
 		EF0000080000000000000008 /* SpeakerPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerPickerView.swift; sourceTree = "<group>"; };
 		EF0000090000000000000009 /* GroupVolumeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupVolumeView.swift; sourceTree = "<group>"; };
@@ -514,6 +532,7 @@
 				8D7AA547F46C2F6F2C2DC77A /* PurifierSpeed.swift */,
 				B126D511CCFBA5E7EF7F80F9 /* HomeLocationEntity.swift */,
 				EF0000010000000000000001 /* MediaPlayerEntity.swift */,
+				EF0000000000000000000A01 /* LyricsTimeline.swift */,
 				EF0000020000000000000002 /* MusicSearchResult.swift */,
 				FD0000000000000000000001 /* MusicQueue.swift */,
 			);
@@ -556,6 +575,7 @@
 				EF0000030000000000000003 /* RestAPIService+Music.swift */,
 				EF0000130000000000000020 /* SpotifyAuthService.swift */,
 				EF0000140000000000000021 /* SpotifyApiService.swift */,
+				EF0000000000000000000A02 /* LyricsApiService.swift */,
 				FD0000000000000000000002 /* MusicAssistantSocketService.swift */,
 				F6FDBE2C2A1A2F970081BC3D /* URLRequestBuilder.swift */,
 				F60345CB27A93BD700212D04 /* URLCreator.swift */,
@@ -608,6 +628,10 @@
 				FD0000000000000000000009 /* MusicViewModelSongFavoriteTests.swift */,
 				FD0000000000000000000008 /* MusicViewModelQueueTests.swift */,
 				FD0000000000000000FA0201 /* MusicViewModelPlaybackTests.swift */,
+				FD0000000000000000000B01 /* LyricsTimelineTests.swift */,
+				FD0000000000000000000B02 /* MediaPlayerEntityLyricsTests.swift */,
+				FD0000000000000000000B03 /* LyricsApiServiceTests.swift */,
+				FD0000000000000000000B04 /* MusicViewModelSeekTests.swift */,
 				FD0000000000000000FA0202 /* MusicViewModelPersonalSectionsTests.swift */,
 				FD0000000000000000FA0203 /* MusicViewModelGroupVolumeTests.swift */,
 				FD0000000000000000FA0299 /* MusicViewModelHardwareMirrorTests.swift */,
@@ -642,6 +666,7 @@
 				D89BCA06BE3A45F2A8E3DAE4 /* LynkViewModelHelpers.swift */,
 				EF0000040000000000000004 /* MusicViewModel.swift */,
 				EF00000400000000000000F1 /* MusicViewModel+Playback.swift */,
+				EF0000000000000000000A03 /* MusicViewModel+Lyrics.swift */,
 				EF0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift */,
 				FD0000000000000000000004 /* MusicViewModel+Queue.swift */,
 				FD000000000000000000FA01 /* MusicViewModel+Favourites.swift */,
@@ -732,6 +757,8 @@
 			children = (
 				EF0000050000000000000005 /* MusicView.swift */,
 				EF0000060000000000000006 /* NowPlayingView.swift */,
+				EF0000000000000000000A04 /* SeekBarView.swift */,
+				EF0000000000000000000A05 /* LyricsViews.swift */,
 				EF0000070000000000000007 /* AlbumArtView.swift */,
 				EF0000080000000000000008 /* SpeakerPickerView.swift */,
 				EF0000090000000000000009 /* GroupVolumeView.swift */,
@@ -1238,6 +1265,11 @@
 				FE0000000000000000000003 /* MusicViewModel+SpotifyTracks.swift in Sources */,
 				EE0000050000000000000005 /* MusicView.swift in Sources */,
 				EE0000060000000000000006 /* NowPlayingView.swift in Sources */,
+				EE0000000000000000000A01 /* LyricsTimeline.swift in Sources */,
+				EE0000000000000000000A02 /* LyricsApiService.swift in Sources */,
+				EE0000000000000000000A03 /* MusicViewModel+Lyrics.swift in Sources */,
+				EE0000000000000000000A04 /* SeekBarView.swift in Sources */,
+				EE0000000000000000000A05 /* LyricsViews.swift in Sources */,
 				EE0000070000000000000007 /* AlbumArtView.swift in Sources */,
 				EE0000080000000000000008 /* SpeakerPickerView.swift in Sources */,
 				EE0000090000000000000009 /* GroupVolumeView.swift in Sources */,
@@ -1279,6 +1311,10 @@
 				FE0000000000000000000009 /* MusicViewModelSongFavoriteTests.swift in Sources */,
 				FE0000000000000000000008 /* MusicViewModelQueueTests.swift in Sources */,
 				FE0000000000000000FA0201 /* MusicViewModelPlaybackTests.swift in Sources */,
+				FE0000000000000000000B01 /* LyricsTimelineTests.swift in Sources */,
+				FE0000000000000000000B02 /* MediaPlayerEntityLyricsTests.swift in Sources */,
+				FE0000000000000000000B03 /* LyricsApiServiceTests.swift in Sources */,
+				FE0000000000000000000B04 /* MusicViewModelSeekTests.swift in Sources */,
 				FE0000000000000000FA0202 /* MusicViewModelPersonalSectionsTests.swift in Sources */,
 				FE0000000000000000FA0203 /* MusicViewModelGroupVolumeTests.swift in Sources */,
 				FE0000000000000000FA0299 /* MusicViewModelHardwareMirrorTests.swift in Sources */,

--- a/IntelliNest/Model/LyricsTimeline.swift
+++ b/IntelliNest/Model/LyricsTimeline.swift
@@ -1,0 +1,104 @@
+//
+//  LyricsTimeline.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-28.
+//
+
+import Foundation
+
+/// One timed line of lyrics: the `time` (seconds from the start of the track) at
+/// which `text` should become the current line.
+struct LyricLine: Equatable {
+    let time: TimeInterval
+    let text: String
+}
+
+/// The outcome of a lyrics lookup. `synced` carries timestamped lines that follow
+/// playback; `plain` carries untimed text shown statically (Spotify does the same
+/// for tracks with no synced lyrics); `notFound` means neither source had a match.
+enum LyricsResult: Equatable {
+    case synced([LyricLine])
+    case plain(String)
+    case notFound
+}
+
+/// Pure helpers for parsing LRC lyrics and mapping playback time to a line. Kept
+/// free of any clock or networking so the timing logic is deterministic and fully
+/// unit-testable.
+enum LyricsTimeline {
+    /// Matches an LRC timestamp tag like `[00:12.34]`, `[1:02:345]`, or `[00:12]`.
+    /// Metadata tags (`[ar:…]`, `[ti:…]`, `[length:…]`) don't match because their
+    /// content isn't `digits:digits`, so they're ignored.
+    private static let timestampPattern = "\\[(\\d{1,2}):(\\d{2})(?:[.:](\\d{1,3}))?\\]"
+
+    /// Parses raw LRC text into time-sorted lines. A single source line may carry
+    /// several timestamps (`[00:10.0][00:20.0]chorus`), which yields one line per
+    /// timestamp. Blank/instrumental lines are kept so the gaps between sung lines
+    /// are preserved. Returns an empty array when nothing parses (e.g. the input
+    /// was actually plain, untimed text).
+    static func parseLRC(_ raw: String) -> [LyricLine] {
+        guard let regex = try? NSRegularExpression(pattern: timestampPattern) else {
+            return []
+        }
+        var lines: [LyricLine] = []
+        for sourceLine in raw.components(separatedBy: .newlines) {
+            let range = NSRange(sourceLine.startIndex..., in: sourceLine)
+            let matches = regex.matches(in: sourceLine, range: range)
+            guard matches.isNotEmpty else {
+                continue
+            }
+            let text = regex.stringByReplacingMatches(in: sourceLine, range: range, withTemplate: "")
+                .trimmingCharacters(in: .whitespaces)
+            for match in matches {
+                if let time = seconds(from: match, in: sourceLine) {
+                    lines.append(LyricLine(time: time, text: text))
+                }
+            }
+        }
+        return lines.sorted { $0.time < $1.time }
+    }
+
+    /// The index of the line that should be highlighted at `elapsed`: the last line
+    /// whose time is at or before `elapsed`. Nil before the first line begins or
+    /// when there are no lines.
+    static func currentLineIndex(in lines: [LyricLine], at elapsed: TimeInterval) -> Int? {
+        var current: Int?
+        for (index, line) in lines.enumerated() where line.time <= elapsed {
+            current = index
+        }
+        return current
+    }
+
+    /// The timing offset that makes `lineIndex` the current line at `elapsed`, i.e.
+    /// `currentLineIndex(at: elapsed + offset)` returns `lineIndex`. Used by the
+    /// scroll-to-realign correction: the user scrolls a line to "now" and this is
+    /// the nudge applied to every subsequent lookup. Zero for an out-of-range index.
+    static func offset(toAlign lineIndex: Int, in lines: [LyricLine], at elapsed: TimeInterval) -> TimeInterval {
+        guard lines.indices.contains(lineIndex) else {
+            return 0
+        }
+        return lines[lineIndex].time - elapsed
+    }
+
+    private static func seconds(from match: NSTextCheckingResult, in source: String) -> TimeInterval? {
+        guard let minutes = intGroup(match, 1, in: source),
+              let wholeSeconds = intGroup(match, 2, in: source) else {
+            return nil
+        }
+        var total = TimeInterval(minutes * 60 + wholeSeconds)
+        if match.numberOfRanges > 3,
+           let fractionRange = Range(match.range(at: 3), in: source) {
+            // "34" → 0.34, "340" → 0.340; "0." + digits handles either length.
+            total += Double("0." + source[fractionRange]) ?? 0
+        }
+        return total
+    }
+
+    private static func intGroup(_ match: NSTextCheckingResult, _ index: Int, in source: String) -> Int? {
+        guard let range = Range(match.range(at: index), in: source) else {
+            return nil
+        }
+        return Int(source[range])
+    }
+}

--- a/IntelliNest/Model/MediaPlayerEntity.swift
+++ b/IntelliNest/Model/MediaPlayerEntity.swift
@@ -151,7 +151,9 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
         guard isPlaying, let mediaPositionUpdatedAt else {
             return max(mediaPosition, 0)
         }
-        let elapsed = mediaPosition + now.timeIntervalSince(mediaPositionUpdatedAt)
+        // Never extrapolate backward: if the device clock lags Home Assistant the
+        // delta is negative, which would make the scrubber and lyrics jump back.
+        let elapsed = max(mediaPosition, mediaPosition + now.timeIntervalSince(mediaPositionUpdatedAt))
         if let mediaDuration {
             return min(max(elapsed, 0), mediaDuration)
         }

--- a/IntelliNest/Model/MediaPlayerEntity.swift
+++ b/IntelliNest/Model/MediaPlayerEntity.swift
@@ -31,6 +31,17 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
     var groupMembers: [EntityId]
     var shuffle: Bool
     var repeatMode: MediaRepeatMode
+    /// Playback position in seconds at the moment Home Assistant last reported it
+    /// (`media_position`). It is *not* live — it only advances in the payload when
+    /// HA re-reports it (on play/pause/seek/track change), so the live elapsed time
+    /// must be extrapolated from `mediaPositionUpdatedAt`. See `currentElapsed(asOf:)`.
+    var mediaPosition: Double?
+    /// Track length in seconds (`media_duration`). Nil for sources with no known
+    /// length (e.g. a live stream), which hides the scrubber.
+    var mediaDuration: Double?
+    /// When `mediaPosition` was sampled (`media_position_updated_at`), the anchor
+    /// for extrapolating the live position while playing.
+    var mediaPositionUpdatedAt: Date?
 
     var isActive: Bool {
         state == "playing"
@@ -96,6 +107,11 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
         mirrored.mediaArtist = twin.mediaArtist
         mirrored.mediaAlbumName = twin.mediaAlbumName
         mirrored.entityPicture = twin.entityPicture
+        // The twin drives the audio here, so its position is the real one; the MA
+        // queue entity's frozen position would mis-place the scrubber and lyrics.
+        mirrored.mediaPosition = twin.mediaPosition
+        mirrored.mediaDuration = twin.mediaDuration
+        mirrored.mediaPositionUpdatedAt = twin.mediaPositionUpdatedAt
         if !twin.isSameTrack(as: self) {
             mirrored.mediaContentID = nil
         }
@@ -122,6 +138,26 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
         state == "unavailable"
     }
 
+    /// The live playback position in seconds as of `now`. While playing, the
+    /// last-reported `mediaPosition` is extrapolated forward from its sample time
+    /// (`mediaPositionUpdatedAt`) and clamped to the track length; while paused (or
+    /// with no sample time) the reported position is returned as-is. Nil when the
+    /// source reports no position at all. `now` is passed in so the computation is
+    /// deterministic and testable.
+    func currentElapsed(asOf now: Date) -> TimeInterval? {
+        guard let mediaPosition else {
+            return nil
+        }
+        guard isPlaying, let mediaPositionUpdatedAt else {
+            return max(mediaPosition, 0)
+        }
+        let elapsed = mediaPosition + now.timeIntervalSince(mediaPositionUpdatedAt)
+        if let mediaDuration {
+            return min(max(elapsed, 0), mediaDuration)
+        }
+        return max(elapsed, 0)
+    }
+
     enum CodingKeys: String, CodingKey {
         case entityId = "entity_id"
         case state
@@ -139,6 +175,9 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
         case groupMembers = "group_members"
         case shuffle
         case repeatMode = "repeat"
+        case mediaPosition = "media_position"
+        case mediaDuration = "media_duration"
+        case mediaPositionUpdatedAt = "media_position_updated_at"
     }
 
     init(entityId: EntityId, state: String = "Loading", friendlyName: String = "") {
@@ -168,6 +207,11 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
             groupMembers = memberStrings.compactMap { EntityId(rawValue: $0) }
             shuffle = try attributes.decodeIfPresent(Bool.self, forKey: .shuffle) ?? false
             repeatMode = try attributes.decodeIfPresent(MediaRepeatMode.self, forKey: .repeatMode) ?? .off
+            mediaPosition = try attributes.decodeIfPresent(Double.self, forKey: .mediaPosition)
+            mediaDuration = try attributes.decodeIfPresent(Double.self, forKey: .mediaDuration)
+            if let updatedAtString = try attributes.decodeIfPresent(String.self, forKey: .mediaPositionUpdatedAt) {
+                mediaPositionUpdatedAt = Entity.utcDateFormatter.date(from: updatedAtString)
+            }
         } else {
             friendlyName = ""
             volumeLevel = 0
@@ -193,6 +237,9 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
             lhs.entityPicture == rhs.entityPicture &&
             lhs.groupMembers == rhs.groupMembers &&
             lhs.shuffle == rhs.shuffle &&
-            lhs.repeatMode == rhs.repeatMode
+            lhs.repeatMode == rhs.repeatMode &&
+            lhs.mediaPosition == rhs.mediaPosition &&
+            lhs.mediaDuration == rhs.mediaDuration &&
+            lhs.mediaPositionUpdatedAt == rhs.mediaPositionUpdatedAt
     }
 }

--- a/IntelliNest/Navigation/Navigator.swift
+++ b/IntelliNest/Navigation/Navigator.swift
@@ -104,7 +104,8 @@ class Navigator: ObservableObject {
                                                  self?.setErrorBannerText(title: title, message: message)
                                              },
                                              spotify: spotifyApiService,
-                                             queueSocket: MusicAssistantSocketService())
+                                             queueSocket: MusicAssistantSocketService(),
+                                             lyricsService: LyricsApiService())
 
     init() {
         WidgetCenter.shared.reloadAllTimelines()

--- a/IntelliNest/Services/LyricsApiService.swift
+++ b/IntelliNest/Services/LyricsApiService.swift
@@ -143,7 +143,9 @@ final class LyricsApiService: LyricsService {
             }
             return try JSONDecoder().decode(Response.self, from: data)
         } catch {
-            Log.error("Lyrics fetch failed for \(url.absoluteString): \(error)")
+            // Log only the host, never the full URL — it carries the song/artist, and
+            // app logs are forwarded to Home Assistant's system log.
+            Log.error("Lyrics fetch failed for \(url.host ?? "lyrics provider"): \(error)")
             return nil
         }
     }

--- a/IntelliNest/Services/LyricsApiService.swift
+++ b/IntelliNest/Services/LyricsApiService.swift
@@ -1,0 +1,175 @@
+//
+//  LyricsApiService.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-28.
+//
+
+import Foundation
+
+/// Fetches lyrics for the now-playing track. Hidden behind a protocol so
+/// `MusicViewModel` can be tested with a stub and previews need no network.
+@MainActor
+protocol LyricsService {
+    /// Looks up lyrics for a track. Prefers time-synced lyrics; falls back to plain
+    /// text, then `.notFound`. Never throws — every failure degrades to `.notFound`.
+    func fetchLyrics(title: String, artist: String, album: String?, durationSeconds: Double?) async -> LyricsResult
+}
+
+/// A no-op lyrics service used by previews and tests so the music UI works without
+/// reaching the network.
+@MainActor
+final class DisabledLyricsService: LyricsService {
+    func fetchLyrics(title: String, artist: String, album: String?, durationSeconds: Double?) async -> LyricsResult {
+        .notFound
+    }
+}
+
+/// Looks up lyrics from LRCLIB (synced, primary) with lyrics.ovh (plain, backup).
+/// Both are free, key-less, on-demand lookups suited to a personal app; LRCLIB asks
+/// callers to send a descriptive `User-Agent`, which this does. All failures are
+/// swallowed into `.notFound` so a missing or unreachable source never disrupts
+/// playback.
+@MainActor
+final class LyricsApiService: LyricsService {
+    private let session: URLSession
+    private let userAgent: String
+
+    private let lrclibBaseURL = "https://lrclib.net/api"
+    private let lyricsOvhBaseURL = "https://api.lyrics.ovh/v1"
+
+    init(session: URLSession = .shared, userAgent: String = LyricsApiService.defaultUserAgent) {
+        self.session = session
+        self.userAgent = userAgent
+    }
+
+    /// `IntelliNest/<app version> (+repo url)`, the descriptive agent LRCLIB requests.
+    /// `nonisolated` so it can be used as a default argument (evaluated outside the
+    /// main actor).
+    nonisolated static var defaultUserAgent: String {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
+        return "IntelliNest/\(version) (+https://github.com/tobiaslaross/IntelliNest)"
+    }
+
+    func fetchLyrics(title: String, artist: String, album: String?, durationSeconds: Double?) async -> LyricsResult {
+        guard title.isNotEmpty, artist.isNotEmpty else {
+            return .notFound
+        }
+        let primary = await fetchFromLRCLIB(title: title, artist: artist, album: album, durationSeconds: durationSeconds)
+        if primary != .notFound {
+            return primary
+        }
+        if let plain = await fetchFromLyricsOvh(title: title, artist: artist) {
+            return .plain(plain)
+        }
+        return .notFound
+    }
+
+    // MARK: - LRCLIB (primary, synced)
+
+    private func fetchFromLRCLIB(title: String, artist: String, album: String?, durationSeconds: Double?) async -> LyricsResult {
+        var components = URLComponents(string: "\(lrclibBaseURL)/get")
+        var queryItems = [
+            URLQueryItem(name: "artist_name", value: artist),
+            URLQueryItem(name: "track_name", value: title)
+        ]
+        if let album, album.isNotEmpty {
+            queryItems.append(URLQueryItem(name: "album_name", value: album))
+        }
+        if let durationSeconds {
+            queryItems.append(URLQueryItem(name: "duration", value: String(Int(durationSeconds.rounded()))))
+        }
+        components?.queryItems = queryItems
+
+        if let url = components?.url, let record = await getJSON(url, as: LRCLIBRecord.self) {
+            let result = record.lyricsResult
+            if result != .notFound {
+                return result
+            }
+        }
+        return await searchLRCLIB(title: title, artist: artist, durationSeconds: durationSeconds)
+    }
+
+    /// Falls back to LRCLIB's fuzzy search when the exact `get` misses, then picks
+    /// the candidate closest to the known track length (preferring synced ones).
+    private func searchLRCLIB(title: String, artist: String, durationSeconds: Double?) async -> LyricsResult {
+        var components = URLComponents(string: "\(lrclibBaseURL)/search")
+        components?.queryItems = [URLQueryItem(name: "q", value: "\(title) \(artist)")]
+        guard let url = components?.url,
+              let records = await getJSON(url, as: [LRCLIBRecord].self),
+              records.isNotEmpty else {
+            return .notFound
+        }
+        let synced = records.filter { $0.syncedLyrics?.isNotEmpty == true }
+        let pool = synced.isNotEmpty ? synced : records
+        let best: LRCLIBRecord = if let durationSeconds {
+            pool.min {
+                abs(($0.duration ?? 0) - durationSeconds) < abs(($1.duration ?? 0) - durationSeconds)
+            } ?? pool[0]
+        } else {
+            pool[0]
+        }
+        return best.lyricsResult
+    }
+
+    // MARK: - lyrics.ovh (backup, plain)
+
+    private func fetchFromLyricsOvh(title: String, artist: String) async -> String? {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove("/")
+        guard let escapedArtist = artist.addingPercentEncoding(withAllowedCharacters: allowed),
+              let escapedTitle = title.addingPercentEncoding(withAllowedCharacters: allowed),
+              let url = URL(string: "\(lyricsOvhBaseURL)/\(escapedArtist)/\(escapedTitle)") else {
+            return nil
+        }
+        guard let record = await getJSON(url, as: LyricsOvhRecord.self),
+              let lyrics = record.lyrics,
+              lyrics.isNotEmpty else {
+            return nil
+        }
+        return lyrics
+    }
+
+    // MARK: - Networking
+
+    private func getJSON<Response: Decodable>(_ url: URL, as type: Response.Type) async -> Response? {
+        var request = URLRequest(url: url)
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200 ..< 300).contains(httpResponse.statusCode) else {
+                return nil
+            }
+            return try JSONDecoder().decode(Response.self, from: data)
+        } catch {
+            Log.error("Lyrics fetch failed for \(url.absoluteString): \(error)")
+            return nil
+        }
+    }
+}
+
+/// One LRCLIB record (from `get` or an item of `search`). Carries both the synced
+/// and plain forms; `lyricsResult` prefers synced when it actually parses.
+private struct LRCLIBRecord: Decodable {
+    let duration: Double?
+    let plainLyrics: String?
+    let syncedLyrics: String?
+
+    var lyricsResult: LyricsResult {
+        if let syncedLyrics, syncedLyrics.isNotEmpty {
+            let lines = LyricsTimeline.parseLRC(syncedLyrics)
+            if lines.isNotEmpty {
+                return .synced(lines)
+            }
+        }
+        if let plainLyrics, plainLyrics.isNotEmpty {
+            return .plain(plainLyrics)
+        }
+        return .notFound
+    }
+}
+
+private struct LyricsOvhRecord: Decodable {
+    let lyrics: String?
+}

--- a/IntelliNest/Services/RestAPIService+Music.swift
+++ b/IntelliNest/Services/RestAPIService+Music.swift
@@ -165,6 +165,19 @@ extension RestAPIService {
                reloadTimes: reloadTimes)
     }
 
+    /// Seeks the player to `positionSeconds` from the start of the current track
+    /// via `media_player.media_seek`. The repeated reload picks up the new
+    /// `media_position`/`media_position_updated_at` so the scrubber and lyrics
+    /// settle on the real position after the optimistic jump.
+    func seek(entityID: EntityId, positionSeconds: Double, reloadTimes: Int = 2) {
+        update(entityID: entityID,
+               domain: .mediaPlayer,
+               action: .mediaSeek,
+               dataKey: .seekPosition,
+               dataValue: positionSeconds,
+               reloadTimes: reloadTimes)
+    }
+
     func setShuffle(entityID: EntityId, shuffle: Bool, reloadTimes: Int = 2) {
         Task {
             var json = [JSONKey: Any]()

--- a/IntelliNest/Utils/Constants/Actions.swift
+++ b/IntelliNest/Utils/Constants/Actions.swift
@@ -48,6 +48,7 @@ enum Action: String, Codable {
     case mediaPause = "media_pause"
     case mediaNextTrack = "media_next_track"
     case mediaPreviousTrack = "media_previous_track"
+    case mediaSeek = "media_seek"
     case volumeSet = "volume_set"
     case shuffleSet = "shuffle_set"
     case repeatSet = "repeat_set"

--- a/IntelliNest/Utils/Constants/JSONKey.swift
+++ b/IntelliNest/Utils/Constants/JSONKey.swift
@@ -58,6 +58,7 @@ enum JSONKey: String, Equatable, Codable, Hashable {
     case mediaContentType = "media_content_type"
     case enqueue
     case volumeLevel = "volume_level"
+    case seekPosition = "seek_position"
     case shuffle
     case repeatMode = "repeat"
     case groupMembers = "group_members"

--- a/IntelliNest/ViewModels/MusicViewModel+Lyrics.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Lyrics.swift
@@ -42,23 +42,36 @@ extension MusicViewModel {
             resetLyrics()
             return
         }
-        guard key != lyricsTrackKey else {
+        // Skip when this song's lyrics are already applied, or a fetch for it is
+        // already in flight. The cached key is latched only on success below, so a
+        // failed lookup can still be retried.
+        guard key != lyricsTrackKey, key != inFlightLyricsKey else {
             return
         }
-        lyricsTrackKey = key
-        lyricsOffset = 0
+        inFlightLyricsKey = key
         isLoadingLyrics = true
         let result = await lyricsService.fetchLyrics(title: speaker.mediaTitle ?? "",
                                                      artist: speaker.mediaArtist ?? "",
                                                      album: speaker.mediaAlbumName,
                                                      durationSeconds: speaker.mediaDuration)
-        // The track may have changed while the fetch was in flight; only apply the
-        // result if it still matches what's playing.
+        // The track may have changed while the fetch was in flight; drop a stale
+        // result so it can't clobber the new song's lyrics.
         guard currentLyricsTrackKey == key else {
+            if inFlightLyricsKey == key {
+                inFlightLyricsKey = nil
+                isLoadingLyrics = false
+            }
             return
         }
         lyrics = result
+        lyricsOffset = 0
         isLoadingLyrics = false
+        inFlightLyricsKey = nil
+        // Latch only on a real hit; `.notFound` collapses transient failures and
+        // true misses, so leaving the key unset lets a later trigger retry.
+        if result != .notFound {
+            lyricsTrackKey = key
+        }
     }
 
     /// Re-aligns synced lyrics so `lineIndex` is the current line at `elapsed`, by
@@ -74,6 +87,7 @@ extension MusicViewModel {
     private func resetLyrics() {
         lyrics = .notFound
         lyricsTrackKey = nil
+        inFlightLyricsKey = nil
         lyricsOffset = 0
         isLoadingLyrics = false
     }

--- a/IntelliNest/ViewModels/MusicViewModel+Lyrics.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Lyrics.swift
@@ -1,0 +1,80 @@
+//
+//  MusicViewModel+Lyrics.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-28.
+//
+
+import Foundation
+
+/// Lyrics loading and the manual scroll-to-realign correction, split out of
+/// `MusicViewModel` to keep that type focused on speaker and playback state.
+extension MusicViewModel {
+    /// A stable key for the displayed track, used to detect song changes so lyrics
+    /// only refetch when needed. Nil when nothing with a title is playing. Reads the
+    /// mirrored `displayedActiveSpeaker` so it matches what the card shows.
+    var currentLyricsTrackKey: String? {
+        guard let speaker = displayedActiveSpeaker,
+              let title = speaker.mediaTitle, title.isNotEmpty else {
+            return nil
+        }
+        // Unit separator joins the two fields so a title can't collide with an artist.
+        return "\(title)\u{1F}\(speaker.mediaArtist ?? "")"
+    }
+
+    /// Toggles the inline lyrics peek, loading lyrics on first expand.
+    func toggleLyricsExpanded() {
+        isLyricsExpanded.toggle()
+        if isLyricsExpanded {
+            Task { await refreshLyricsForCurrentTrack() }
+        }
+    }
+
+    /// Fetches lyrics for the current track when the song has changed since the last
+    /// load. Resets the manual realign offset on a change and shows a loading flag so
+    /// the UI doesn't flash "not found". No-op when the same track is already loaded
+    /// or when the lyrics panel isn't visible (nothing is shown, so nothing to load).
+    func refreshLyricsForCurrentTrack() async {
+        guard isLyricsExpanded || isShowingFullLyrics else {
+            return
+        }
+        guard let key = currentLyricsTrackKey, let speaker = displayedActiveSpeaker else {
+            resetLyrics()
+            return
+        }
+        guard key != lyricsTrackKey else {
+            return
+        }
+        lyricsTrackKey = key
+        lyricsOffset = 0
+        isLoadingLyrics = true
+        let result = await lyricsService.fetchLyrics(title: speaker.mediaTitle ?? "",
+                                                     artist: speaker.mediaArtist ?? "",
+                                                     album: speaker.mediaAlbumName,
+                                                     durationSeconds: speaker.mediaDuration)
+        // The track may have changed while the fetch was in flight; only apply the
+        // result if it still matches what's playing.
+        guard currentLyricsTrackKey == key else {
+            return
+        }
+        lyrics = result
+        isLoadingLyrics = false
+    }
+
+    /// Re-aligns synced lyrics so `lineIndex` is the current line at `elapsed`, by
+    /// nudging the timing offset. Used by the scroll-to-realign gesture; a no-op for
+    /// plain or missing lyrics, where there's no timeline to shift.
+    func applyRealign(toLineIndex lineIndex: Int, at elapsed: TimeInterval) {
+        guard case let .synced(lines) = lyrics else {
+            return
+        }
+        lyricsOffset = LyricsTimeline.offset(toAlign: lineIndex, in: lines, at: elapsed)
+    }
+
+    private func resetLyrics() {
+        lyrics = .notFound
+        lyricsTrackKey = nil
+        lyricsOffset = 0
+        isLoadingLyrics = false
+    }
+}

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -319,13 +319,22 @@ extension MusicViewModel {
     /// and routes the command to the group leader; the follow-up reload reconciles
     /// with the real position.
     func seek(to seconds: Double) {
-        guard let activeSpeakerID, let targetID = playbackTargetID else {
+        guard let activeSpeakerID else {
             return
         }
         let clamped = max(seconds, 0)
         speakers[activeSpeakerID]?.mediaPosition = clamped
         speakers[activeSpeakerID]?.mediaPositionUpdatedAt = Date()
-        restAPIService.seek(entityID: targetID, positionSeconds: clamped)
+        Task {
+            // Group membership can change between reloads; refresh before resolving
+            // the leader so the seek isn't routed to a stale leader (or a follower
+            // that rejects it), matching `startPlayback`.
+            await refreshActiveSpeaker(activeSpeakerID)
+            guard let targetID = playbackTargetID else {
+                return
+            }
+            restAPIService.seek(entityID: targetID, positionSeconds: clamped)
+        }
     }
 
     func setVolume(_ volume: Double) {

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -314,6 +314,20 @@ extension MusicViewModel {
         restAPIService.mediaTransport(entityID: targetID, action: .mediaPreviousTrack)
     }
 
+    /// Seeks the current track to `seconds`. Optimistically anchors the active
+    /// speaker's position to the new spot (so the scrubber and lyrics jump at once)
+    /// and routes the command to the group leader; the follow-up reload reconciles
+    /// with the real position.
+    func seek(to seconds: Double) {
+        guard let activeSpeakerID, let targetID = playbackTargetID else {
+            return
+        }
+        let clamped = max(seconds, 0)
+        speakers[activeSpeakerID]?.mediaPosition = clamped
+        speakers[activeSpeakerID]?.mediaPositionUpdatedAt = Date()
+        restAPIService.seek(entityID: targetID, positionSeconds: clamped)
+    }
+
     func setVolume(_ volume: Double) {
         guard let activeSpeakerID else {
             return

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -132,9 +132,15 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// scroll a line to "now" and correct drifting LRC timestamps. Reset to 0 on
     /// each track change (offset-per-track).
     @Published var lyricsOffset: TimeInterval = 0
-    /// The track (title+artist) the loaded `lyrics` belong to, so a refresh only
-    /// refetches when the song actually changes. Set by `MusicViewModel+Lyrics`.
+    /// The track (title+artist) whose lyrics are currently applied, so a refresh
+    /// only refetches when the song actually changes. Latched **only on a
+    /// successful** load, so a transient failure doesn't permanently suppress
+    /// retries. Set by `MusicViewModel+Lyrics`.
     var lyricsTrackKey: String?
+    /// The track key of an in-flight lyrics fetch, used to dedupe concurrent
+    /// requests for the same song without latching the cached key. Set by
+    /// `MusicViewModel+Lyrics`.
+    var inFlightLyricsKey: String?
 
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -119,6 +119,22 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// and the refreshed membership. Mutated by the grouping calls in
     /// `MusicViewModel+Grouping`.
     @Published var pendingGroupingSpeakers: Set<EntityId> = []
+    /// Drives the inline lyrics peek inside the now-playing card.
+    @Published var isLyricsExpanded = false
+    /// Drives the full-screen lyrics sheet opened from the peek.
+    @Published var isShowingFullLyrics = false
+    /// The lyrics loaded for the current track (synced, plain, or not found).
+    @Published var lyrics: LyricsResult = .notFound
+    /// Whether a lyrics fetch is in flight, so the UI shows a spinner instead of
+    /// flashing "not found" while a new track's lyrics load.
+    @Published var isLoadingLyrics = false
+    /// A manual timing nudge added to every synced-lyrics lookup so the user can
+    /// scroll a line to "now" and correct drifting LRC timestamps. Reset to 0 on
+    /// each track change (offset-per-track).
+    @Published var lyricsOffset: TimeInterval = 0
+    /// The track (title+artist) the loaded `lyrics` belong to, so a refresh only
+    /// refetches when the song actually changes. Set by `MusicViewModel+Lyrics`.
+    var lyricsTrackKey: String?
 
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false
@@ -146,6 +162,10 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// Home Assistant exposes no REST service for). Defaults to a disabled no-op
     /// so previews and tests need no socket.
     let queueSocket: MusicAssistantQueueSocket
+    /// Fetches lyrics for the now-playing track. Defaults to a disabled no-op so
+    /// previews and tests reach no network; the real LRCLIB/lyrics.ovh service is
+    /// injected by the `Navigator`.
+    let lyricsService: LyricsService
     /// The personal accounts whose public playlists are surfaced as their own
     /// sections. Injectable so tests can exercise multiple-account ordering and the
     /// hide-when-empty rule without depending on the baked-in list.
@@ -187,6 +207,7 @@ class MusicViewModel: ObservableObject, Reloadable {
          setErrorBannerText: @escaping StringStringClosure = { _, _ in },
          spotify: SpotifyPlaylistService = DisabledSpotifyPlaylistService(),
          queueSocket: MusicAssistantQueueSocket = DisabledMusicAssistantQueueSocket(),
+         lyricsService: LyricsService = DisabledLyricsService(),
          personalAccounts: [SpotifyPersonalAccount] = SpotifyPersonalAccount.configured,
          currentUser: @escaping @MainActor () -> User = { UserManager.currentUser },
          loadLastSpeaker: @escaping @MainActor () -> EntityId? = {
@@ -199,6 +220,7 @@ class MusicViewModel: ObservableObject, Reloadable {
         self.setErrorBannerText = setErrorBannerText
         self.spotify = spotify
         self.queueSocket = queueSocket
+        self.lyricsService = lyricsService
         self.personalAccounts = personalAccounts
         self.currentUser = currentUser
         self.loadLastSpeaker = loadLastSpeaker

--- a/IntelliNest/Views/Music/LyricsViews.swift
+++ b/IntelliNest/Views/Music/LyricsViews.swift
@@ -1,0 +1,224 @@
+//
+//  LyricsViews.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-28.
+//
+
+import SwiftUI
+
+/// One line in the inline peek, identified by its index so SwiftUI can animate the
+/// window sliding as the current line advances.
+private struct PeekEntry: Identifiable {
+    let id: Int
+    let text: String
+    let isCurrent: Bool
+}
+
+/// The compact lyrics peek shown inside the now-playing card when expanded: a few
+/// lines that auto-advance with playback, the current line highlighted. Tapping it
+/// opens the full-screen lyrics. Falls back to a static head for plain lyrics and a
+/// message (or spinner) when none are found.
+struct LyricsStripView: View {
+    let speaker: MediaPlayerEntity
+    @ObservedObject var viewModel: MusicViewModel
+
+    /// How many lines the peek shows at once.
+    private let windowSize = 3
+    private let stripHeight: CGFloat = 66
+
+    var body: some View {
+        Button {
+            viewModel.isShowingFullLyrics = true
+        } label: {
+            content
+                .frame(maxWidth: .infinity)
+                .frame(height: stripHeight)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Öppna sångtext i helskärm")
+    }
+
+    @ViewBuilder private var content: some View {
+        switch viewModel.lyrics {
+        case let .synced(lines):
+            syncedPeek(lines)
+        case let .plain(text):
+            plainPeek(text)
+        case .notFound:
+            if viewModel.isLoadingLyrics {
+                ProgressView().tint(.white)
+            } else {
+                Text("Ingen sångtext hittades")
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+        }
+    }
+
+    private func syncedPeek(_ lines: [LyricLine]) -> some View {
+        TimelineView(.periodic(from: .now, by: 0.5)) { context in
+            let elapsed = (speaker.currentElapsed(asOf: context.date) ?? 0) + viewModel.lyricsOffset
+            let index = LyricsTimeline.currentLineIndex(in: lines, at: elapsed)
+            VStack(spacing: 4) {
+                ForEach(peekEntries(lines: lines, current: index)) { entry in
+                    Text(entry.text)
+                        .font(entry.isCurrent ? .subheadline.weight(.semibold) : .caption)
+                        .foregroundStyle(entry.isCurrent ? .yellow : .white.opacity(0.5))
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .animation(.easeInOut(duration: 0.2), value: index)
+        }
+    }
+
+    private func plainPeek(_ text: String) -> some View {
+        let lines = text
+            .components(separatedBy: .newlines)
+            .filter { $0.trimmingCharacters(in: .whitespaces).isNotEmpty }
+            .prefix(windowSize)
+        return VStack(spacing: 4) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                Text(line)
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.6))
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// A window of up to `windowSize` lines centred on the current one (clamped at the
+    /// ends), each marked whether it's the current line. Blank LRC lines render as a
+    /// musical note so an instrumental gap isn't an empty row.
+    private func peekEntries(lines: [LyricLine], current: Int?) -> [PeekEntry] {
+        guard lines.isNotEmpty else {
+            return []
+        }
+        let center = min(max(current ?? 0, 0), lines.count - 1)
+        var start = max(center - 1, 0)
+        var end = min(start + windowSize - 1, lines.count - 1)
+        start = max(end - windowSize + 1, 0)
+        end = min(end, lines.count - 1)
+        return (start ... end).map { index in
+            let text = lines[index].text.isEmpty ? "♪" : lines[index].text
+            return PeekEntry(id: index, text: text, isCurrent: current == index)
+        }
+    }
+}
+
+/// The full-screen lyrics view. Synced lyrics auto-scroll to keep the current line
+/// near the top; dragging the lyrics re-aligns the timing (the line the user scrolls
+/// into focus becomes "now"), correcting drifting LRC timestamps without touching
+/// playback. Plain lyrics show as static scrollable text.
+struct LyricsFullView: View {
+    let speaker: MediaPlayerEntity
+    @ObservedObject var viewModel: MusicViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// The line currently scrolled into focus (the topmost line below the top
+    /// margin). Written programmatically to auto-follow playback and read back to
+    /// re-align when the user scrolls.
+    @State private var focusedLineID: Int?
+    @State private var currentIndex: Int?
+    @State private var isDragging = false
+
+    private let ticker = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        NavigationStack {
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .navigationTitle("Sångtext")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Stäng") { dismiss() }
+                            .foregroundStyle(.white)
+                    }
+                }
+                .backgroundModifier()
+                .foregroundStyle(.white)
+                .task { await viewModel.refreshLyricsForCurrentTrack() }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        switch viewModel.lyrics {
+        case let .synced(lines):
+            syncedView(lines)
+        case let .plain(text):
+            plainView(text)
+        case .notFound:
+            if viewModel.isLoadingLyrics {
+                ProgressView().tint(.white)
+            } else {
+                Text("Ingen sångtext hittades")
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+        }
+    }
+
+    private func syncedView(_ lines: [LyricLine]) -> some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 18) {
+                ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
+                    Text(line.text.isEmpty ? "♪" : line.text)
+                        .font(.title3)
+                        .fontWeight(index == currentIndex ? .bold : .regular)
+                        .foregroundStyle(index == currentIndex ? .yellow : .white.opacity(0.45))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .id(index)
+                }
+            }
+            .scrollTargetLayout()
+            .padding(.horizontal, 24)
+        }
+        // Keep the focused line below the top edge so it reads as the focal line, and
+        // leave room to scroll the last lines into focus.
+        .contentMargins(.vertical, 140, for: .scrollContent)
+        .scrollPosition(id: $focusedLineID)
+        .simultaneousGesture(
+            DragGesture()
+                .onChanged { _ in isDragging = true }
+                .onEnded { _ in
+                    if let focusedLineID {
+                        viewModel.applyRealign(toLineIndex: focusedLineID, at: speaker.currentElapsed(asOf: Date()) ?? 0)
+                    }
+                    isDragging = false
+                }
+        )
+        .onReceive(ticker) { _ in
+            advance(lines)
+        }
+        .onAppear { advance(lines) }
+    }
+
+    private func plainView(_ text: String) -> some View {
+        ScrollView {
+            Text(text)
+                .font(.title3)
+                .foregroundStyle(.white.opacity(0.8))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(24)
+        }
+    }
+
+    /// Recomputes the current line from playback time + the manual offset and, unless
+    /// the user is actively scrolling, scrolls it into focus.
+    private func advance(_ lines: [LyricLine]) {
+        let elapsed = (speaker.currentElapsed(asOf: Date()) ?? 0) + viewModel.lyricsOffset
+        let index = LyricsTimeline.currentLineIndex(in: lines, at: elapsed)
+        guard index != currentIndex else {
+            return
+        }
+        currentIndex = index
+        if !isDragging, let index {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                focusedLineID = index
+            }
+        }
+    }
+}

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -56,6 +56,11 @@ struct MusicView: View {
         .sheet(isPresented: $viewModel.isShowingQueue) {
             QueueView(viewModel: viewModel)
         }
+        .sheet(isPresented: $viewModel.isShowingFullLyrics) {
+            if let activeSpeaker = viewModel.displayedActiveSpeaker {
+                LyricsFullView(speaker: activeSpeaker, viewModel: viewModel)
+            }
+        }
         .sheet(item: $viewModel.browsingLibraryPlaylist) { playlist in
             NavigationStack {
                 MusicPlaylistView(viewModel: viewModel, playlist: playlist)

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -59,6 +59,10 @@ struct MusicView: View {
         .sheet(isPresented: $viewModel.isShowingFullLyrics) {
             if let activeSpeaker = viewModel.displayedActiveSpeaker {
                 LyricsFullView(speaker: activeSpeaker, viewModel: viewModel)
+            } else {
+                // The speaker dropped out while the sheet was open — don't strand an
+                // empty modal; dismiss it.
+                Color.clear.onAppear { viewModel.isShowingFullLyrics = false }
             }
         }
         .sheet(item: $viewModel.browsingLibraryPlaylist) { playlist in

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -20,19 +20,25 @@ struct NowPlayingView: View {
                     .font(.headline)
                     .foregroundStyle(.yellow)
                     .lineLimit(1)
-                Spacer()
-                Button {
-                    Task { await viewModel.openQueue() }
-                } label: {
-                    Image(systemName: "list.bullet")
+                Spacer(minLength: 4)
+                // Each action gets a full 44×44 hit target so the three controls are
+                // comfortably tappable and evenly spaced.
+                HStack(spacing: 4) {
+                    headerButton("quote.bubble",
+                                 label: "Visa sångtext",
+                                 isActive: viewModel.isLyricsExpanded) {
+                        viewModel.toggleLyricsExpanded()
+                    }
+                    headerButton("list.bullet", label: "Visa kö") {
+                        Task { await viewModel.openQueue() }
+                    }
+                    headerButton("hifispeaker.2.fill", label: "Byt högtalare") {
+                        viewModel.activeSpeakerID = nil
+                    }
                 }
-                .accessibilityLabel("Visa kö")
-                Button {
-                    viewModel.activeSpeakerID = nil
-                } label: {
-                    Image(systemName: "hifispeaker.2.fill")
-                }
-                .accessibilityLabel("Byt högtalare")
+                // Pull the row of icons to the card's edge so the 44pt hit targets
+                // don't add visible padding beyond the card's own inset.
+                .padding(.trailing, -10)
             }
 
             HStack(spacing: 12) {
@@ -44,7 +50,13 @@ struct NowPlayingView: View {
                 }
             }
 
+            SeekBarView(speaker: speaker, viewModel: viewModel)
+
             TransportControlsView(speaker: speaker, viewModel: viewModel)
+
+            if viewModel.isLyricsExpanded {
+                LyricsStripView(speaker: speaker, viewModel: viewModel)
+            }
 
             GroupVolumeView(viewModel: viewModel)
         }
@@ -59,6 +71,28 @@ struct NowPlayingView: View {
         .task(id: speaker.mediaContentID) {
             await viewModel.loadSavedSongStates(uris: [speaker.mediaContentID].compactMap { $0 })
         }
+        // Refetch lyrics when the track changes while the lyrics panel is open
+        // (a no-op otherwise).
+        .task(id: viewModel.currentLyricsTrackKey) {
+            await viewModel.refreshLyricsForCurrentTrack()
+        }
+    }
+
+    /// A header action rendered with a full 44×44 hit target (Apple's minimum), so
+    /// the three now-playing controls are easy to tap and evenly spaced. `isActive`
+    /// tints the icon yellow to show a toggled-on state (used by the lyrics toggle).
+    private func headerButton(_ systemName: String,
+                              label: String,
+                              isActive: Bool = false,
+                              action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.title3)
+                .foregroundStyle(isActive ? .yellow : .white)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel(label)
     }
 
     /// The album art and track metadata. Tapping it opens the playlist the track

--- a/IntelliNest/Views/Music/SeekBarView.swift
+++ b/IntelliNest/Views/Music/SeekBarView.swift
@@ -1,0 +1,116 @@
+//
+//  SeekBarView.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-28.
+//
+
+import SwiftUI
+
+/// Formats a playback time as `m:ss` (or `h:mm:ss` once past an hour). Kept as a
+/// pure, free-standing helper so the elapsed/remaining labels are unit-testable
+/// without a view. Negative inputs clamp to zero.
+enum PlaybackTimeFormat {
+    static func clock(_ seconds: TimeInterval) -> String {
+        let total = Int(max(seconds, 0).rounded(.down))
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let secs = total % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, secs)
+        }
+        return String(format: "%d:%02d", minutes, secs)
+    }
+}
+
+/// An Apple-Music-style scrubber for the now-playing card: a thin track with a
+/// draggable thumb, the elapsed time on the left and the remaining time (`-m:ss`)
+/// on the right. The thumb advances live from the speaker's extrapolated position
+/// while playing; during a drag the dragged position wins and the seek is sent
+/// only on release (no request spam mid-drag, matching `VolumeSliderView`).
+///
+/// Hidden entirely when the source reports no length (`mediaDuration` nil/0), e.g.
+/// a live stream, where seeking is meaningless.
+struct SeekBarView: View {
+    let speaker: MediaPlayerEntity
+    @ObservedObject var viewModel: MusicViewModel
+
+    /// The fraction (0...1) the user is dragging to, or nil when not dragging.
+    @State private var dragFraction: Double?
+
+    var body: some View {
+        if let duration = speaker.mediaDuration, duration > 0 {
+            TimelineView(.periodic(from: .now, by: 0.5)) { context in
+                let liveElapsed = speaker.currentElapsed(asOf: context.date) ?? 0
+                let elapsed = dragFraction.map { $0 * duration } ?? liveElapsed
+                let fraction = min(max(elapsed / duration, 0), 1)
+                content(duration: duration, elapsed: elapsed, fraction: fraction)
+            }
+        }
+    }
+
+    private func content(duration: Double, elapsed: Double, fraction: Double) -> some View {
+        VStack(spacing: 2) {
+            track(fraction: fraction, duration: duration)
+            HStack {
+                Text(PlaybackTimeFormat.clock(elapsed))
+                Spacer()
+                Text("-\(PlaybackTimeFormat.clock(duration - elapsed))")
+            }
+            .font(.caption2)
+            .monospacedDigit()
+            .foregroundStyle(.white.opacity(0.6))
+        }
+    }
+
+    private func track(fraction: Double, duration: Double) -> some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            let thumbSize: CGFloat = 12
+            // Keep the thumb fully inside the track at both ends.
+            let travel = max(width - thumbSize, 0)
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.white.opacity(0.25))
+                    .frame(height: 4)
+                Capsule()
+                    .fill(Color.white.opacity(0.9))
+                    .frame(width: max(width * fraction, 0), height: 4)
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: thumbSize, height: thumbSize)
+                    .offset(x: travel * fraction)
+            }
+            .frame(maxHeight: .infinity, alignment: .center)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        dragFraction = clampedFraction(value.location.x, width: width)
+                    }
+                    .onEnded { value in
+                        let target = clampedFraction(value.location.x, width: width) * duration
+                        viewModel.seek(to: target)
+                        dragFraction = nil
+                    }
+            )
+        }
+        .frame(height: 24)
+        .accessibilityElement()
+        .accessibilityLabel("Spelposition")
+        .accessibilityValue(PlaybackTimeFormat.clock(fraction * duration))
+        .accessibilityAdjustableAction { direction in
+            let step = 5.0
+            let current = fraction * duration
+            let next = direction == .increment ? current + step : current - step
+            viewModel.seek(to: min(max(next, 0), duration))
+        }
+    }
+
+    private func clampedFraction(_ locationX: CGFloat, width: CGFloat) -> Double {
+        guard width > 0 else {
+            return 0
+        }
+        return Double(min(max(locationX / width, 0), 1))
+    }
+}

--- a/IntelliNestTests/LyricsApiServiceTests.swift
+++ b/IntelliNestTests/LyricsApiServiceTests.swift
@@ -1,0 +1,121 @@
+@testable import IntelliNest
+import XCTest
+
+@MainActor
+final class LyricsApiServiceTests: XCTestCase {
+    private var service: LyricsApiService!
+    private let userAgent = "IntelliNestTest/1.0"
+    private let title = "Bohemian Rhapsody"
+    private let artist = "Queen"
+
+    override func setUp() {
+        URLProtocolStub.startInterceptingRequests()
+        service = LyricsApiService(session: URLProtocolStub.createStubbedURLSession(), userAgent: userAgent)
+    }
+
+    override func tearDown() {
+        URLProtocolStub.stopInterceptingRequests()
+        service = nil
+    }
+
+    // MARK: - URL builders (mirror the service exactly so stubs match)
+
+    private func lrclibGetURL(album: String? = nil, duration: Int? = nil) -> URL {
+        var components = URLComponents(string: "https://lrclib.net/api/get")!
+        var items = [
+            URLQueryItem(name: "artist_name", value: artist),
+            URLQueryItem(name: "track_name", value: title)
+        ]
+        if let album {
+            items.append(URLQueryItem(name: "album_name", value: album))
+        }
+        if let duration {
+            items.append(URLQueryItem(name: "duration", value: String(duration)))
+        }
+        components.queryItems = items
+        return components.url!
+    }
+
+    private func lrclibSearchURL() -> URL {
+        var components = URLComponents(string: "https://lrclib.net/api/search")!
+        components.queryItems = [URLQueryItem(name: "q", value: "\(title) \(artist)")]
+        return components.url!
+    }
+
+    private func lyricsOvhURL() -> URL {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove("/")
+        let escapedArtist = artist.addingPercentEncoding(withAllowedCharacters: allowed)!
+        let escapedTitle = title.addingPercentEncoding(withAllowedCharacters: allowed)!
+        return URL(string: "https://api.lyrics.ovh/v1/\(escapedArtist)/\(escapedTitle)")!
+    }
+
+    // MARK: - Stub helpers
+
+    private func stub(_ url: URL, json: String, statusCode: Int = 200) {
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: Data(json.utf8), response: response, error: nil)
+    }
+
+    // MARK: - Tests
+
+    func testReturnsSyncedLyricsFromLRCLIB() async {
+        stub(lrclibGetURL(duration: 233), json: """
+        {"duration":233,"plainLyrics":null,"syncedLyrics":"[00:01.00]Hello world"}
+        """)
+        let result = await service.fetchLyrics(title: title, artist: artist, album: nil, durationSeconds: 233)
+        XCTAssertEqual(result, .synced([LyricLine(time: 1.0, text: "Hello world")]))
+    }
+
+    func testFallsBackToPlainLyricsFromLRCLIB() async {
+        stub(lrclibGetURL(duration: 233), json: """
+        {"duration":233,"plainLyrics":"Just plain text","syncedLyrics":null}
+        """)
+        let result = await service.fetchLyrics(title: title, artist: artist, album: nil, durationSeconds: 233)
+        XCTAssertEqual(result, .plain("Just plain text"))
+    }
+
+    func testSearchPicksClosestDurationWhenGetMisses() async {
+        stub(lrclibGetURL(duration: 233), json: "{}", statusCode: 404)
+        stub(lrclibSearchURL(), json: """
+        [
+          {"duration":100,"plainLyrics":null,"syncedLyrics":"[00:02.00]Wrong"},
+          {"duration":230,"plainLyrics":null,"syncedLyrics":"[00:02.00]Right"}
+        ]
+        """)
+        let result = await service.fetchLyrics(title: title, artist: artist, album: nil, durationSeconds: 233)
+        XCTAssertEqual(result, .synced([LyricLine(time: 2.0, text: "Right")]))
+    }
+
+    func testFallsBackToLyricsOvhWhenLRCLIBEmpty() async {
+        stub(lrclibGetURL(duration: 233), json: "{}", statusCode: 404)
+        stub(lrclibSearchURL(), json: "[]")
+        stub(lyricsOvhURL(), json: #"{"lyrics":"Backup words"}"#)
+        let result = await service.fetchLyrics(title: title, artist: artist, album: nil, durationSeconds: 233)
+        XCTAssertEqual(result, .plain("Backup words"))
+    }
+
+    func testReturnsNotFoundWhenAllSourcesMiss() async {
+        stub(lrclibGetURL(duration: 233), json: "{}", statusCode: 404)
+        stub(lrclibSearchURL(), json: "[]")
+        stub(lyricsOvhURL(), json: #"{"error":"No lyrics found"}"#, statusCode: 404)
+        let result = await service.fetchLyrics(title: title, artist: artist, album: nil, durationSeconds: 233)
+        XCTAssertEqual(result, .notFound)
+    }
+
+    func testSendsDescriptiveUserAgentToLRCLIB() async {
+        let getURL = lrclibGetURL(duration: 233)
+        let expectation = XCTestExpectation(description: "User-Agent on LRCLIB request")
+        URLProtocolStub.observerRequests { request in
+            if request.url == getURL {
+                XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), self.userAgent)
+                expectation.fulfill()
+            }
+        }
+        stub(getURL, json: """
+        {"duration":233,"plainLyrics":null,"syncedLyrics":"[00:01.00]Hello world"}
+        """)
+        _ = await service.fetchLyrics(title: title, artist: artist, album: nil, durationSeconds: 233)
+        await fulfillment(of: [expectation], timeout: 2.0)
+    }
+}

--- a/IntelliNestTests/LyricsTimelineTests.swift
+++ b/IntelliNestTests/LyricsTimelineTests.swift
@@ -1,0 +1,68 @@
+@testable import IntelliNest
+import XCTest
+
+final class LyricsTimelineTests: XCTestCase {
+    private let lrc = """
+    [ar: Test Artist]
+    [ti: Test Song]
+    [00:01.00]First line
+    [00:03.50]Second line
+    [00:03.50]Repeated stamp
+    [01:00.00]Last line
+    """
+
+    func testParseLRCExtractsTimedLinesAndDropsMetadata() {
+        let lines = LyricsTimeline.parseLRC(lrc)
+        XCTAssertEqual(lines.count, 4)
+        XCTAssertEqual(lines[0], LyricLine(time: 1.0, text: "First line"))
+        XCTAssertEqual(lines[1].time, 3.5)
+        XCTAssertEqual(lines[3], LyricLine(time: 60.0, text: "Last line"))
+    }
+
+    func testParseLRCSupportsMultipleStampsOnOneLine() {
+        let lines = LyricsTimeline.parseLRC("[00:10.00][00:20.00]chorus")
+        XCTAssertEqual(lines, [
+            LyricLine(time: 10.0, text: "chorus"),
+            LyricLine(time: 20.0, text: "chorus")
+        ])
+    }
+
+    func testParseLRCReturnsEmptyForPlainText() {
+        XCTAssertTrue(LyricsTimeline.parseLRC("just\nplain\nlyrics").isEmpty)
+    }
+
+    func testCurrentLineIndexAcrossElapsedValues() {
+        let lines = LyricsTimeline.parseLRC(lrc)
+        let cases: [(elapsed: TimeInterval, expected: Int?)] = [
+            (0.0, nil), // before the first line
+            (1.0, 0), // exactly on the first line
+            (2.0, 0),
+            (3.5, 2), // last line at-or-before 3.5 (the repeated stamp wins)
+            (59.0, 2),
+            (120.0, 3) // past the last line
+        ]
+        for testCase in cases {
+            XCTAssertEqual(LyricsTimeline.currentLineIndex(in: lines, at: testCase.elapsed),
+                           testCase.expected,
+                           "elapsed \(testCase.elapsed)")
+        }
+    }
+
+    func testCurrentLineIndexEmptyLines() {
+        XCTAssertNil(LyricsTimeline.currentLineIndex(in: [], at: 5))
+    }
+
+    func testOffsetAlignsChosenLineToNow() {
+        let lines = LyricsTimeline.parseLRC(lrc)
+        let elapsed = 12.0
+        // Realign so line 3 ("Last line", at 60s) is current right now.
+        let offset = LyricsTimeline.offset(toAlign: 3, in: lines, at: elapsed)
+        XCTAssertEqual(offset, 48.0)
+        XCTAssertEqual(LyricsTimeline.currentLineIndex(in: lines, at: elapsed + offset), 3)
+    }
+
+    func testOffsetOutOfRangeIsZero() {
+        let lines = LyricsTimeline.parseLRC(lrc)
+        XCTAssertEqual(LyricsTimeline.offset(toAlign: 99, in: lines, at: 5), 0)
+    }
+}

--- a/IntelliNestTests/MediaPlayerEntityLyricsTests.swift
+++ b/IntelliNestTests/MediaPlayerEntityLyricsTests.swift
@@ -1,0 +1,58 @@
+@testable import IntelliNest
+import XCTest
+
+/// Covers the playback-position helpers added for the scrubber and synced lyrics:
+/// extrapolated elapsed time and hardware-twin position mirroring.
+final class MediaPlayerEntityLyricsTests: XCTestCase {
+    private let sampledAt = Date(timeIntervalSince1970: 995)
+    private let now = Date(timeIntervalSince1970: 1000) // 5s after the sample
+
+    private func makeSpeaker(state: String,
+                             position: Double?,
+                             duration: Double?,
+                             updatedAt: Date?) -> MediaPlayerEntity {
+        var speaker = MediaPlayerEntity(entityId: .mediaPlayerKitchen, state: state)
+        speaker.mediaPosition = position
+        speaker.mediaDuration = duration
+        speaker.mediaPositionUpdatedAt = updatedAt
+        return speaker
+    }
+
+    func testCurrentElapsedExtrapolatesWhilePlaying() {
+        let speaker = makeSpeaker(state: "playing", position: 10, duration: 200, updatedAt: sampledAt)
+        XCTAssertEqual(speaker.currentElapsed(asOf: now), 15)
+    }
+
+    func testCurrentElapsedClampsToDuration() {
+        let speaker = makeSpeaker(state: "playing", position: 198, duration: 200, updatedAt: sampledAt)
+        XCTAssertEqual(speaker.currentElapsed(asOf: now), 200)
+    }
+
+    func testCurrentElapsedFrozenWhilePaused() {
+        let speaker = makeSpeaker(state: "paused", position: 10, duration: 200, updatedAt: sampledAt)
+        XCTAssertEqual(speaker.currentElapsed(asOf: now), 10)
+    }
+
+    func testCurrentElapsedNilWithoutPosition() {
+        let speaker = makeSpeaker(state: "playing", position: nil, duration: 200, updatedAt: sampledAt)
+        XCTAssertNil(speaker.currentElapsed(asOf: now))
+    }
+
+    func testMirroringCopiesLiveTwinPosition() {
+        var queue = MediaPlayerEntity(entityId: .mediaPlayerLivingRoom, state: "idle")
+        queue.mediaPosition = 5
+        queue.mediaDuration = 100
+        queue.mediaPositionUpdatedAt = sampledAt
+
+        var twin = MediaPlayerEntity(entityId: .mediaPlayerLivingRoomSonos, state: "playing")
+        twin.mediaTitle = "Native Track"
+        twin.mediaPosition = 42
+        twin.mediaDuration = 250
+        twin.mediaPositionUpdatedAt = now
+
+        let mirrored = queue.mirroring(twin)
+        XCTAssertEqual(mirrored.mediaPosition, 42)
+        XCTAssertEqual(mirrored.mediaDuration, 250)
+        XCTAssertEqual(mirrored.mediaPositionUpdatedAt, now)
+    }
+}

--- a/IntelliNestTests/MusicViewModelSeekTests.swift
+++ b/IntelliNestTests/MusicViewModelSeekTests.swift
@@ -31,9 +31,68 @@ extension MusicViewModelTests {
         XCTAssertEqual(capturedBody?["seek_position"] as? Double, 42)
     }
 
-    func testSeekWithoutActiveSpeakerIsNoOp() {
+    func testSeekWithoutActiveSpeakerIsNoOp() async {
+        let noRequest = XCTestExpectation(description: "no media_seek request")
+        noRequest.isInverted = true
+        URLProtocolStub.observerRequests { request in
+            if request.url?.path.contains("/media_seek") == true {
+                noRequest.fulfill()
+            }
+        }
         viewModel.seek(to: 10)
         XCTAssertNil(viewModel.activeSpeakerID)
+        XCTAssertNil(viewModel.speakers[.mediaPlayerKitchen]?.mediaPosition)
+        await fulfillment(of: [noRequest], timeout: 0.5)
+    }
+}
+
+// MARK: - Lyrics loading
+
+@MainActor
+private final class StubLyricsService: LyricsService {
+    private let results: [LyricsResult]
+    private(set) var callCount = 0
+
+    init(results: [LyricsResult]) {
+        self.results = results
+    }
+
+    func fetchLyrics(title: String, artist: String, album: String?, durationSeconds: Double?) async -> LyricsResult {
+        defer { callCount += 1 }
+        return callCount < results.count ? results[callCount] : .notFound
+    }
+}
+
+@MainActor
+extension MusicViewModelTests {
+    private func playingSpeaker() -> MediaPlayerEntity {
+        var speaker = MediaPlayerEntity(entityId: .mediaPlayerKitchen, state: "playing", friendlyName: "Kitchen")
+        speaker.mediaTitle = "Song"
+        speaker.mediaArtist = "Artist"
+        return speaker
+    }
+
+    func testLyricsRetryAfterNotFoundThenLatchOnHit() async {
+        let line = LyricLine(time: 0, text: "hi")
+        let stub = StubLyricsService(results: [.notFound, .synced([line])])
+        let viewModel = MusicViewModel(restAPIService: restAPIService, lyricsService: stub)
+        viewModel.activeSpeakerID = .mediaPlayerKitchen
+        viewModel.speakers[.mediaPlayerKitchen] = playingSpeaker()
+        viewModel.isLyricsExpanded = true
+
+        await viewModel.refreshLyricsForCurrentTrack()
+        XCTAssertEqual(viewModel.lyrics, .notFound)
+        XCTAssertNil(viewModel.lyricsTrackKey, "a miss must not latch — it has to stay retryable")
+
+        // Same track, second trigger: it should retry rather than be suppressed.
+        await viewModel.refreshLyricsForCurrentTrack()
+        XCTAssertEqual(stub.callCount, 2)
+        XCTAssertEqual(viewModel.lyrics, .synced([line]))
+        XCTAssertNotNil(viewModel.lyricsTrackKey, "a hit latches so it isn't refetched")
+
+        // Third trigger on the now-loaded track is a no-op.
+        await viewModel.refreshLyricsForCurrentTrack()
+        XCTAssertEqual(stub.callCount, 2)
     }
 }
 

--- a/IntelliNestTests/MusicViewModelSeekTests.swift
+++ b/IntelliNestTests/MusicViewModelSeekTests.swift
@@ -1,0 +1,75 @@
+@testable import IntelliNest
+import XCTest
+
+// MARK: - Seek / scrubber
+
+@MainActor
+extension MusicViewModelTests {
+    func testSeekRoutesToGroupLeaderWithPosition() async {
+        // Kitchen is synced into a group led by the living room; transport (and seek)
+        // must target the leader.
+        viewModel.selectSpeaker(.mediaPlayerKitchen)
+        viewModel.speakers[.mediaPlayerKitchen]?.groupMembers = [.mediaPlayerLivingRoom, .mediaPlayerKitchen]
+
+        let expectation = XCTestExpectation(description: "POST media_seek")
+        var capturedBody: [String: Any]?
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains("/media_seek") == true {
+                let data = request.httpBodyStreamData() ?? request.httpBody
+                capturedBody = data.flatMap { try? JSONSerialization.jsonObject(with: $0) } as? [String: Any]
+                expectation.fulfill()
+            }
+        }
+        stubPostService(path: "/api/services/media_player/media_seek")
+
+        viewModel.seek(to: 42)
+
+        // Optimistic position lands on the selected speaker so the UI jumps at once.
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerKitchen]?.mediaPosition, 42)
+        await fulfillment(of: [expectation], timeout: 2.0)
+        XCTAssertEqual(capturedBody?["entity_id"] as? String, EntityId.mediaPlayerLivingRoom.rawValue)
+        XCTAssertEqual(capturedBody?["seek_position"] as? Double, 42)
+    }
+
+    func testSeekWithoutActiveSpeakerIsNoOp() {
+        viewModel.seek(to: 10)
+        XCTAssertNil(viewModel.activeSpeakerID)
+    }
+}
+
+// MARK: - Time formatting
+
+final class PlaybackTimeFormatTests: XCTestCase {
+    func testClockFormatting() {
+        let cases: [(seconds: TimeInterval, expected: String)] = [
+            (0, "0:00"),
+            (5, "0:05"),
+            (65, "1:05"),
+            (600, "10:00"),
+            (3661, "1:01:01"),
+            (-5, "0:00")
+        ]
+        for testCase in cases {
+            XCTAssertEqual(PlaybackTimeFormat.clock(testCase.seconds), testCase.expected, "\(testCase.seconds)s")
+        }
+    }
+}
+
+private extension URLRequest {
+    /// `URLProtocol` strips `httpBody` into a stream for POSTs, so read it back out.
+    func httpBodyStreamData() -> Data? {
+        guard let stream = httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data.isEmpty ? nil : data
+    }
+}


### PR DESCRIPTION
## What

Two now-playing additions, both built on newly-decoded playback position
(`media_position` / `media_duration` / `media_position_updated_at` on
`MediaPlayerEntity`, extrapolated to live elapsed via `currentElapsed(asOf:)`):

### 🎚️ Seek bar
An Apple-Music-style scrubber on the now-playing card — draggable thumb, elapsed
on the left, remaining (`-m:ss`) on the right, seek-on-release via
`media_player.media_seek`. Hidden for sources with no known length (live streams).

### 🎤 Lyrics (Spotify-style)
A lyrics button expands the card with a few auto-advancing lines (current line
highlighted), and a full-screen view shows the whole song. **Scrolling the
full-screen lyrics re-aligns the timing** — the line you scroll into focus becomes
"now" — so drifting LRC timestamps can be corrected without touching playback. The
offset resets per track.

- **Primary source: LRCLIB** (`lrclib.net`) — MIT, no key, time-synced LRC,
  matched on artist+track+album+duration with a `/api/search` fallback. Sends a
  descriptive `User-Agent` as LRCLIB requests.
- **Backup: lyrics.ovh** — plain text shown statically when no synced lyrics exist.
- Personal, non-commercial, on-demand use only; all failures degrade to "Ingen
  sångtext hittades". Reads `displayedActiveSpeaker`, so it respects the Sonos
  hardware-twin mirroring.

The header now has three controls (lyrics · queue · speaker), each with a 44pt hit
target.

## Tests
- `LyricsTimelineTests` — LRC parsing, current-line lookup, scroll-to-realign offset.
- `MediaPlayerEntityLyricsTests` — `currentElapsed(asOf:)` (playing/paused/clamp/nil)
  and twin position mirroring.
- `LyricsApiServiceTests` — LRCLIB synced/plain/search-by-duration, lyrics.ovh
  fallback, all-miss, and the User-Agent header (stubbed `URLSession`).
- Seek payload (`media_seek` → group leader + `seek_position`) and `m:ss` / `-m:ss`
  formatting.

Full suite green; SwiftFormat + SwiftLint `--strict` clean.

## Screenshots
Posted in chat: collapsed card with seek bar + 3-icon header, synced lyrics strip
(highlighted line), plain fallback, and the not-found state. The full-screen
scroll-to-realign view can't be drawn by the offline `ImageRenderer` (ScrollView),
but it builds and its timing logic is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronized lyrics support, including inline preview and full-screen lyric views.
  * Added a playback scrubber with drag-to-seek controls and accessibility support.
  * Added automatic lyric fetching with fallback to plain text when synced lyrics aren’t available.
  * Added live playback position tracking so lyrics and scrubbing stay aligned.

* **Bug Fixes**
  * Improved lyric refresh behavior when tracks change mid-update.
  * Clamped playback and seek positions to valid track bounds for smoother behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->