### PR TITLE
Cached fetched lyrics on disk so repeat lookups load instantly

### DIFF
--- a/IntelliNest.xcodeproj/project.pbxproj
+++ b/IntelliNest.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		EE0000060000000000000006 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000060000000000000006 /* NowPlayingView.swift */; };
 		EE0000000000000000000A01 /* LyricsTimeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A01 /* LyricsTimeline.swift */; };
 		EE0000000000000000000A02 /* LyricsApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A02 /* LyricsApiService.swift */; };
+		EE00000400000000000000F3 /* LyricsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF00000400000000000000F3 /* LyricsCache.swift */; };
 		EE0000000000000000000A03 /* MusicViewModel+Lyrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A03 /* MusicViewModel+Lyrics.swift */; };
 		EE0000000000000000000A04 /* SeekBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A04 /* SeekBarView.swift */; };
 		EE0000000000000000000A05 /* LyricsViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0000000000000000000A05 /* LyricsViews.swift */; };
@@ -323,6 +324,7 @@
 		EF0000060000000000000006 /* NowPlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingView.swift; sourceTree = "<group>"; };
 		EF0000000000000000000A01 /* LyricsTimeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsTimeline.swift; sourceTree = "<group>"; };
 		EF0000000000000000000A02 /* LyricsApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsApiService.swift; sourceTree = "<group>"; };
+		EF00000400000000000000F3 /* LyricsCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsCache.swift; sourceTree = "<group>"; };
 		EF0000000000000000000A03 /* MusicViewModel+Lyrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MusicViewModel+Lyrics.swift"; sourceTree = "<group>"; };
 		EF0000000000000000000A04 /* SeekBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeekBarView.swift; sourceTree = "<group>"; };
 		EF0000000000000000000A05 /* LyricsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsViews.swift; sourceTree = "<group>"; };
@@ -578,6 +580,7 @@
 				EF0000130000000000000020 /* SpotifyAuthService.swift */,
 				EF0000140000000000000021 /* SpotifyApiService.swift */,
 				EF0000000000000000000A02 /* LyricsApiService.swift */,
+				EF00000400000000000000F3 /* LyricsCache.swift */,
 				FD0000000000000000000002 /* MusicAssistantSocketService.swift */,
 				F6FDBE2C2A1A2F970081BC3D /* URLRequestBuilder.swift */,
 				F60345CB27A93BD700212D04 /* URLCreator.swift */,
@@ -1271,6 +1274,7 @@
 				EE0000060000000000000006 /* NowPlayingView.swift in Sources */,
 				EE0000000000000000000A01 /* LyricsTimeline.swift in Sources */,
 				EE0000000000000000000A02 /* LyricsApiService.swift in Sources */,
+				EE00000400000000000000F3 /* LyricsCache.swift in Sources */,
 				EE0000000000000000000A03 /* MusicViewModel+Lyrics.swift in Sources */,
 				EE0000000000000000000A04 /* SeekBarView.swift in Sources */,
 				EE0000000000000000000A05 /* LyricsViews.swift in Sources */,

--- a/IntelliNest/Model/LyricsTimeline.swift
+++ b/IntelliNest/Model/LyricsTimeline.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// One timed line of lyrics: the `time` (seconds from the start of the track) at
 /// which `text` should become the current line.
-struct LyricLine: Equatable {
+struct LyricLine: Equatable, Codable {
     let time: TimeInterval
     let text: String
 }
@@ -17,7 +17,7 @@ struct LyricLine: Equatable {
 /// The outcome of a lyrics lookup. `synced` carries timestamped lines that follow
 /// playback; `plain` carries untimed text shown statically (Spotify does the same
 /// for tracks with no synced lyrics); `notFound` means neither source had a match.
-enum LyricsResult: Equatable {
+enum LyricsResult: Equatable, Codable {
     case synced([LyricLine])
     case plain(String)
     case notFound

--- a/IntelliNest/Services/LyricsApiService.swift
+++ b/IntelliNest/Services/LyricsApiService.swift
@@ -34,6 +34,9 @@ final class DisabledLyricsService: LyricsService {
 final class LyricsApiService: LyricsService {
     private let session: URLSession
     private let userAgent: String
+    /// Caches successful lookups across launches so a re-opened (or replayed) track
+    /// loads instantly without re-hitting the providers.
+    private let cache: LyricsCache
 
     private let lrclibBaseURL = "https://lrclib.net/api"
     private let lyricsOvhBaseURL = "https://api.lyrics.ovh/v1"
@@ -45,9 +48,12 @@ final class LyricsApiService: LyricsService {
     /// to the sum of their per-request timeouts.
     private static let totalTimeout: TimeInterval = 10
 
-    init(session: URLSession = .shared, userAgent: String = LyricsApiService.defaultUserAgent) {
+    init(session: URLSession = .shared,
+         userAgent: String = LyricsApiService.defaultUserAgent,
+         cache: LyricsCache = LyricsCache()) {
         self.session = session
         self.userAgent = userAgent
+        self.cache = cache
     }
 
     /// `IntelliNest/<app version> (+repo url)`, the descriptive agent LRCLIB requests.
@@ -62,9 +68,25 @@ final class LyricsApiService: LyricsService {
         guard title.isNotEmpty, artist.isNotEmpty else {
             return .notFound
         }
+        // Serve a previously-fetched track straight from the cache — no network.
+        let key = LyricsCache.key(title: title, artist: artist, album: album)
+        if let cached = await cache.value(forKey: key) {
+            return cached
+        }
         // One shared deadline for the whole chain so the spinner can't hang for the
         // sum of every provider's individual timeout.
         let deadline = Date().addingTimeInterval(Self.totalTimeout)
+        let result = await lookup(title: title, artist: artist, album: album,
+                                  durationSeconds: durationSeconds, deadline: deadline)
+        // `insert` ignores `.notFound`, so a miss stays retryable next time.
+        await cache.insert(result, forKey: key)
+        return result
+    }
+
+    /// Runs the provider fallback chain (LRCLIB get → search → lyrics.ovh) within the
+    /// shared `deadline`, returning the first hit or `.notFound`.
+    private func lookup(title: String, artist: String, album: String?,
+                        durationSeconds: Double?, deadline: Date) async -> LyricsResult {
         let primary = await fetchFromLRCLIB(title: title, artist: artist, album: album,
                                             durationSeconds: durationSeconds, deadline: deadline)
         if primary != .notFound {

--- a/IntelliNest/Services/LyricsCache.swift
+++ b/IntelliNest/Services/LyricsCache.swift
@@ -105,6 +105,10 @@ actor LyricsCache {
         guard let fileURL else {
             return
         }
+        // The default Caches directory always exists, but an injected one might not —
+        // create it first so the write doesn't silently fail and drop the cache.
+        try? FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
         let stored = lru.compactMap { key in entries[key].map { StoredEntry(key: key, result: $0) } }
         guard let data = try? JSONEncoder().encode(stored) else {
             return

--- a/IntelliNest/Services/LyricsCache.swift
+++ b/IntelliNest/Services/LyricsCache.swift
@@ -1,0 +1,119 @@
+//
+//  LyricsCache.swift
+//  IntelliNest
+//
+//  Created by Tobias on 2026-06-29.
+//
+
+import Foundation
+
+/// A small persistent cache of fetched lyrics, keyed by a normalized track key
+/// (title + artist + album). Lyrics for a track never change, so a hit is served
+/// without touching the network — instant on a re-open and across launches.
+///
+/// Backed by a single JSON file in the Caches directory. Only successful lookups
+/// are stored: a `.notFound` collapses transient failures and true misses, so it
+/// stays retryable (matching the fetch-side latch). Capacity-bounded with simple
+/// LRU eviction. An `actor` so the in-memory map and the file stay consistent off
+/// the main actor; all I/O is best-effort and never throws into the caller.
+actor LyricsCache {
+    private var entries: [String: LyricsResult] = [:]
+    /// Keys in least-recently-used order (oldest first) for capacity eviction.
+    private var lru: [String] = []
+    private let capacity: Int
+    private let fileURL: URL?
+    private var didLoad = false
+
+    /// `directory: nil` keeps the cache in memory only — used by tests and previews
+    /// so they never read or write the shared on-disk cache.
+    init(capacity: Int = 200,
+         directory: URL? = LyricsCache.defaultDirectory,
+         filename: String = "lyrics-cache.json") {
+        self.capacity = capacity
+        fileURL = directory?.appendingPathComponent(filename)
+    }
+
+    static var defaultDirectory: URL? {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+    }
+
+    /// A stable key from the track identity, normalized so trivial case/spacing
+    /// differences don't fragment the cache. The unit separator can't appear in the
+    /// fields, so a title can't collide with an artist.
+    static func key(title: String, artist: String, album: String?) -> String {
+        func normalized(_ value: String) -> String {
+            value.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return [normalized(title), normalized(artist), normalized(album ?? "")].joined(separator: "\u{1F}")
+    }
+
+    func value(forKey key: String) -> LyricsResult? {
+        loadIfNeeded()
+        guard let result = entries[key] else {
+            return nil
+        }
+        touch(key)
+        return result
+    }
+
+    func insert(_ result: LyricsResult, forKey key: String) {
+        // Never cache a miss — it must stay retryable so a transient failure doesn't
+        // permanently suppress a later successful lookup.
+        guard result != .notFound else {
+            return
+        }
+        loadIfNeeded()
+        entries[key] = result
+        touch(key)
+        evictIfNeeded()
+        persist()
+    }
+
+    private func touch(_ key: String) {
+        lru.removeAll { $0 == key }
+        lru.append(key)
+    }
+
+    private func evictIfNeeded() {
+        while lru.count > capacity, let oldest = lru.first {
+            lru.removeFirst()
+            entries[oldest] = nil
+        }
+    }
+
+    /// Loads the on-disk cache into memory once, on first access. A missing or
+    /// corrupt file simply starts the cache empty — never a crash.
+    private func loadIfNeeded() {
+        guard !didLoad else {
+            return
+        }
+        didLoad = true
+        guard let fileURL,
+              let data = try? Data(contentsOf: fileURL),
+              let stored = try? JSONDecoder().decode([StoredEntry].self, from: data) else {
+            return
+        }
+        for entry in stored {
+            entries[entry.key] = entry.result
+            lru.append(entry.key)
+        }
+    }
+
+    /// Writes the whole cache back to disk (LRU order preserved). Best-effort: a
+    /// failed write just means the next launch re-fetches.
+    private func persist() {
+        guard let fileURL else {
+            return
+        }
+        let stored = lru.compactMap { key in entries[key].map { StoredEntry(key: key, result: $0) } }
+        guard let data = try? JSONEncoder().encode(stored) else {
+            return
+        }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    private struct StoredEntry: Codable {
+        let key: String
+        let result: LyricsResult
+    }
+}

--- a/IntelliNestTests/LyricsApiServiceTests.swift
+++ b/IntelliNestTests/LyricsApiServiceTests.swift
@@ -150,7 +150,11 @@ final class LyricsCacheTests: XCTestCase {
     private var directory: URL!
 
     override func setUpWithError() throws {
-        directory = FileManager.default.temporaryDirectory.appendingPathComponent("lyrics-cache-tests")
+        // Per-test subdirectory (keyed by the deterministic test name, not a runtime
+        // UUID) so the persistence fixtures can't collide between tests.
+        let safeName = name.components(separatedBy: CharacterSet.alphanumerics.inverted).joined()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lyrics-cache-tests-\(safeName)", isDirectory: true)
         try? FileManager.default.removeItem(at: directory)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     }

--- a/IntelliNestTests/LyricsApiServiceTests.swift
+++ b/IntelliNestTests/LyricsApiServiceTests.swift
@@ -10,7 +10,11 @@ final class LyricsApiServiceTests: XCTestCase {
 
     override func setUp() {
         URLProtocolStub.startInterceptingRequests()
-        service = LyricsApiService(session: URLProtocolStub.createStubbedURLSession(), userAgent: userAgent)
+        // Memory-only cache (directory: nil) so tests never touch the shared on-disk
+        // cache and each gets a clean slate.
+        service = LyricsApiService(session: URLProtocolStub.createStubbedURLSession(),
+                                   userAgent: userAgent,
+                                   cache: LyricsCache(directory: nil))
     }
 
     override func tearDown() {
@@ -103,6 +107,22 @@ final class LyricsApiServiceTests: XCTestCase {
         XCTAssertEqual(result, .notFound)
     }
 
+    func testSecondLookupIsServedFromCacheWithoutRefetching() async {
+        stub(lrclibGetURL(duration: 233), json: """
+        {"duration":233,"plainLyrics":null,"syncedLyrics":"[00:01.00]Hello world"}
+        """)
+        let first = await service.fetchLyrics(title: title, artist: artist, album: nil, durationSeconds: 233)
+        XCTAssertEqual(first, .synced([LyricLine(time: 1.0, text: "Hello world")]))
+
+        // The provider now misses; a cached track must still resolve from the cache
+        // rather than fall through to the (now empty) network result.
+        stub(lrclibGetURL(duration: 233), json: "{}", statusCode: 404)
+        stub(lrclibSearchURL(), json: "[]")
+        stub(lyricsOvhURL(), json: "{}", statusCode: 404)
+        let second = await service.fetchLyrics(title: title, artist: artist, album: nil, durationSeconds: 233)
+        XCTAssertEqual(second, first, "a cached hit is served without re-fetching")
+    }
+
     func testSendsDescriptiveUserAgentToLRCLIB() async {
         let getURL = lrclibGetURL(duration: 233)
         let expectation = XCTestExpectation(description: "User-Agent on LRCLIB request")
@@ -117,5 +137,71 @@ final class LyricsApiServiceTests: XCTestCase {
         """)
         _ = await service.fetchLyrics(title: title, artist: artist, album: nil, durationSeconds: 233)
         await fulfillment(of: [expectation], timeout: 2.0)
+    }
+}
+
+// MARK: - LyricsCache
+
+final class LyricsCacheTests: XCTestCase {
+    private let synced = LyricsResult.synced([LyricLine(time: 1, text: "hi")])
+    private let plain = LyricsResult.plain("words")
+
+    // A fresh temp directory per test for the persistence cases, cleaned up after.
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent("lyrics-cache-tests")
+        try? FileManager.default.removeItem(at: directory)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    func testStoresAndReturnsAHit() async {
+        let cache = LyricsCache(directory: nil)
+        await cache.insert(synced, forKey: "k")
+        let value = await cache.value(forKey: "k")
+        XCTAssertEqual(value, synced)
+    }
+
+    func testDoesNotCacheNotFoundSoItStaysRetryable() async {
+        let cache = LyricsCache(directory: nil)
+        await cache.insert(.notFound, forKey: "k")
+        let value = await cache.value(forKey: "k")
+        XCTAssertNil(value)
+    }
+
+    func testKeyNormalizesCaseAndSurroundingWhitespace() {
+        let messy = LyricsCache.key(title: "  Bohemian Rhapsody ", artist: "QUEEN", album: nil)
+        let clean = LyricsCache.key(title: "bohemian rhapsody", artist: "queen", album: nil)
+        XCTAssertEqual(messy, clean)
+        // Album is part of the identity, so a different album is a different key.
+        XCTAssertNotEqual(clean, LyricsCache.key(title: "bohemian rhapsody", artist: "queen", album: "A Night at the Opera"))
+    }
+
+    func testEvictsTheLeastRecentlyUsedBeyondCapacity() async {
+        let cache = LyricsCache(capacity: 2, directory: nil)
+        await cache.insert(synced, forKey: "a")
+        await cache.insert(plain, forKey: "b")
+        // Touch "a" so "b" becomes the least-recently-used before "c" pushes one out.
+        _ = await cache.value(forKey: "a")
+        await cache.insert(synced, forKey: "c")
+        let aValue = await cache.value(forKey: "a")
+        let bValue = await cache.value(forKey: "b")
+        let cValue = await cache.value(forKey: "c")
+        XCTAssertEqual(aValue, synced, "the recently-used entry survives")
+        XCTAssertNil(bValue, "the least-recently-used entry is evicted")
+        XCTAssertEqual(cValue, synced)
+    }
+
+    func testPersistsAcrossInstances() async {
+        let first = LyricsCache(directory: directory)
+        await first.insert(synced, forKey: "k")
+        // A new instance over the same directory loads the entry from disk.
+        let second = LyricsCache(directory: directory)
+        let value = await second.value(forKey: "k")
+        XCTAssertEqual(value, synced, "a cached track survives a relaunch")
     }
 }


### PR DESCRIPTION
## What

Follow-up to the lyrics work (#168): lyrics now persist in a cache so a re-opened or
replayed track loads instantly — no network round-trip, even across app launches.

Before this, only the *currently playing* track was latched (`lyricsTrackKey`); flipping
to a song viewed earlier refetched from the providers.

## How

- New `LyricsCache` (`Services/LyricsCache.swift`): an `actor` holding an in-memory map
  backed by a single JSON file in the Caches directory.
  - Keyed by a normalized `title + artist + album` (lowercased/trimmed), so trivial
    case/spacing differences don't fragment the cache.
  - LRU-capped (200 tracks) to bound disk/memory.
  - Only **successful** lookups are stored — a `.notFound` stays retryable, matching the
    existing fetch-side latch.
  - All file I/O is best-effort (`try?`); a missing/corrupt file just starts empty.
- `LyricsApiService` consults the cache before the provider chain and stores the result
  after; injectable so tests/previews use a memory-only cache (`directory: nil`).
- Made `LyricsResult` / `LyricLine` `Codable` for persistence.

## Tests
- `LyricsCacheTests` — store/return, `.notFound` not cached, key normalization, LRU
  eviction, and persistence across instances (relaunch).
- `LyricsApiServiceTests` — a second lookup is served from the cache even after the
  providers start missing; existing tests use a memory-only cache.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent lyrics caching, so successful lookups can be reused across app launches.
  * Improved lyrics lookup reliability by keeping cached results available even if later network requests fail.

* **Bug Fixes**
  * Prevented failed lyric searches from being stored as permanent misses, allowing retries later.
  * Added support for saving and loading cached lyrics data without disrupting the app if cache data is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->