### PR TITLE
Made lyrics lines tappable to realign and fixed the seek/pause position jump

### DIFF
--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		FE0000000000000000000007 /* MusicQueueModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000007 /* MusicQueueModelTests.swift */; };
 		EE0000040000000000000004 /* MusicViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000040000000000000004 /* MusicViewModel.swift */; };
 		EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00000400000000000000F1 /* MusicViewModel+Playback.swift */; };
+		EE00000400000000000000F2 /* MusicViewModel+Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00000400000000000000F2 /* MusicViewModel+Transport.swift */; };
 		EE0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift */; };
 		FE0000000000000000000004 /* MusicViewModel+Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0000000000000000000004 /* MusicViewModel+Queue.swift */; };
 		FE000000000000000000FA01 /* MusicViewModel+Favourites.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD000000000000000000FA01 /* MusicViewModel+Favourites.swift */; };
@@ -312,6 +313,7 @@
 		FD0000000000000000000007 /* MusicQueueModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicQueueModelTests.swift; sourceTree = "<group>"; };
 		EF0000040000000000000004 /* MusicViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicViewModel.swift; sourceTree = "<group>"; };
 		EF00000400000000000000F1 /* MusicViewModel+Playback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Playback.swift"; sourceTree = "<group>"; };
+		EF00000400000000000000F2 /* MusicViewModel+Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Transport.swift"; sourceTree = "<group>"; };
 		EF0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+HardwareMirror.swift"; sourceTree = "<group>"; };
 		FD0000000000000000000004 /* MusicViewModel+Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Queue.swift"; sourceTree = "<group>"; };
 		FD000000000000000000FA01 /* MusicViewModel+Favourites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Favourites.swift"; sourceTree = "<group>"; };
@@ -666,6 +668,7 @@
 				D89BCA06BE3A45F2A8E3DAE4 /* LynkViewModelHelpers.swift */,
 				EF0000040000000000000004 /* MusicViewModel.swift */,
 				EF00000400000000000000F1 /* MusicViewModel+Playback.swift */,
+				EF00000400000000000000F2 /* MusicViewModel+Transport.swift */,
 				EF0000000000000000000A03 /* MusicViewModel+Lyrics.swift */,
 				EF0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift */,
 				FD0000000000000000000004 /* MusicViewModel+Queue.swift */,
@@ -1258,6 +1261,7 @@
 				FE0000000000000000000002 /* MusicAssistantSocketService.swift in Sources */,
 				EE0000040000000000000004 /* MusicViewModel.swift in Sources */,
 				EE00000400000000000000F1 /* MusicViewModel+Playback.swift in Sources */,
+				EE00000400000000000000F2 /* MusicViewModel+Transport.swift in Sources */,
 				EE0000040000000000000F2A1 /* MusicViewModel+HardwareMirror.swift in Sources */,
 				FE0000000000000000000004 /* MusicViewModel+Queue.swift in Sources */,
 				FE000000000000000000FA01 /* MusicViewModel+Favourites.swift in Sources */,

--- a/IntelliNest/Model/LyricsTimeline.swift
+++ b/IntelliNest/Model/LyricsTimeline.swift
@@ -72,7 +72,7 @@ enum LyricsTimeline {
 
     /// The timing offset that makes `lineIndex` the current line at `elapsed`, i.e.
     /// `currentLineIndex(at: elapsed + offset)` returns `lineIndex`. Used by the
-    /// scroll-to-realign correction: the user scrolls a line to "now" and this is
+    /// tap-to-realign correction: the user taps a line to mark it "now" and this is
     /// the nudge applied to every subsequent lookup. Zero for an out-of-range index.
     static func offset(toAlign lineIndex: Int, in lines: [LyricLine], at elapsed: TimeInterval) -> TimeInterval {
         guard lines.indices.contains(lineIndex) else {

--- a/IntelliNest/Model/MediaPlayerEntity.swift
+++ b/IntelliNest/Model/MediaPlayerEntity.swift
@@ -245,3 +245,41 @@ struct MediaPlayerEntity: EntityProtocol, Decodable {
             lhs.mediaPositionUpdatedAt == rhs.mediaPositionUpdatedAt
     }
 }
+
+/// A playback position the app applied locally (after a seek or a pause) that Home
+/// Assistant hasn't confirmed yet. The reload loop reconciles each refreshed speaker
+/// against this so a transient position from HA doesn't snap the scrubber and lyrics
+/// away from where the user just put them: after a seek HA often still reports the
+/// pre-seek spot for a cycle, and a pausing player can briefly drop its position to
+/// nil/0. The hold keeps `target` on the active speaker until HA reports a position
+/// near it, or the hold expires (so a source that never reports the exact spot can't
+/// freeze the scrubber forever).
+struct PlaybackPositionHold: Equatable {
+    let target: TimeInterval
+    let since: Date
+
+    /// How long to keep holding before giving up and trusting HA again.
+    static let timeout: TimeInterval = 8
+    /// How close HA's reported position must be to `target` to count as confirmed.
+    static let tolerance: TimeInterval = 3
+
+    /// Reconciles a freshly reloaded speaker against the held position. Returns the
+    /// entity to publish and whether the hold is still pending — `false` once HA has
+    /// confirmed the position (so the caller drops the hold) or the hold expired.
+    /// While pending, `target` is pinned onto the entity, anchored at `since` so a
+    /// still-playing track keeps advancing from the held spot rather than restarting.
+    func reconcile(_ fresh: MediaPlayerEntity, asOf now: Date) -> (entity: MediaPlayerEntity, stillPending: Bool) {
+        if now.timeIntervalSince(since) > Self.timeout {
+            return (fresh, false)
+        }
+        // A nil reported position (common mid-transition) counts as unconfirmed, so
+        // the hold persists rather than letting the scrubber fall to 0.
+        if let reported = fresh.currentElapsed(asOf: now), abs(reported - target) <= Self.tolerance {
+            return (fresh, false)
+        }
+        var held = fresh
+        held.mediaPosition = target
+        held.mediaPositionUpdatedAt = since
+        return (held, true)
+    }
+}

--- a/IntelliNest/Services/LyricsApiService.swift
+++ b/IntelliNest/Services/LyricsApiService.swift
@@ -40,6 +40,10 @@ final class LyricsApiService: LyricsService {
     /// Per-request timeout. Short enough that a stalled provider doesn't hang the
     /// lyrics spinner, generous enough for a slow mobile network.
     private static let requestTimeout: TimeInterval = 8
+    /// Cap for the whole fallback chain (LRCLIB get → search → lyrics.ovh). A single
+    /// shared deadline bounds the total wait so three sequential stalls can't add up
+    /// to the sum of their per-request timeouts.
+    private static let totalTimeout: TimeInterval = 10
 
     init(session: URLSession = .shared, userAgent: String = LyricsApiService.defaultUserAgent) {
         self.session = session
@@ -58,11 +62,15 @@ final class LyricsApiService: LyricsService {
         guard title.isNotEmpty, artist.isNotEmpty else {
             return .notFound
         }
-        let primary = await fetchFromLRCLIB(title: title, artist: artist, album: album, durationSeconds: durationSeconds)
+        // One shared deadline for the whole chain so the spinner can't hang for the
+        // sum of every provider's individual timeout.
+        let deadline = Date().addingTimeInterval(Self.totalTimeout)
+        let primary = await fetchFromLRCLIB(title: title, artist: artist, album: album,
+                                            durationSeconds: durationSeconds, deadline: deadline)
         if primary != .notFound {
             return primary
         }
-        if let plain = await fetchFromLyricsOvh(title: title, artist: artist) {
+        if let plain = await fetchFromLyricsOvh(title: title, artist: artist, deadline: deadline) {
             return .plain(plain)
         }
         return .notFound
@@ -70,7 +78,8 @@ final class LyricsApiService: LyricsService {
 
     // MARK: - LRCLIB (primary, synced)
 
-    private func fetchFromLRCLIB(title: String, artist: String, album: String?, durationSeconds: Double?) async -> LyricsResult {
+    private func fetchFromLRCLIB(title: String, artist: String, album: String?,
+                                 durationSeconds: Double?, deadline: Date) async -> LyricsResult {
         var components = URLComponents(string: "\(lrclibBaseURL)/get")
         var queryItems = [
             URLQueryItem(name: "artist_name", value: artist),
@@ -84,22 +93,22 @@ final class LyricsApiService: LyricsService {
         }
         components?.queryItems = queryItems
 
-        if let url = components?.url, let record = await getJSON(url, as: LRCLIBRecord.self) {
+        if let url = components?.url, let record = await getJSON(url, as: LRCLIBRecord.self, deadline: deadline) {
             let result = record.lyricsResult
             if result != .notFound {
                 return result
             }
         }
-        return await searchLRCLIB(title: title, artist: artist, durationSeconds: durationSeconds)
+        return await searchLRCLIB(title: title, artist: artist, durationSeconds: durationSeconds, deadline: deadline)
     }
 
     /// Falls back to LRCLIB's fuzzy search when the exact `get` misses, then picks
     /// the candidate closest to the known track length (preferring synced ones).
-    private func searchLRCLIB(title: String, artist: String, durationSeconds: Double?) async -> LyricsResult {
+    private func searchLRCLIB(title: String, artist: String, durationSeconds: Double?, deadline: Date) async -> LyricsResult {
         var components = URLComponents(string: "\(lrclibBaseURL)/search")
         components?.queryItems = [URLQueryItem(name: "q", value: "\(title) \(artist)")]
         guard let url = components?.url,
-              let records = await getJSON(url, as: [LRCLIBRecord].self),
+              let records = await getJSON(url, as: [LRCLIBRecord].self, deadline: deadline),
               records.isNotEmpty else {
             return .notFound
         }
@@ -117,7 +126,7 @@ final class LyricsApiService: LyricsService {
 
     // MARK: - lyrics.ovh (backup, plain)
 
-    private func fetchFromLyricsOvh(title: String, artist: String) async -> String? {
+    private func fetchFromLyricsOvh(title: String, artist: String, deadline: Date) async -> String? {
         var allowed = CharacterSet.urlPathAllowed
         allowed.remove("/")
         guard let escapedArtist = artist.addingPercentEncoding(withAllowedCharacters: allowed),
@@ -125,7 +134,7 @@ final class LyricsApiService: LyricsService {
               let url = URL(string: "\(lyricsOvhBaseURL)/\(escapedArtist)/\(escapedTitle)") else {
             return nil
         }
-        guard let record = await getJSON(url, as: LyricsOvhRecord.self),
+        guard let record = await getJSON(url, as: LyricsOvhRecord.self, deadline: deadline),
               let lyrics = record.lyrics,
               lyrics.isNotEmpty else {
             return nil
@@ -135,10 +144,15 @@ final class LyricsApiService: LyricsService {
 
     // MARK: - Networking
 
-    private func getJSON<Response: Decodable>(_ url: URL, as type: Response.Type) async -> Response? {
-        // Cap each lookup so a slow or stalled provider can't leave the lyrics
-        // spinner hanging — the chain has a backup source, and a miss is fine.
-        var request = URLRequest(url: url, timeoutInterval: Self.requestTimeout)
+    private func getJSON<Response: Decodable>(_ url: URL, as type: Response.Type, deadline: Date) async -> Response? {
+        // Bound each lookup by whatever is left of the shared chain deadline (never
+        // more than the per-request cap), so a stalled provider can't hang the lyrics
+        // spinner — the chain has a backup source, and a miss is fine.
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else {
+            return nil
+        }
+        var request = URLRequest(url: url, timeoutInterval: min(Self.requestTimeout, remaining))
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         do {
             let (data, response) = try await session.data(for: request)

--- a/IntelliNest/Services/LyricsApiService.swift
+++ b/IntelliNest/Services/LyricsApiService.swift
@@ -37,6 +37,9 @@ final class LyricsApiService: LyricsService {
 
     private let lrclibBaseURL = "https://lrclib.net/api"
     private let lyricsOvhBaseURL = "https://api.lyrics.ovh/v1"
+    /// Per-request timeout. Short enough that a stalled provider doesn't hang the
+    /// lyrics spinner, generous enough for a slow mobile network.
+    private static let requestTimeout: TimeInterval = 8
 
     init(session: URLSession = .shared, userAgent: String = LyricsApiService.defaultUserAgent) {
         self.session = session
@@ -133,7 +136,9 @@ final class LyricsApiService: LyricsService {
     // MARK: - Networking
 
     private func getJSON<Response: Decodable>(_ url: URL, as type: Response.Type) async -> Response? {
-        var request = URLRequest(url: url)
+        // Cap each lookup so a slow or stalled provider can't leave the lyrics
+        // spinner hanging — the chain has a backup source, and a miss is fine.
+        var request = URLRequest(url: url, timeoutInterval: Self.requestTimeout)
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         do {
             let (data, response) = try await session.data(for: request)

--- a/IntelliNest/ViewModels/MusicViewModel+Lyrics.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Lyrics.swift
@@ -32,12 +32,11 @@ extension MusicViewModel {
 
     /// Fetches lyrics for the current track when the song has changed since the last
     /// load. Resets the manual realign offset on a change and shows a loading flag so
-    /// the UI doesn't flash "not found". No-op when the same track is already loaded
-    /// or when the lyrics panel isn't visible (nothing is shown, so nothing to load).
+    /// the UI doesn't flash "not found". Prefetches as soon as the track is known —
+    /// not only when the lyrics panel is open — so the lyrics are already in hand by
+    /// the time the user taps to show them. No-op when the same track is already
+    /// loaded or a fetch for it is in flight.
     func refreshLyricsForCurrentTrack() async {
-        guard isLyricsExpanded || isShowingFullLyrics else {
-            return
-        }
         guard let key = currentLyricsTrackKey, let speaker = displayedActiveSpeaker else {
             resetLyrics()
             return
@@ -75,7 +74,7 @@ extension MusicViewModel {
     }
 
     /// Re-aligns synced lyrics so `lineIndex` is the current line at `elapsed`, by
-    /// nudging the timing offset. Used by the scroll-to-realign gesture; a no-op for
+    /// nudging the timing offset. Used by the tap-to-realign gesture; a no-op for
     /// plain or missing lyrics, where there's no timeline to shift.
     func applyRealign(toLineIndex lineIndex: Int, at elapsed: TimeInterval) {
         guard case let .synced(lines) = lyrics else {

--- a/IntelliNest/ViewModels/MusicViewModel+Playback.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Playback.swift
@@ -119,7 +119,8 @@ extension MusicViewModel {
     /// Playback and queue commands must go to the active speaker's group leader;
     /// a synced follower rejects them. Returns the active speaker itself when it
     /// is ungrouped. Volume stays per-speaker, so it is not redirected here.
-    private var playbackTargetID: EntityId? {
+    /// Internal so the transport controls in `MusicViewModel+Transport` can route.
+    var playbackTargetID: EntityId? {
         guard let activeSpeaker else {
             return activeSpeakerID
         }
@@ -128,10 +129,14 @@ extension MusicViewModel {
 
     /// Re-fetches the active speaker's state so playback routing reads its
     /// current group membership rather than a value up to one reload cycle
-    /// stale. A failed fetch leaves the existing state in place.
-    private func refreshActiveSpeaker(_ speakerID: EntityId) async {
+    /// stale. A failed fetch leaves the existing state in place. Internal so the
+    /// seek control in `MusicViewModel+Transport` can refresh before routing.
+    func refreshActiveSpeaker(_ speakerID: EntityId) async {
         if let fresh = try? await restAPIService.reload(entityId: speakerID, entityType: MediaPlayerEntity.self) {
-            speakers[speakerID] = fresh
+            // Route through the position hold so a refresh fired right after a seek
+            // (to resolve the group leader) doesn't overwrite the optimistic position
+            // with HA's still-stale pre-seek one.
+            speakers[speakerID] = reconcilePositionHold(speakerID: speakerID, fresh: fresh)
         }
     }
 
@@ -157,6 +162,9 @@ extension MusicViewModel {
             setErrorBannerText("Ingen högtalare vald", "Välj en högtalare innan du spelar musik")
             return false
         }
+        // A new track resets playback position, so any seek/pause hold is obsolete —
+        // clear it before the refresh below can re-pin a stale position.
+        positionHold = nil
         // Group membership can change between the 5-second reloads (e.g. the
         // speaker was just ungrouped). Refresh the active speaker before routing
         // so playback isn't sent to a stale group leader it's no longer synced
@@ -283,95 +291,5 @@ extension MusicViewModel {
             Log.error("Spotify login failed: \(error)")
             setErrorBannerText("Spotify-inloggning misslyckades", "Kunde inte logga in på Spotify")
         }
-    }
-
-    // MARK: - Transport & volume
-
-    func togglePlayPause() {
-        guard let activeSpeaker, let targetID = playbackTargetID else {
-            return
-        }
-        // Decide from the mirrored state the card actually shows (the hardware
-        // twin's when it diverges), so the button does what its icon implies. The
-        // command still routes to the Music Assistant group leader.
-        let isPlaying = displayedActiveSpeaker?.isPlaying ?? activeSpeaker.isPlaying
-        let action: Action = isPlaying ? .mediaPause : .mediaPlay
-        speakers[activeSpeaker.entityId]?.state = isPlaying ? "paused" : "playing"
-        restAPIService.mediaTransport(entityID: targetID, action: action)
-    }
-
-    func nextTrack() {
-        guard let targetID = playbackTargetID else {
-            return
-        }
-        restAPIService.mediaTransport(entityID: targetID, action: .mediaNextTrack)
-    }
-
-    func previousTrack() {
-        guard let targetID = playbackTargetID else {
-            return
-        }
-        restAPIService.mediaTransport(entityID: targetID, action: .mediaPreviousTrack)
-    }
-
-    /// Seeks the current track to `seconds`. Optimistically anchors the active
-    /// speaker's position to the new spot (so the scrubber and lyrics jump at once)
-    /// and routes the command to the group leader; the follow-up reload reconciles
-    /// with the real position.
-    func seek(to seconds: Double) {
-        guard let activeSpeakerID else {
-            return
-        }
-        let clamped = max(seconds, 0)
-        speakers[activeSpeakerID]?.mediaPosition = clamped
-        speakers[activeSpeakerID]?.mediaPositionUpdatedAt = Date()
-        Task {
-            // Group membership can change between reloads; refresh before resolving
-            // the leader so the seek isn't routed to a stale leader (or a follower
-            // that rejects it), matching `startPlayback`.
-            await refreshActiveSpeaker(activeSpeakerID)
-            guard let targetID = playbackTargetID else {
-                return
-            }
-            restAPIService.seek(entityID: targetID, positionSeconds: clamped)
-        }
-    }
-
-    func setVolume(_ volume: Double) {
-        guard let activeSpeakerID else {
-            return
-        }
-        setVolume(volume, for: activeSpeakerID)
-    }
-
-    /// Sets the volume of a specific speaker. Volume is always per-speaker (never
-    /// redirected to a group leader), so any speaker in the list can be adjusted
-    /// in place.
-    func setVolume(_ volume: Double, for speakerID: EntityId) {
-        speakers[speakerID]?.volumeLevel = volume
-        restAPIService.setVolume(entityID: speakerID, volume: volume)
-    }
-
-    func toggleShuffle() {
-        guard let activeSpeaker, let targetID = playbackTargetID else {
-            return
-        }
-        let newValue = !activeSpeaker.shuffle
-        speakers[activeSpeaker.entityId]?.shuffle = newValue
-        restAPIService.setShuffle(entityID: targetID, shuffle: newValue)
-    }
-
-    func toggleRepeat() {
-        guard let activeSpeaker, let targetID = playbackTargetID else {
-            return
-        }
-        // Cycle off → all → one → off, matching the Sonos-style three-state control.
-        let newMode: MediaRepeatMode = switch activeSpeaker.repeatMode {
-        case .off: .all
-        case .all: .one
-        case .one: .off
-        }
-        speakers[activeSpeaker.entityId]?.repeatMode = newMode
-        restAPIService.setRepeat(entityID: targetID, repeatMode: newMode)
     }
 }

--- a/IntelliNest/ViewModels/MusicViewModel+Transport.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Transport.swift
@@ -71,15 +71,21 @@ extension MusicViewModel {
         speakers[activeSpeakerID]?.mediaPositionUpdatedAt = now
         // Hold the new spot through the next reloads: HA keeps reporting the pre-seek
         // position for a cycle or two, which would otherwise snap the scrubber back.
-        positionHold = PlaybackPositionHold(target: clamped, since: now)
+        let hold = PlaybackPositionHold(target: clamped, since: now)
+        positionHold = hold
         Task {
             // Group membership can change between reloads; refresh before resolving
             // the leader so the seek isn't routed to a stale leader (or a follower
             // that rejects it), matching `startPlayback`.
             await refreshActiveSpeaker(activeSpeakerID)
-            guard let targetID = playbackTargetID else {
+            // If the user switched speakers or seeked again during the await, this
+            // seek is stale — bail rather than route it to whatever is now active.
+            // Resolve the leader from the speaker that initiated the seek, not the
+            // current `playbackTargetID` (which reads whatever is active now).
+            guard self.activeSpeakerID == activeSpeakerID, positionHold == hold else {
                 return
             }
+            let targetID = speakers[activeSpeakerID]?.playbackTargetID ?? activeSpeakerID
             restAPIService.seek(entityID: targetID, positionSeconds: clamped)
         }
         // Pull the confirmed position in quickly so the hold releases without waiting

--- a/IntelliNest/ViewModels/MusicViewModel+Transport.swift
+++ b/IntelliNest/ViewModels/MusicViewModel+Transport.swift
@@ -1,0 +1,127 @@
+//
+//  MusicViewModel+Transport.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-28.
+//
+
+import Foundation
+
+/// Transport (play/pause, skip, seek), volume, shuffle, and repeat controls for the
+/// active speaker, split out of `MusicViewModel+Playback` to keep each file focused
+/// and under the line-length limit.
+extension MusicViewModel {
+    func togglePlayPause() {
+        guard let activeSpeaker, let targetID = playbackTargetID else {
+            return
+        }
+        // Decide from the mirrored state the card actually shows (the hardware
+        // twin's when it diverges), so the button does what its icon implies. The
+        // command still routes to the Music Assistant group leader.
+        let isPlaying = displayedActiveSpeaker?.isPlaying ?? activeSpeaker.isPlaying
+        let action: Action = isPlaying ? .mediaPause : .mediaPlay
+        if isPlaying {
+            // Pausing: pin the scrubber to the live position. A pausing player can
+            // briefly report no position (or 0) while it transitions, which would
+            // snap the scrubber to 0; hold the frozen spot until HA reports it back.
+            // Read the elapsed time before flipping the state, while it still extrapolates.
+            let now = Date()
+            let frozen = (displayedActiveSpeaker ?? activeSpeaker).currentElapsed(asOf: now) ?? 0
+            speakers[activeSpeaker.entityId]?.mediaPosition = frozen
+            speakers[activeSpeaker.entityId]?.mediaPositionUpdatedAt = now
+            positionHold = PlaybackPositionHold(target: frozen, since: now)
+        } else {
+            // Resuming: drop any hold so the live position advances freely again.
+            positionHold = nil
+        }
+        speakers[activeSpeaker.entityId]?.state = isPlaying ? "paused" : "playing"
+        restAPIService.mediaTransport(entityID: targetID, action: action)
+        // Confirm the new state/position quickly so the hold releases promptly.
+        restAPIService.triggerRepeatReload(times: 3)
+    }
+
+    func nextTrack() {
+        guard let targetID = playbackTargetID else {
+            return
+        }
+        // A new track resets position, so a seek/pause hold no longer applies.
+        positionHold = nil
+        restAPIService.mediaTransport(entityID: targetID, action: .mediaNextTrack)
+    }
+
+    func previousTrack() {
+        guard let targetID = playbackTargetID else {
+            return
+        }
+        positionHold = nil
+        restAPIService.mediaTransport(entityID: targetID, action: .mediaPreviousTrack)
+    }
+
+    /// Seeks the current track to `seconds`. Optimistically anchors the active
+    /// speaker's position to the new spot (so the scrubber and lyrics jump at once)
+    /// and routes the command to the group leader; the follow-up reload reconciles
+    /// with the real position.
+    func seek(to seconds: Double) {
+        guard let activeSpeakerID else {
+            return
+        }
+        let now = Date()
+        let clamped = max(seconds, 0)
+        speakers[activeSpeakerID]?.mediaPosition = clamped
+        speakers[activeSpeakerID]?.mediaPositionUpdatedAt = now
+        // Hold the new spot through the next reloads: HA keeps reporting the pre-seek
+        // position for a cycle or two, which would otherwise snap the scrubber back.
+        positionHold = PlaybackPositionHold(target: clamped, since: now)
+        Task {
+            // Group membership can change between reloads; refresh before resolving
+            // the leader so the seek isn't routed to a stale leader (or a follower
+            // that rejects it), matching `startPlayback`.
+            await refreshActiveSpeaker(activeSpeakerID)
+            guard let targetID = playbackTargetID else {
+                return
+            }
+            restAPIService.seek(entityID: targetID, positionSeconds: clamped)
+        }
+        // Pull the confirmed position in quickly so the hold releases without waiting
+        // for the full 5-second loop.
+        restAPIService.triggerRepeatReload(times: 3)
+    }
+
+    func setVolume(_ volume: Double) {
+        guard let activeSpeakerID else {
+            return
+        }
+        setVolume(volume, for: activeSpeakerID)
+    }
+
+    /// Sets the volume of a specific speaker. Volume is always per-speaker (never
+    /// redirected to a group leader), so any speaker in the list can be adjusted
+    /// in place.
+    func setVolume(_ volume: Double, for speakerID: EntityId) {
+        speakers[speakerID]?.volumeLevel = volume
+        restAPIService.setVolume(entityID: speakerID, volume: volume)
+    }
+
+    func toggleShuffle() {
+        guard let activeSpeaker, let targetID = playbackTargetID else {
+            return
+        }
+        let newValue = !activeSpeaker.shuffle
+        speakers[activeSpeaker.entityId]?.shuffle = newValue
+        restAPIService.setShuffle(entityID: targetID, shuffle: newValue)
+    }
+
+    func toggleRepeat() {
+        guard let activeSpeaker, let targetID = playbackTargetID else {
+            return
+        }
+        // Cycle off → all → one → off, matching the Sonos-style three-state control.
+        let newMode: MediaRepeatMode = switch activeSpeaker.repeatMode {
+        case .off: .all
+        case .all: .one
+        case .one: .off
+        }
+        speakers[activeSpeaker.entityId]?.repeatMode = newMode
+        restAPIService.setRepeat(entityID: targetID, repeatMode: newMode)
+    }
+}

--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -142,6 +142,13 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// `MusicViewModel+Lyrics`.
     var inFlightLyricsKey: String?
 
+    /// An optimistic playback position (set by a seek or a pause) the reload loop
+    /// keeps on the active speaker until Home Assistant confirms it, so a transient
+    /// pre-seek / mid-pause position can't snap the scrubber and lyrics back. Read
+    /// and cleared in `reloadSpeakers`; set by the transport calls in
+    /// `MusicViewModel+Playback`.
+    var positionHold: PlaybackPositionHold?
+
     var isReloading = false
     private var hasSelectedDefaultSpeaker = false
     /// Read/written by the library-playlist loader in `MusicViewModel+Playback`.
@@ -271,11 +278,27 @@ class MusicViewModel: ObservableObject, Reloadable {
 
             for await result in group {
                 if let (speakerID, speaker) = result {
-                    self.speakers[speakerID] = speaker
+                    self.speakers[speakerID] = reconcilePositionHold(speakerID: speakerID, fresh: speaker)
                 }
             }
         }
         await reloadHardwareTwins()
+    }
+
+    /// Applies the pending position hold to a freshly reloaded speaker. Only the
+    /// active speaker (whose position drives the scrubber and lyrics) is held; every
+    /// other speaker is published as-is. Drops the hold once HA confirms the position
+    /// or it expires. Internal so the targeted `refreshActiveSpeaker` in
+    /// `MusicViewModel+Playback` reuses it and doesn't clobber a just-seeked position.
+    func reconcilePositionHold(speakerID: EntityId, fresh: MediaPlayerEntity) -> MediaPlayerEntity {
+        guard speakerID == activeSpeakerID, let hold = positionHold else {
+            return fresh
+        }
+        let (entity, stillPending) = hold.reconcile(fresh, asOf: Date())
+        if !stillPending {
+            positionHold = nil
+        }
+        return entity
     }
 
     /// On the first reload after the view appears, default the active speaker to
@@ -302,6 +325,10 @@ class MusicViewModel: ObservableObject, Reloadable {
     }
 
     func selectSpeaker(_ entityID: EntityId) {
+        // A different speaker has its own position; drop any hold tied to the old one.
+        if entityID != activeSpeakerID {
+            positionHold = nil
+        }
         activeSpeakerID = entityID
         saveLastSpeaker(entityID)
     }

--- a/IntelliNest/Views/Music/LyricsViews.swift
+++ b/IntelliNest/Views/Music/LyricsViews.swift
@@ -223,12 +223,15 @@ struct LyricsFullView: View {
     private func advance(_ lines: [LyricLine]) {
         let elapsed = (speaker.currentElapsed(asOf: Date()) ?? 0) + viewModel.lyricsOffset
         let index = LyricsTimeline.currentLineIndex(in: lines, at: elapsed)
-        guard index != currentIndex else {
+        let isBrowsing = lastManualScroll.map { Date().timeIntervalSince($0) < browseGracePeriod } ?? false
+        // Re-focus once browsing ends even if the current line hasn't changed — e.g.
+        // the user scrolled away during a long line and playback is still on it.
+        let shouldRefocus = !isBrowsing && index != focusedLineID
+        guard index != currentIndex || shouldRefocus else {
             return
         }
         currentIndex = index
-        let isBrowsing = lastManualScroll.map { Date().timeIntervalSince($0) < browseGracePeriod } ?? false
-        if !isBrowsing, let index {
+        if shouldRefocus, let index {
             withAnimation(.easeInOut(duration: 0.3)) {
                 focusedLineID = index
             }

--- a/IntelliNest/Views/Music/LyricsViews.swift
+++ b/IntelliNest/Views/Music/LyricsViews.swift
@@ -110,21 +110,26 @@ struct LyricsStripView: View {
 }
 
 /// The full-screen lyrics view. Synced lyrics auto-scroll to keep the current line
-/// near the top; dragging the lyrics re-aligns the timing (the line the user scrolls
-/// into focus becomes "now"), correcting drifting LRC timestamps without touching
-/// playback. Plain lyrics show as static scrollable text.
+/// near the top; tapping a line re-aligns the timing (the tapped line becomes
+/// "now"), correcting drifting LRC timestamps without touching playback. Scrolling
+/// just browses — it pauses the auto-follow for a few seconds so the user can read
+/// ahead without being yanked back. Plain lyrics show as static scrollable text.
 struct LyricsFullView: View {
     let speaker: MediaPlayerEntity
     @ObservedObject var viewModel: MusicViewModel
     @Environment(\.dismiss) private var dismiss
 
     /// The line currently scrolled into focus (the topmost line below the top
-    /// margin). Written programmatically to auto-follow playback and read back to
-    /// re-align when the user scrolls.
+    /// margin). Written programmatically to auto-follow playback.
     @State private var focusedLineID: Int?
     @State private var currentIndex: Int?
-    @State private var isDragging = false
+    /// When the user last scrolled the lyrics by hand. Auto-follow stays paused for
+    /// `browseGracePeriod` after this so a scroll to read ahead isn't immediately
+    /// snapped back to the playing line. Nil while following.
+    @State private var lastManualScroll: Date?
 
+    /// How long auto-follow stays paused after a manual scroll.
+    private let browseGracePeriod: TimeInterval = 4
     private let ticker = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -170,6 +175,8 @@ struct LyricsFullView: View {
                         .fontWeight(index == currentIndex ? .bold : .regular)
                         .foregroundStyle(index == currentIndex ? .yellow : .white.opacity(0.45))
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                        .onTapGesture { realign(to: index, in: lines) }
                         .id(index)
                 }
             }
@@ -180,20 +187,24 @@ struct LyricsFullView: View {
         // leave room to scroll the last lines into focus.
         .contentMargins(.vertical, 140, for: .scrollContent)
         .scrollPosition(id: $focusedLineID)
-        .simultaneousGesture(
-            DragGesture()
-                .onChanged { _ in isDragging = true }
-                .onEnded { _ in
-                    if let focusedLineID {
-                        viewModel.applyRealign(toLineIndex: focusedLineID, at: speaker.currentElapsed(asOf: Date()) ?? 0)
-                    }
-                    isDragging = false
-                }
-        )
+        // A scroll drag pauses auto-follow so the user can browse; a plain tap moves
+        // no distance, so it falls through to a line's tap-to-realign instead.
+        .simultaneousGesture(DragGesture().onChanged { _ in lastManualScroll = Date() })
         .onReceive(ticker) { _ in
             advance(lines)
         }
         .onAppear { advance(lines) }
+    }
+
+    /// Re-aligns the timeline so the tapped line becomes "now" and resumes
+    /// auto-follow from there, snapping it into focus.
+    private func realign(to index: Int, in lines: [LyricLine]) {
+        viewModel.applyRealign(toLineIndex: index, at: speaker.currentElapsed(asOf: Date()) ?? 0)
+        lastManualScroll = nil
+        currentIndex = index
+        withAnimation(.easeInOut(duration: 0.3)) {
+            focusedLineID = index
+        }
     }
 
     private func plainView(_ text: String) -> some View {
@@ -206,8 +217,9 @@ struct LyricsFullView: View {
         }
     }
 
-    /// Recomputes the current line from playback time + the manual offset and, unless
-    /// the user is actively scrolling, scrolls it into focus.
+    /// Recomputes the current line from playback time + the manual offset, updating
+    /// the highlight. Scrolls it into focus unless the user is browsing — i.e. has
+    /// scrolled by hand within the last `browseGracePeriod`.
     private func advance(_ lines: [LyricLine]) {
         let elapsed = (speaker.currentElapsed(asOf: Date()) ?? 0) + viewModel.lyricsOffset
         let index = LyricsTimeline.currentLineIndex(in: lines, at: elapsed)
@@ -215,7 +227,8 @@ struct LyricsFullView: View {
             return
         }
         currentIndex = index
-        if !isDragging, let index {
+        let isBrowsing = lastManualScroll.map { Date().timeIntervalSince($0) < browseGracePeriod } ?? false
+        if !isBrowsing, let index {
             withAnimation(.easeInOut(duration: 0.3)) {
                 focusedLineID = index
             }

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -71,8 +71,8 @@ struct NowPlayingView: View {
         .task(id: speaker.mediaContentID) {
             await viewModel.loadSavedSongStates(uris: [speaker.mediaContentID].compactMap { $0 })
         }
-        // Refetch lyrics when the track changes while the lyrics panel is open
-        // (a no-op otherwise).
+        // Prefetch lyrics whenever the track changes so they're ready the moment the
+        // user opens the panel, rather than starting the lookup on that tap.
         .task(id: viewModel.currentLyricsTrackKey) {
             await viewModel.refreshLyricsForCurrentTrack()
         }

--- a/IntelliNestTests/MusicViewModelSeekTests.swift
+++ b/IntelliNestTests/MusicViewModelSeekTests.swift
@@ -44,6 +44,122 @@ extension MusicViewModelTests {
         XCTAssertNil(viewModel.speakers[.mediaPlayerKitchen]?.mediaPosition)
         await fulfillment(of: [noRequest], timeout: 0.5)
     }
+
+    func testSeekRegistersPositionHold() async {
+        viewModel.selectSpeaker(.mediaPlayerSpa)
+        viewModel.speakers[.mediaPlayerSpa] = MediaPlayerEntity(entityId: .mediaPlayerSpa, state: "playing", friendlyName: "Spa")
+        // Await the fired request so the async seek Task can't bleed a stray media_seek
+        // POST into a sibling test sharing the process-global URLProtocolStub.
+        let sent = transportExpectation(path: "/media_seek")
+        stubPostService(path: "/api/services/media_player/media_seek")
+
+        viewModel.seek(to: 42)
+
+        // The hold keeps the seeked spot through the reloads that still report the
+        // pre-seek position, so the scrubber doesn't snap back.
+        XCTAssertEqual(viewModel.positionHold?.target ?? -1, 42, accuracy: 0.001)
+        await fulfillment(of: [sent], timeout: 2.0)
+    }
+
+    func testPauseHoldsTheLivePositionSoItCannotSnapToZero() async {
+        var speaker = MediaPlayerEntity(entityId: .mediaPlayerSpa, state: "playing", friendlyName: "Spa")
+        speaker.mediaPosition = 30
+        speaker.mediaPositionUpdatedAt = Date()
+        viewModel.speakers[.mediaPlayerSpa] = speaker
+        viewModel.activeSpeakerID = .mediaPlayerSpa
+        let sent = transportExpectation(path: "/media_pause")
+        stubPostService(path: "/api/services/media_player/media_pause")
+
+        viewModel.togglePlayPause()
+
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerSpa]?.state, "paused")
+        XCTAssertEqual(viewModel.positionHold?.target ?? -1, 30, accuracy: 0.5)
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerSpa]?.mediaPosition ?? -1, 30, accuracy: 0.5)
+        await fulfillment(of: [sent], timeout: 2.0)
+    }
+
+    func testResumeClearsThePositionHold() async {
+        var speaker = MediaPlayerEntity(entityId: .mediaPlayerSpa, state: "paused", friendlyName: "Spa")
+        speaker.mediaPosition = 30
+        viewModel.speakers[.mediaPlayerSpa] = speaker
+        viewModel.activeSpeakerID = .mediaPlayerSpa
+        viewModel.positionHold = PlaybackPositionHold(target: 30, since: Date())
+        let sent = transportExpectation(path: "/media_play")
+        stubPostService(path: "/api/services/media_player/media_play")
+
+        viewModel.togglePlayPause()
+
+        XCTAssertEqual(viewModel.speakers[.mediaPlayerSpa]?.state, "playing")
+        XCTAssertNil(viewModel.positionHold, "resuming must let the live position advance freely")
+        await fulfillment(of: [sent], timeout: 2.0)
+    }
+
+    /// Fulfilled when a POST to `path` is observed, so a test can await the async
+    /// transport Task it kicked off and not leak a request into the next test.
+    private func transportExpectation(path: String) -> XCTestExpectation {
+        let expectation = XCTestExpectation(description: "POST \(path)")
+        URLProtocolStub.observerRequests { request in
+            if request.httpMethod == "POST", request.url?.path.contains(path) == true {
+                expectation.fulfill()
+            }
+        }
+        return expectation
+    }
+}
+
+// MARK: - Position hold
+
+final class PlaybackPositionHoldTests: XCTestCase {
+    // Fixed epoch — no wall-clock or random data, so the timing math is deterministic.
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func speaker(position: Double?, state: String = "paused", updatedAt: Date? = nil) -> MediaPlayerEntity {
+        var entity = MediaPlayerEntity(entityId: .mediaPlayerSpa, state: state, friendlyName: "Spa")
+        entity.mediaPosition = position
+        entity.mediaPositionUpdatedAt = updatedAt
+        return entity
+    }
+
+    func testHoldsWhileHaStillReportsThePreSeekPosition() {
+        let hold = PlaybackPositionHold(target: 100, since: epoch)
+        let (entity, stillPending) = hold.reconcile(speaker(position: 10), asOf: epoch.addingTimeInterval(1))
+        XCTAssertTrue(stillPending)
+        XCTAssertEqual(entity.mediaPosition, 100)
+    }
+
+    func testReleasesOnceHaConfirmsThePositionWithinTolerance() {
+        let hold = PlaybackPositionHold(target: 100, since: epoch)
+        let (entity, stillPending) = hold.reconcile(speaker(position: 99), asOf: epoch.addingTimeInterval(1))
+        XCTAssertFalse(stillPending)
+        XCTAssertEqual(entity.mediaPosition, 99, "the confirmed HA state passes through untouched")
+    }
+
+    func testHoldsWhenReportedPositionIsMissing() {
+        // A pausing player that drops its position to nil must not snap the scrubber to 0.
+        let hold = PlaybackPositionHold(target: 55, since: epoch)
+        let (entity, stillPending) = hold.reconcile(speaker(position: nil), asOf: epoch.addingTimeInterval(1))
+        XCTAssertTrue(stillPending)
+        XCTAssertEqual(entity.mediaPosition, 55)
+    }
+
+    func testReleasesAfterTimeoutEvenWhenUnconfirmed() {
+        let hold = PlaybackPositionHold(target: 100, since: epoch)
+        let pastTimeout = epoch.addingTimeInterval(PlaybackPositionHold.timeout + 1)
+        let (entity, stillPending) = hold.reconcile(speaker(position: 10), asOf: pastTimeout)
+        XCTAssertFalse(stillPending)
+        XCTAssertEqual(entity.mediaPosition, 10, "a source that never reports the spot can't freeze the scrubber forever")
+    }
+
+    func testHeldPlayingPositionKeepsAdvancingFromTheSeekedSpot() {
+        // While playing, the held position is anchored at `since`, so the scrubber
+        // resumes advancing from the seeked spot rather than freezing or restarting.
+        let hold = PlaybackPositionHold(target: 100, since: epoch)
+        let fresh = speaker(position: 10, state: "playing", updatedAt: epoch)
+        let now = epoch.addingTimeInterval(2)
+        let (entity, stillPending) = hold.reconcile(fresh, asOf: now)
+        XCTAssertTrue(stillPending)
+        XCTAssertEqual(entity.currentElapsed(asOf: now) ?? -1, 102, accuracy: 0.001)
+    }
 }
 
 // MARK: - Lyrics loading
@@ -93,6 +209,22 @@ extension MusicViewModelTests {
         // Third trigger on the now-loaded track is a no-op.
         await viewModel.refreshLyricsForCurrentTrack()
         XCTAssertEqual(stub.callCount, 2)
+    }
+
+    func testLyricsPrefetchWhilePanelClosed() async {
+        let line = LyricLine(time: 0, text: "hi")
+        let stub = StubLyricsService(results: [.synced([line])])
+        let viewModel = MusicViewModel(restAPIService: restAPIService, lyricsService: stub)
+        viewModel.activeSpeakerID = .mediaPlayerKitchen
+        viewModel.speakers[.mediaPlayerKitchen] = playingSpeaker()
+        XCTAssertFalse(viewModel.isLyricsExpanded, "the panel is closed — prefetch must still run")
+
+        await viewModel.refreshLyricsForCurrentTrack()
+
+        // Lyrics are fetched on the track change so they're ready the instant the
+        // user opens the panel, not started by that tap.
+        XCTAssertEqual(stub.callCount, 1)
+        XCTAssertEqual(viewModel.lyrics, .synced([line]))
     }
 }
 

--- a/IntelliNestTests/MusicViewModelSeekTests.swift
+++ b/IntelliNestTests/MusicViewModelSeekTests.swift
@@ -94,6 +94,42 @@ extension MusicViewModelTests {
         await fulfillment(of: [sent], timeout: 2.0)
     }
 
+    func testReconcileDropsHoldWhenReloadConfirmsThePosition() {
+        viewModel.activeSpeakerID = .mediaPlayerSpa
+        viewModel.positionHold = PlaybackPositionHold(target: 100, since: Date())
+        var fresh = MediaPlayerEntity(entityId: .mediaPlayerSpa, state: "paused", friendlyName: "Spa")
+        fresh.mediaPosition = 99
+
+        let result = viewModel.reconcilePositionHold(speakerID: .mediaPlayerSpa, fresh: fresh)
+
+        XCTAssertEqual(result.mediaPosition, 99, "a confirmed reload passes through untouched")
+        XCTAssertNil(viewModel.positionHold)
+    }
+
+    func testReconcileKeepsHeldPositionWhenReloadIsStillStale() {
+        viewModel.activeSpeakerID = .mediaPlayerSpa
+        viewModel.positionHold = PlaybackPositionHold(target: 100, since: Date())
+        var fresh = MediaPlayerEntity(entityId: .mediaPlayerSpa, state: "paused", friendlyName: "Spa")
+        fresh.mediaPosition = 5
+
+        let result = viewModel.reconcilePositionHold(speakerID: .mediaPlayerSpa, fresh: fresh)
+
+        XCTAssertEqual(result.mediaPosition, 100, "the stale pre-seek position is overridden by the hold")
+        XCTAssertNotNil(viewModel.positionHold, "the hold persists until HA confirms")
+    }
+
+    func testReconcileLeavesNonActiveSpeakersUntouched() {
+        viewModel.activeSpeakerID = .mediaPlayerSpa
+        viewModel.positionHold = PlaybackPositionHold(target: 100, since: Date())
+        var fresh = MediaPlayerEntity(entityId: .mediaPlayerKitchen, state: "paused", friendlyName: "Kitchen")
+        fresh.mediaPosition = 5
+
+        let result = viewModel.reconcilePositionHold(speakerID: .mediaPlayerKitchen, fresh: fresh)
+
+        XCTAssertEqual(result.mediaPosition, 5, "only the active speaker's position is held")
+        XCTAssertNotNil(viewModel.positionHold)
+    }
+
     /// Fulfilled when a POST to `path` is observed, so a test can await the async
     /// transport Task it kicked off and not leak a request into the next test.
     private func transportExpectation(path: String) -> XCTestExpectation {


### PR DESCRIPTION
## What

Three fixes to the now-playing card from PR #167 feedback.

### 1. Tap a lyric line to realign (was: scroll to realign)
In fullscreen lyrics, **tapping a line** now marks it as "now" and nudges the timing
offset (correcting drifting LRC timestamps without touching playback). **Scrolling**
just browses — auto-follow pauses for a few seconds after a manual scroll so you can
read ahead without being yanked back, then resumes. The current line still stays
highlighted while you browse.

### 2. Seek/pause no longer snaps the position back
Sliding the scrubber forward used to jump back to the old spot before the new one
persisted, and pausing briefly flicked the elapsed time to 0. Both came from a reload
overwriting the good local position with a transient one from Home Assistant (HA keeps
reporting the pre-seek spot for a cycle; a pausing player can momentarily drop its
position). A new `PlaybackPositionHold` pins the optimistic position on the active
speaker until HA confirms it (within tolerance) or the hold times out. The targeted
`refreshActiveSpeaker` fired during a seek now routes through the hold too, so it can't
clobber the just-seeked position. A quick repeat-reload pulls the confirmed position in
so the hold releases promptly.

### 3. Lyrics load faster
Lyrics now prefetch the moment the track changes (not only when the panel is opened),
so they're in hand by the time you tap to show them, and each provider request has an
8s timeout so a stalled source can't hang the spinner.

## Notes
- Split `MusicViewModel+Transport.swift` out of `MusicViewModel+Playback.swift` to stay
  under the 400-line file limit after the position-hold wiring.

## Tests
- `PlaybackPositionHoldTests` — pure reconcile logic (holds while stale, releases on
  confirm/timeout, holds when HA drops the position, keeps advancing while playing).
- `MusicViewModelTests` — seek and pause register a hold; resume clears it; lyrics
  prefetch with the panel closed.
- Full suite green.

## Verification
The tap/scroll interaction and the seek/pause timing are behavioral — best confirmed
live on device with real HA. The static layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added music playback controls for play/pause, next/previous track, seeking, volume, shuffle, and repeat.
  * Lyrics can now prefetch when the track changes, even if the lyrics panel is closed.
  * Tapping a lyric line re-centers and applies a timing realignment for that line.

* **Bug Fixes**
  * Improved scrubber and lyrics position stability during reloads, pauses, seeks, and speaker changes using a temporary playback-position hold.
  * Reduced lyric lookup delays by enforcing shared request/deadline time limits across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->