### PR TITLE
Added Pure 500 purifier and fixed the fan speed conversion

### DIFF
--- a/IntelliNest/Model/PurifierEntity.swift
+++ b/IntelliNest/Model/PurifierEntity.swift
@@ -11,9 +11,41 @@ struct PurifierEntity: Decodable {
     var speed: Double = 0
     var temperature: Double = 0
     var humidity: Int = 0
+    var pm25: Int = 0
     var isActive: Bool {
         fanMode != .off
     }
 
     init() {}
+}
+
+/// Maps a purifier's discrete fan levels to the Home Assistant `fan.set_percentage` scale and back.
+///
+/// The Wellbeing/Electrolux fans expose their speed as a percentage whose granularity is fixed by the
+/// device (`percentage_step`). The picker in the app works in whole levels (0 = off), so every level has
+/// to convert to the exact percentage the device rests on and every reported percentage has to snap back
+/// to the same level. `percentage(forLevel:)` and `level(forPercentage:)` are inverses over `0...levelCount`,
+/// which is what keeps the picker from jumping when the fan reports its state back.
+struct PurifierFanScale {
+    /// Number of usable manual fan levels (the picker shows `0...levelCount`).
+    let levelCount: Int
+    /// Percentage the device advances per level. Derived from the device's `percentage_step`.
+    let percentagePerLevel: Double
+
+    func percentage(forLevel level: Double) -> Double {
+        guard level > 0 else { return 0 }
+        let clamped = min(level, Double(levelCount))
+        return (clamped * percentagePerLevel).rounded()
+    }
+
+    func level(forPercentage percentage: Double) -> Double {
+        guard percentage > 0 else { return 0 }
+        let level = (percentage / percentagePerLevel).rounded()
+        return min(max(level, 0), Double(levelCount))
+    }
+
+    /// The original Pure has 9 manual speeds (percentage_step ≈ 11.11).
+    static let pure = PurifierFanScale(levelCount: 9, percentagePerLevel: 100.0 / 9.0)
+    /// Pure 500 has 3 usable manual speeds resting on 20 / 40 / 60 % (percentage_step 20, top steps clamp).
+    static let pure500 = PurifierFanScale(levelCount: 3, percentagePerLevel: 20)
 }

--- a/IntelliNest/Model/PurifierSpeed.swift
+++ b/IntelliNest/Model/PurifierSpeed.swift
@@ -5,7 +5,8 @@ struct PurifierSpeed: Decodable, EntityProtocol {
     var state = ""
     var nextUpdate = Date.now
     var isActive = false
-    var speed: Double
+    /// Raw Home Assistant fan percentage; the caller converts it to a level with the matching `PurifierFanScale`.
+    var percentage: Double
 
     enum CodingKeys: String, CodingKey {
         case entityId = "entity_id"
@@ -20,10 +21,10 @@ struct PurifierSpeed: Decodable, EntityProtocol {
         state = try container.decode(String.self, forKey: .state)
 
         let attributes = try container.decode(PurifierSpeedAttributes.self, forKey: .attributes)
-        speed = attributes.percentage.toFanSpeedTargetNumber
+        percentage = attributes.percentage ?? 0
     }
 }
 
 struct PurifierSpeedAttributes: Decodable {
-    let percentage: Double
+    let percentage: Double?
 }

--- a/IntelliNest/Utils/Constants/EntityId.swift
+++ b/IntelliNest/Utils/Constants/EntityId.swift
@@ -119,6 +119,12 @@ enum EntityId: String, Decodable, CaseIterable {
     case purifierTimerMode = "input_boolean.purifier_timer_mode"
     case resetPurifierTime = "input_datetime.reset_purifier_heater_time"
     case purifierSavedSpeed = "input_number.purifier_saved_speed"
+    /* Pure 500 */
+    case purifier500FanSpeed = "fan.wellbeing_pure_500_fanspeed"
+    case purifier500PM25 = "sensor.wellbeing_pure_500_pm2_5_approximate"
+    case purifier500TimerMode = "input_boolean.purifier_500_timer_mode"
+    case resetPurifier500Time = "input_datetime.reset_purifier_500_time"
+    case purifier500SavedSpeed = "input_number.purifier_500_saved_speed"
     /* Heaters */
     case heaterCorridor = "climate.varmepump"
     case heaterPlayroom = "climate.mellanrummet"

--- a/IntelliNest/Utils/Extensions/DoubleExtension.swift
+++ b/IntelliNest/Utils/Extensions/DoubleExtension.swift
@@ -29,37 +29,4 @@ extension Double {
         let roundedKilowWatt = (abs(kiloWatt) < 0.06 ? 0 : kiloWatt).roundedWithOneDecimal
         return roundedKilowWatt == 0 ? "\(Int(roundedKilowWatt))kW" : String(format: "%.1fkW", roundedKilowWatt)
     }
-
-    var toFanSpeedPercentage: Double {
-        if self == 0 {
-            0
-        } else if self == 1 {
-            11
-        } else {
-            (self + 2) * 10
-        }
-    }
-
-    var toFanSpeedTargetNumber: Double {
-        switch self {
-        case 11:
-            1
-        case 33:
-            2
-        case 44:
-            3
-        case 55:
-            4
-        case 66:
-            5
-        case 77:
-            6
-        case 88:
-            7
-        case 100:
-            8
-        default:
-            0
-        }
-    }
 }

--- a/IntelliNest/ViewModels/HeatersViewModel.swift
+++ b/IntelliNest/ViewModels/HeatersViewModel.swift
@@ -12,10 +12,12 @@ class HeatersViewModel: ObservableObject, Reloadable {
     @Published var heaterCorridor = HeaterEntity(entityId: .heaterCorridor)
     @Published var heaterPlayroom = HeaterEntity(entityId: .heaterPlayroom)
     @Published var purifier = PurifierEntity()
+    @Published var purifier500 = PurifierEntity()
     @Published var thermCorridor = Entity(entityId: .thermCorridor)
     @Published var resetCorridorHeaterTime = Entity(entityId: .resetCorridorHeaterTime)
     @Published var resetPlayroomHeaterTime = Entity(entityId: .resetPlayroomHeaterTime)
     @Published var resetPurifierTime = Entity(entityId: .resetPurifierTime)
+    @Published var resetPurifier500Time = Entity(entityId: .resetPurifier500Time)
     @Published var thermBedroom = Entity(entityId: .thermBedroom)
     @Published var thermGym = Entity(entityId: .thermGym)
     @Published var thermVince = Entity(entityId: .thermVince)
@@ -26,10 +28,20 @@ class HeatersViewModel: ObservableObject, Reloadable {
     @Published var heaterCorridorTimerMode = Entity(entityId: .heaterCorridorTimerMode)
     @Published var heaterPlayroomTimerMode = Entity(entityId: .heaterPlayroomTimerMode)
     @Published var purifierTimerMode = Entity(entityId: .purifierTimerMode)
+    @Published var purifier500TimerMode = Entity(entityId: .purifier500TimerMode)
 
     let entityIDs: [EntityId] = [.resetCorridorHeaterTime, .resetPlayroomHeaterTime, .heaterCorridorTimerMode, .heaterPlayroomTimerMode,
                                  .purifierTimerMode, .purifierFanSpeed, .purifierHumidity, .purifierTemperature, .purifierMode,
-                                 .resetPurifierTime]
+                                 .resetPurifierTime, .purifier500TimerMode, .purifier500FanSpeed, .purifier500PM25,
+                                 .resetPurifier500Time]
+
+    var purifierSubtitle: String {
+        "\(purifier.temperature)℃ - \(purifier.humidity)%"
+    }
+
+    var purifier500Subtitle: String {
+        "PM2.5 \(purifier500.pm25) µg/m³"
+    }
 
     var isReloading = false
 
@@ -54,7 +66,16 @@ class HeatersViewModel: ObservableObject, Reloadable {
                               domain: .fan,
                               action: .setPercentage,
                               dataKey: .percentage,
-                              dataValue: speed.toFanSpeedPercentage,
+                              dataValue: PurifierFanScale.pure.percentage(forLevel: speed),
+                              reloadTimes: 5)
+    }
+
+    func setPurifier500FanSpeed(_ speed: Double) {
+        restAPIService.update(entityID: .purifier500FanSpeed,
+                              domain: .fan,
+                              action: .setPercentage,
+                              dataKey: .percentage,
+                              dataValue: PurifierFanScale.pure500.percentage(forLevel: speed),
                               reloadTimes: 5)
     }
 
@@ -121,7 +142,17 @@ class HeatersViewModel: ObservableObject, Reloadable {
         toggleHeaterTimerMode(heaterEntityID: .purifierFanSpeed,
                               heaterTimerModeEntityID: purifierTimerMode.entityId,
                               dateEntity: resetPurifierTime,
-                              action: action)
+                              action: action,
+                              savedSpeed: (.purifierSavedSpeed, PurifierFanScale.pure.percentage(forLevel: purifier.speed)))
+    }
+
+    func togglePurifier500TimerMode() {
+        let action: Action = purifier500TimerMode.isActive ? .turnOff : .turnOn
+        toggleHeaterTimerMode(heaterEntityID: .purifier500FanSpeed,
+                              heaterTimerModeEntityID: purifier500TimerMode.entityId,
+                              dateEntity: resetPurifier500Time,
+                              action: action,
+                              savedSpeed: (.purifier500SavedSpeed, PurifierFanScale.pure500.percentage(forLevel: purifier500.speed)))
     }
 
     private lazy var entityKeyPaths: [EntityId: ReferenceWritableKeyPath<HeatersViewModel, Entity>] = [
@@ -130,14 +161,20 @@ class HeatersViewModel: ObservableObject, Reloadable {
         .heaterCorridorTimerMode: \.heaterCorridorTimerMode,
         .heaterPlayroomTimerMode: \.heaterPlayroomTimerMode,
         .resetPurifierTime: \.resetPurifierTime,
-        .purifierTimerMode: \.purifierTimerMode
+        .purifierTimerMode: \.purifierTimerMode,
+        .resetPurifier500Time: \.resetPurifier500Time,
+        .purifier500TimerMode: \.purifier500TimerMode
     ]
 
     private lazy var purifierReloaders: [EntityId: (String) -> Void] = [
         .purifierMode: { [unowned self] state in purifier.fanMode = PurifierFanMode(rawValue: state) ?? .off },
-        .purifierFanSpeed: { [unowned self] state in purifier.speed = Double(state)?.toFanSpeedTargetNumber ?? 0 },
+        .purifierFanSpeed: { [unowned self] state in purifier.speed = PurifierFanScale.pure.level(forPercentage: Double(state) ?? 0) },
         .purifierTemperature: { [unowned self] state in purifier.temperature = Double(state) ?? 0 },
-        .purifierHumidity: { [unowned self] state in purifier.humidity = Int(state) ?? 0 }
+        .purifierHumidity: { [unowned self] state in purifier.humidity = Int(state) ?? 0 },
+        .purifier500FanSpeed: { [unowned self] state in
+            purifier500.speed = PurifierFanScale.pure500.level(forPercentage: Double(state) ?? 0)
+        },
+        .purifier500PM25: { [unowned self] state in purifier500.pm25 = Int(Double(state) ?? 0) }
     ]
 
     func reload(entityID: EntityId, state: String) {
@@ -162,7 +199,14 @@ class HeatersViewModel: ObservableObject, Reloadable {
 }
 
 private extension HeatersViewModel {
-    func toggleHeaterTimerMode(heaterEntityID: EntityId, heaterTimerModeEntityID: EntityId, dateEntity: Entity, action: Action) {
+    /// Toggles a timer-mode helper. On enable it schedules the reset time 15 minutes out and snapshots the
+    /// current speed/state so a Home Assistant automation can restore it: purifiers save their fan percentage
+    /// into `savedSpeed`, heaters snapshot via the `saveClimateState` script.
+    func toggleHeaterTimerMode(heaterEntityID: EntityId,
+                               heaterTimerModeEntityID: EntityId,
+                               dateEntity: Entity,
+                               action: Action,
+                               savedSpeed: (entityID: EntityId, percentage: Double)? = nil) {
         var dateEntity = dateEntity
         restAPIService.update(entityID: heaterTimerModeEntityID, domain: .inputBoolean, action: action)
 
@@ -172,12 +216,12 @@ private extension HeatersViewModel {
             if let newDate = calendar.date(byAdding: .minute, value: 15, to: now) {
                 dateEntity.date = newDate
                 setClimateSchedule(dateEntity: dateEntity)
-                if heaterEntityID == .purifierFanSpeed {
-                    restAPIService.update(entityID: .purifierSavedSpeed,
+                if let savedSpeed {
+                    restAPIService.update(entityID: savedSpeed.entityID,
                                           domain: .inputNumber,
                                           action: .setValue,
                                           dataKey: .value,
-                                          dataValue: purifier.speed.toFanSpeedPercentage)
+                                          dataValue: savedSpeed.percentage)
                 } else {
                     restAPIService.callScript(scriptID: .saveClimateState, variables: [.entityID: heaterEntityID.rawValue])
                 }

--- a/IntelliNest/ViewModels/HeatersViewModelExtension.swift
+++ b/IntelliNest/ViewModels/HeatersViewModelExtension.swift
@@ -37,7 +37,10 @@ extension HeatersViewModel {
                 do {
                     if entityID == .purifierFanSpeed {
                         let purifierSpeed = try await self.restAPIService.reload(entityId: entityID, entityType: PurifierSpeed.self)
-                        self.purifier.speed = purifierSpeed.speed
+                        self.purifier.speed = PurifierFanScale.pure.level(forPercentage: purifierSpeed.percentage)
+                    } else if entityID == .purifier500FanSpeed {
+                        let purifierSpeed = try await self.restAPIService.reload(entityId: entityID, entityType: PurifierSpeed.self)
+                        self.purifier500.speed = PurifierFanScale.pure500.level(forPercentage: purifierSpeed.percentage)
                     } else {
                         let entity = try await self.restAPIService.reloadState(entityID: entityID)
                         self.reload(entityID: entityID, state: entity.state)

--- a/IntelliNest/Views/Dashboards/HeatersView.swift
+++ b/IntelliNest/Views/Dashboards/HeatersView.swift
@@ -43,11 +43,27 @@ struct HeatersView: View {
                                  setClimateScheduleTimeClosure: viewModel.setClimateSchedule)
                     .padding(.bottom)
                 Divider()
-                PurifierView(purifier: $viewModel.purifier,
+                PurifierView(title: "Luftrenare",
+                             subtitle: viewModel.purifierSubtitle,
+                             fanEntityId: .purifierFanSpeed,
+                             maxLevel: PurifierFanScale.pure.levelCount,
+                             currentLevel: viewModel.purifier.speed,
                              resetClimateTimeEntity: $viewModel.resetPurifierTime,
                              isTimerModeEnabled: viewModel.purifierTimerMode.isActive,
                              setFanSpeedClosure: viewModel.setPurifierFanSpeed,
                              toggleTimerModeClosure: viewModel.togglePurifierTimerMode,
+                             setClimateScheduleTimeClosure: viewModel.setClimateSchedule)
+                    .padding(.bottom)
+                Divider()
+                PurifierView(title: "Luftrenare 500",
+                             subtitle: viewModel.purifier500Subtitle,
+                             fanEntityId: .purifier500FanSpeed,
+                             maxLevel: PurifierFanScale.pure500.levelCount,
+                             currentLevel: viewModel.purifier500.speed,
+                             resetClimateTimeEntity: $viewModel.resetPurifier500Time,
+                             isTimerModeEnabled: viewModel.purifier500TimerMode.isActive,
+                             setFanSpeedClosure: viewModel.setPurifier500FanSpeed,
+                             toggleTimerModeClosure: viewModel.togglePurifier500TimerMode,
                              setClimateScheduleTimeClosure: viewModel.setClimateSchedule)
                     .padding(.bottom)
             }

--- a/IntelliNest/Views/Heater/PurifierView.swift
+++ b/IntelliNest/Views/Heater/PurifierView.swift
@@ -4,7 +4,11 @@ struct PurifierView: View {
     @State private var targetNumber: Double
     @Binding private var resetClimateTimeDate: Date
 
-    @Binding var purifier: PurifierEntity
+    let title: String
+    let subtitle: String
+    let fanEntityId: EntityId
+    let maxLevel: Int
+    let currentLevel: Double
     @Binding var resetClimateTimeEntity: Entity
     var isTimerModeEnabled: Bool
     let setFanSpeedClosure: DoubleClosure
@@ -20,19 +24,19 @@ struct PurifierView: View {
                     .padding(.horizontal, 4)
             }
             VStack {
-                INText("Luftrenare", font: .title)
-                INText("\(purifier.temperature)℃ - \(purifier.humidity)%", font: .subheadline)
+                INText(title, font: .title)
+                INText(subtitle, font: .subheadline)
 
                 ZStack(alignment: .center) {
                     VStack {
-                        NumberPickerScrollView(entityId: .purifierFanSpeed,
+                        NumberPickerScrollView(entityId: fanEntityId,
                                                targetNumber: $targetNumber,
                                                numberSelectedCallback: { _, targetNumber in
                                                    self.targetNumber = targetNumber
                                                    setFanSpeedClosure(targetNumber)
                                                },
                                                strideFrom: 0,
-                                               strideTo: 9,
+                                               strideTo: CGFloat(maxLevel + 1),
                                                strideStep: 1)
                             .padding(.vertical)
                     }
@@ -65,23 +69,34 @@ struct PurifierView: View {
             }
         }
         .onAppear {
-            targetNumber = purifier.speed
+            targetNumber = currentLevel
+        }
+        .onChange(of: currentLevel) {
+            targetNumber = currentLevel
         }
     }
 
-    init(purifier: Binding<PurifierEntity>,
+    init(title: String,
+         subtitle: String,
+         fanEntityId: EntityId,
+         maxLevel: Int,
+         currentLevel: Double,
          resetClimateTimeEntity: Binding<Entity>,
          isTimerModeEnabled: Bool,
          setFanSpeedClosure: @escaping DoubleClosure,
          toggleTimerModeClosure: @escaping VoidClosure,
          setClimateScheduleTimeClosure: @escaping MainActorEntityClosure) {
-        _purifier = purifier
+        self.title = title
+        self.subtitle = subtitle
+        self.fanEntityId = fanEntityId
+        self.maxLevel = maxLevel
+        self.currentLevel = currentLevel
         _resetClimateTimeEntity = resetClimateTimeEntity
         _resetClimateTimeDate = resetClimateTimeEntity.date
         self.isTimerModeEnabled = isTimerModeEnabled
         self.setFanSpeedClosure = setFanSpeedClosure
         self.toggleTimerModeClosure = toggleTimerModeClosure
         self.setClimateScheduleTimeClosure = setClimateScheduleTimeClosure
-        targetNumber = 0
+        targetNumber = currentLevel
     }
 }

--- a/IntelliNestTests/DoubleExtensionTests.swift
+++ b/IntelliNestTests/DoubleExtensionTests.swift
@@ -94,61 +94,59 @@ class DoubleExtensionTests: XCTestCase {
         XCTAssertEqual((-1000.0).toKWString, "-1.0kW")
     }
 
-    // MARK: - toFanSpeedPercentage
+    // MARK: - PurifierFanScale (original Pure, 9 speeds)
 
-    func testToFanSpeedPercentageZeroInput() {
-        XCTAssertEqual(0.0.toFanSpeedPercentage, 0.0)
+    func testPureFanScalePercentageForLevel() {
+        let cases: [(level: Double, percentage: Double)] = [
+            (0, 0), (1, 11), (2, 22), (3, 33), (4, 44), (5, 56), (6, 67), (7, 78), (8, 89), (9, 100)
+        ]
+        for testCase in cases {
+            XCTAssertEqual(PurifierFanScale.pure.percentage(forLevel: testCase.level), testCase.percentage,
+                           "Pure level \(testCase.level) should map to \(testCase.percentage)%")
+        }
     }
 
-    func testToFanSpeedPercentageOneInput() {
-        // 1 → 11 (special case)
-        XCTAssertEqual(1.0.toFanSpeedPercentage, 11.0)
+    func testPureFanScaleLevelForPercentage() {
+        // The device reports its own snapped percentages (multiples of 100/9); each maps back to its level.
+        let cases: [(percentage: Double, level: Double)] = [
+            (0, 0), (11, 1), (22, 2), (33, 3), (44, 4), (56, 5), (67, 6), (78, 7), (89, 8), (100, 9)
+        ]
+        for testCase in cases {
+            XCTAssertEqual(PurifierFanScale.pure.level(forPercentage: testCase.percentage), testCase.level,
+                           "Pure \(testCase.percentage)% should map to level \(testCase.level)")
+        }
     }
 
-    func testToFanSpeedPercentageTwoInput() {
-        // 2 → (2+2)*10 = 40
-        XCTAssertEqual(2.0.toFanSpeedPercentage, 40.0)
+    func testPureFanScaleRoundTripIsStable() {
+        for level in stride(from: 0.0, through: 9.0, by: 1) {
+            let percentage = PurifierFanScale.pure.percentage(forLevel: level)
+            XCTAssertEqual(PurifierFanScale.pure.level(forPercentage: percentage), level,
+                           "Pure round-trip broke for level \(level) (percentage \(percentage))")
+        }
     }
 
-    func testToFanSpeedPercentageThreeInput() {
-        // 3 → (3+2)*10 = 50
-        XCTAssertEqual(3.0.toFanSpeedPercentage, 50.0)
+    // MARK: - PurifierFanScale (Pure 500, 3 speeds)
+
+    func testPure500FanScalePercentageForLevel() {
+        let cases: [(level: Double, percentage: Double)] = [(0, 0), (1, 20), (2, 40), (3, 60)]
+        for testCase in cases {
+            XCTAssertEqual(PurifierFanScale.pure500.percentage(forLevel: testCase.level), testCase.percentage,
+                           "Pure 500 level \(testCase.level) should map to \(testCase.percentage)%")
+        }
     }
 
-    func testToFanSpeedPercentageEightInput() {
-        // 8 → (8+2)*10 = 100
-        XCTAssertEqual(8.0.toFanSpeedPercentage, 100.0)
+    func testPure500FanScaleClampsAboveMax() {
+        // The device only accepts Fanspeed 1-3, so the app never emits 80/100 % (which the API rejects with 406).
+        XCTAssertEqual(PurifierFanScale.pure500.percentage(forLevel: 4), 60)
+        XCTAssertEqual(PurifierFanScale.pure500.level(forPercentage: 80), 3)
+        XCTAssertEqual(PurifierFanScale.pure500.level(forPercentage: 100), 3)
     }
 
-    // MARK: - toFanSpeedTargetNumber
-
-    func testToFanSpeedTargetNumberKnownValues() {
-        XCTAssertEqual(11.0.toFanSpeedTargetNumber, 1.0)
-        XCTAssertEqual(33.0.toFanSpeedTargetNumber, 2.0)
-        XCTAssertEqual(44.0.toFanSpeedTargetNumber, 3.0)
-        XCTAssertEqual(55.0.toFanSpeedTargetNumber, 4.0)
-        XCTAssertEqual(66.0.toFanSpeedTargetNumber, 5.0)
-        XCTAssertEqual(77.0.toFanSpeedTargetNumber, 6.0)
-        XCTAssertEqual(88.0.toFanSpeedTargetNumber, 7.0)
-        XCTAssertEqual(100.0.toFanSpeedTargetNumber, 8.0)
-    }
-
-    func testToFanSpeedTargetNumberUnknownValueReturnsZero() {
-        XCTAssertEqual(0.0.toFanSpeedTargetNumber, 0.0)
-        XCTAssertEqual(50.0.toFanSpeedTargetNumber, 0.0)
-        XCTAssertEqual(99.0.toFanSpeedTargetNumber, 0.0)
-    }
-
-    // MARK: - toFanSpeedPercentage / toFanSpeedTargetNumber round-trip
-
-    // Verifies that converting a target number to percentage and back yields the original
-    func testFanSpeedRoundTripForKnownValues() {
-        // Target 1 → percentage 11 → target 1
-        XCTAssertEqual(1.0.toFanSpeedPercentage.toFanSpeedTargetNumber, 1.0)
-        // Target 2 → percentage 40 — note: 40 is not in the toFanSpeedTargetNumber switch,
-        // so this intentionally returns 0, revealing a gap in the mapping.
-        // This test documents the current (potentially incorrect) behavior:
-        XCTAssertEqual(2.0.toFanSpeedPercentage.toFanSpeedTargetNumber, 0.0,
-                       "toFanSpeedPercentage(2) = 40, but toFanSpeedTargetNumber has no case for 40 — round-trip is broken for speed 2")
+    func testPure500FanScaleRoundTripIsStable() {
+        for level in stride(from: 0.0, through: 3.0, by: 1) {
+            let percentage = PurifierFanScale.pure500.percentage(forLevel: level)
+            XCTAssertEqual(PurifierFanScale.pure500.level(forPercentage: percentage), level,
+                           "Pure 500 round-trip broke for level \(level) (percentage \(percentage))")
+        }
     }
 }

--- a/IntelliNestTests/HeatersViewModelTests.swift
+++ b/IntelliNestTests/HeatersViewModelTests.swift
@@ -42,6 +42,9 @@ class HeatersViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.purifier.speed, 0)
         XCTAssertEqual(viewModel.purifier.temperature, 0)
         XCTAssertEqual(viewModel.purifier.humidity, 0)
+        XCTAssertEqual(viewModel.purifier500TimerMode.state, "Loading")
+        XCTAssertEqual(viewModel.purifier500.speed, 0)
+        XCTAssertEqual(viewModel.purifier500.pm25, 0)
     }
 
     // MARK: - reload(entityID:state:)
@@ -84,20 +87,48 @@ class HeatersViewModelTests: XCTestCase {
     }
 
     func testReloadUpdatesPurifierFanSpeedKnownValue() {
-        // "11" → toFanSpeedTargetNumber → 1.0
+        // 11 % → PurifierFanScale.pure → level 1
         viewModel.reload(entityID: .purifierFanSpeed, state: "11")
         XCTAssertEqual(viewModel.purifier.speed, 1.0)
     }
 
-    func testReloadUpdatesPurifierFanSpeedUnknownValueZero() {
-        // "50" has no matching case in toFanSpeedTargetNumber → 0
+    func testReloadUpdatesPurifierFanSpeedRoundsToNearestLevel() {
+        // 50 % → level 5 (round(50 · 9 / 100)); the old lossy mapping wrongly returned 0 here.
         viewModel.reload(entityID: .purifierFanSpeed, state: "50")
-        XCTAssertEqual(viewModel.purifier.speed, 0.0)
+        XCTAssertEqual(viewModel.purifier.speed, 5.0)
     }
 
     func testReloadUpdatesPurifierFanSpeedInvalidStringZero() {
         viewModel.reload(entityID: .purifierFanSpeed, state: "not-a-number")
         XCTAssertEqual(viewModel.purifier.speed, 0.0)
+    }
+
+    func testReloadUpdatesPurifier500FanSpeed() {
+        // 40 % → PurifierFanScale.pure500 → level 2
+        viewModel.reload(entityID: .purifier500FanSpeed, state: "40")
+        XCTAssertEqual(viewModel.purifier500.speed, 2.0)
+    }
+
+    func testReloadUpdatesPurifier500FanSpeedClampsAboveMax() {
+        // 100 % would map to level 5, but Pure 500 has only 3 levels, so it clamps to 3.
+        viewModel.reload(entityID: .purifier500FanSpeed, state: "100")
+        XCTAssertEqual(viewModel.purifier500.speed, 3.0)
+    }
+
+    func testReloadUpdatesPurifier500PM25() {
+        viewModel.reload(entityID: .purifier500PM25, state: "7")
+        XCTAssertEqual(viewModel.purifier500.pm25, 7)
+    }
+
+    func testReloadUpdatesPurifier500TimerMode() {
+        viewModel.reload(entityID: .purifier500TimerMode, state: "on")
+        XCTAssertEqual(viewModel.purifier500TimerMode.state, "on")
+        XCTAssertTrue(viewModel.purifier500TimerMode.isActive)
+    }
+
+    func testReloadUpdatesResetPurifier500Time() {
+        viewModel.reload(entityID: .resetPurifier500Time, state: "2023-06-17T12:00:00")
+        XCTAssertEqual(viewModel.resetPurifier500Time.state, "2023-06-17T12:00:00")
     }
 
     func testReloadUpdatesPurifierTemperature() {
@@ -182,39 +213,33 @@ class HeatersViewModelTests: XCTestCase {
     // MARK: - Network Reload (entityIDs loop only — therm async let bypassed in CI)
 
     func testReloadFetchesEntityIDEntitiesFromNetwork() async {
-        // Stub all entityIDs except purifierFanSpeed (tested separately)
-        for entityID in viewModel.entityIDs where entityID != .purifierFanSpeed {
+        // Stub all entityIDs except the two fan speeds (they need attributes JSON, stubbed below)
+        for entityID in viewModel.entityIDs where entityID != .purifierFanSpeed && entityID != .purifier500FanSpeed {
             stubEntityURL(entityID: entityID, state: "on")
         }
-        // purifierFanSpeed requires attributes JSON
-        let purifierData = makeEntityJSON(
-            entityId: EntityId.purifierFanSpeed.rawValue,
-            state: "100",
-            attributes: ["percentage": 100.0]
-        )
-        stubEntityURL(entityID: .purifierFanSpeed, data: purifierData)
+        stubFanSpeed(.purifierFanSpeed, percentage: 100.0)
+        stubFanSpeed(.purifier500FanSpeed, percentage: 40.0)
 
         await viewModel.reload()
 
         XCTAssertEqual(viewModel.heaterCorridorTimerMode.state, "on")
         XCTAssertEqual(viewModel.heaterPlayroomTimerMode.state, "on")
         XCTAssertEqual(viewModel.purifierTimerMode.state, "on")
+        XCTAssertEqual(viewModel.purifier500TimerMode.state, "on")
         XCTAssertEqual(viewModel.resetCorridorHeaterTime.state, "on")
         XCTAssertEqual(viewModel.resetPlayroomHeaterTime.state, "on")
-        XCTAssertEqual(viewModel.purifier.speed, 8.0)
+        XCTAssertEqual(viewModel.purifier.speed, 9.0)
+        XCTAssertEqual(viewModel.purifier500.speed, 2.0)
     }
 
     func testReloadFetchesPurifierSpeed() async {
-        let purifierData = makeEntityJSON(
-            entityId: EntityId.purifierFanSpeed.rawValue,
-            state: "100",
-            attributes: ["percentage": 100.0]
-        )
-        stubEntityURL(entityID: .purifierFanSpeed, data: purifierData)
+        stubFanSpeed(.purifierFanSpeed, percentage: 100.0)
+        stubFanSpeed(.purifier500FanSpeed, percentage: 60.0)
 
         await viewModel.reload()
 
-        XCTAssertEqual(viewModel.purifier.speed, 8.0)
+        XCTAssertEqual(viewModel.purifier.speed, 9.0)
+        XCTAssertEqual(viewModel.purifier500.speed, 3.0)
     }
 
     func testReloadSilentlyHandlesNetworkFailure() async {
@@ -228,15 +253,11 @@ class HeatersViewModelTests: XCTestCase {
     // MARK: - Concurrent Reload Guard
 
     func testReloadGuard_preventsConcurrentReload() async {
-        for entityID in viewModel.entityIDs where entityID != .purifierFanSpeed {
+        for entityID in viewModel.entityIDs where entityID != .purifierFanSpeed && entityID != .purifier500FanSpeed {
             stubEntityURL(entityID: entityID, state: "on", delay: 0.05)
         }
-        let purifierData = makeEntityJSON(
-            entityId: EntityId.purifierFanSpeed.rawValue,
-            state: "100",
-            attributes: ["percentage": 100.0]
-        )
-        stubEntityURL(entityID: .purifierFanSpeed, data: purifierData)
+        stubFanSpeed(.purifierFanSpeed, percentage: 100.0)
+        stubFanSpeed(.purifier500FanSpeed, percentage: 40.0)
 
         let lock = NSLock()
         var requestCount = 0
@@ -253,5 +274,12 @@ class HeatersViewModelTests: XCTestCase {
 
         XCTAssertLessThanOrEqual(requestCount, viewModel.entityIDs.count,
                                  "Concurrent guard failed: \(requestCount) requests > \(viewModel.entityIDs.count)")
+    }
+
+    // MARK: - Helpers
+
+    private func stubFanSpeed(_ entityID: EntityId, percentage: Double) {
+        let data = makeEntityJSON(entityId: entityID.rawValue, state: "on", attributes: ["percentage": percentage])
+        stubEntityURL(entityID: entityID, data: data)
     }
 }

--- a/IntelliNestTests/HeatersViewModelTests.swift
+++ b/IntelliNestTests/HeatersViewModelTests.swift
@@ -276,6 +276,22 @@ class HeatersViewModelTests: XCTestCase {
                                  "Concurrent guard failed: \(requestCount) requests > \(viewModel.entityIDs.count)")
     }
 
+    // MARK: - PurifierSpeed decoding
+
+    func testPurifierSpeedDecodesPercentage() throws {
+        let data = makeEntityJSON(entityId: EntityId.purifier500FanSpeed.rawValue, state: "on", attributes: ["percentage": 40.0])
+        let decoded = try JSONDecoder().decode(PurifierSpeed.self, from: data)
+        XCTAssertEqual(decoded.entityId, .purifier500FanSpeed)
+        XCTAssertEqual(decoded.percentage, 40.0)
+    }
+
+    func testPurifierSpeedDefaultsPercentageToZeroWhenAbsent() throws {
+        // A fan that is off reports no percentage; the optional attribute must fall back to 0, not throw.
+        let data = makeEntityJSON(entityId: EntityId.purifier500FanSpeed.rawValue, state: "off", attributes: [:])
+        let decoded = try JSONDecoder().decode(PurifierSpeed.self, from: data)
+        XCTAssertEqual(decoded.percentage, 0)
+    }
+
     // MARK: - Helpers
 
     private func stubFanSpeed(_ entityID: EntityId, percentage: Double) {


### PR DESCRIPTION
## Pure 500 air purifier

Adds the new Electrolux **Pure 500** below the existing Pure on the Värmepumpar screen
(`Luftrenare 500`), with the same fan-speed picker and boost-timer behaviour.

- 3 manual fan levels (the device only supports Fanspeed 1–3 → 20 / 40 / 60 %).
- PM2.5 subtitle (Pure 500 has no temperature/humidity sensor, unlike the original Pure).
- Timer mode reuses the shared mechanism via new HA helpers
  (`input_boolean.purifier_500_timer_mode`, `input_datetime.reset_purifier_500_time`,
  `input_number.purifier_500_saved_speed`) plus new branches in the
  `Reset Heaters Based on Time` automation.

## Fixed the fan-level ↔ percentage conversion

The old `toFanSpeedPercentage` / `toFanSpeedTargetNumber` (in `DoubleExtension`) were not
inverses: picking Pure level 2 sent 40 %, which the 9-speed device snapped to 44 % and read
back as level 3; device speed 22 % read back as level 0. Replaced both with a single
`PurifierFanScale` (in `PurifierEntity.swift`) that is a true round-trip-stable inverse, and
expanded the Pure picker to its real 9 speeds (0–9). `Pure = 9 levels`, `Pure 500 = 3 levels`.

## Note on the wellbeing integration (not fixed here, by request)

Electrolux's API reports the Pure 500's `Fanspeed` as `min 1, max 3`, but the `wellbeing`
HACS integration hardcodes `speed_range = (1, 5)` for the Muju model. That is why HA's native
fan card 406s on 80 %/100 % and the turn-on button 406s (its default speed maps to Fanspeed 0).
The app sidesteps all of this — it only ever emits 20/40/60 % (Fanspeed 1/2/3) and `turn_off`.

## Verification

- Confirmed the device's real speeds directly against `api.developer.electrolux.one`
  (Fanspeed 1/2/3 → 200, 4 → 406 "Integer out of range").
- Unit tests: `PurifierFanScale` round-trip for both scales + Pure 500 reload/speed/timer.
- SwiftFormat + SwiftLint `--strict` clean; full test target green.
- Screenshots rendered (fan picker and DatePicker are ImageRenderer artifacts, not bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRsr6gtFF9zpuoThgWJHzY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a second purifier model with its own fan controls, timer settings, and status display.
  * Introduced PM2.5 readings for purifier devices.

* **Improvements**
  * Fan speed now follows the device’s reported percentage more accurately across supported speed levels.
  * Purifier controls now adapt to each model’s available speed range.

* **Bug Fixes**
  * Improved handling of purifier fan-speed updates, including clamping and safer defaults when values are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->