### PR TITLE
Fixed purifier fan picker snapping back on the slow reload

### DIFF
--- a/IntelliNest/Views/Heater/PurifierView.swift
+++ b/IntelliNest/Views/Heater/PurifierView.swift
@@ -71,9 +71,6 @@ struct PurifierView: View {
         .onAppear {
             targetNumber = currentLevel
         }
-        .onChange(of: currentLevel) {
-            targetNumber = currentLevel
-        }
     }
 
     init(title: String,


### PR DESCRIPTION
## Problem

On the Pure 500, selecting fan **level 3** appeared not to work (1 and 2 were fine).

Root cause is a regression from #170: `PurifierView` gained an `.onChange(of: currentLevel)`
that forced the picker to whatever the 5-second reload reported. The Electrolux Pure 500 is
very laggy (verified directly against the appliance API — a speed change can take 2–3 minutes
to reflect), so after tapping level 3 (→ 60 %, Fanspeed 3, which the device *does* accept and
hold), the reload kept reading the old lower speed for minutes and yanked the picker back down.
Level 3 has the longest climb, so it was hit hardest; 1 and 2 usually settled before it showed.

## Fix

Removed the `onChange`, restoring the original behaviour: the picker syncs from state on
`onAppear` and otherwise holds the user's selection (this is how the original Pure card always
worked). Applies to both Pure and Pure 500.

## Verification

- Confirmed against `api.developer.electrolux.one` that the appliance accepts and holds
  Fanspeed 3, and that its reported state lags 2–3 minutes — i.e. the device was never the
  problem, the picker was being reset out from under the user.
- SwiftFormat + SwiftLint `--strict` clean; test target green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRsr6gtFF9zpuoThgWJHzY