### PR TITLE
ci: run iOS build/test on the self-hosted fleet, not macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ env:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: macos-latest
+    # Runs on the self-hosted macOS fleet, like the other iOS repos, instead of
+    # GitHub-hosted macos-latest (10x-billed, per-job minute rounding).
+    runs-on: [self-hosted, macOS, arm64]
     timeout-minutes: 30
     permissions:
       contents: write


### PR DESCRIPTION
Move `build-and-test` off GitHub-hosted `macos-latest` onto the self-hosted macOS runners the other iOS repos already use.

Hosted macOS bills at **10x** with per-job minute rounding. This repo is public (so it draws from the free unlimited pool rather than the 2000-min quota), but keeping iOS CI on our own fleet matches the other iOS repos and avoids depending on GitHub-hosted macOS capacity.

## Change
- `runs-on: macos-latest` → `[self-hosted, macOS, arm64]`

## Note
The runner needs `xcbeautify`, `swiftlint`, `python3`, and an available iPhone simulator — all present on the self-hosted Macs. The existing `brew install xcbeautify swiftlint` step is a no-op when they're already installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI build-and-test job to run on a different macOS runner setup.
  * Added notes to clarify the runner choice for future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->