### PR TITLE
ci: revert to macos-latest (no self-hosted runner; public repo = free minutes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ env:
 jobs:
   build-and-test:
     name: Build and Test
-    # Runs on the self-hosted macOS fleet, like the other iOS repos, instead of
-    # GitHub-hosted macos-latest (10x-billed, per-job minute rounding).
-    runs-on: [self-hosted, macOS, arm64]
+    # GitHub-hosted, not the self-hosted fleet: this repo is public, so hosted
+    # minutes are free (no quota to protect), and it has no self-hosted runner
+    # registered — running here also keeps untrusted fork-PR code off our Macs.
+    runs-on: macos-latest
     timeout-minutes: 30
     permissions:
       contents: write


### PR DESCRIPTION
Reverts the runner move from #172. That change set `runs-on: [self-hosted, macOS, arm64]`, but **no self-hosted runner is registered to this repo** — personal-account runners are per-repository, and IntelliNest never had one — so jobs queued indefinitely (the post-merge `main` run sat queued 15+ min and was cancelled).

This repo is **public**, so GitHub-hosted `macos-latest` minutes are **free** (never counted against the 2000-min quota). There was no cost to avoid here, and hosted runners also keep untrusted fork-PR code off our Macs.

## Change
- `runs-on: [self-hosted, macOS, arm64]` → `macos-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)