### PR TITLE
Made purifier fan commands fire-and-forget and marked the confirmed level

### DIFF
--- a/IntelliNest/Services/RestAPIService+PostRequest.swift
+++ b/IntelliNest/Services/RestAPIService+PostRequest.swift
@@ -1,18 +1,25 @@
 import Foundation
 
 extension RestAPIService {
-    func sendPostRequest(customPath: String? = nil, json: [JSONKey: Any]?, domain: Domain, action: Action) async {
+    /// Sends a service-call POST.
+    ///
+    /// - Parameter fireAndForget: when `true`, the request is sent once with no external-URL failover and any
+    ///   failure is logged instead of raising the error banner. Use it for eventually-consistent commands whose
+    ///   true state the reload loop reflects anyway — e.g. the Wellbeing purifier fans, whose integration holds the
+    ///   HTTP response ~20 s (a `sleep` + cloud re-poll) even though the command itself lands in the first second.
+    ///   Waiting on and retrying that long-held connection is what surfaced 500 / -1005 errors and double-fired the
+    ///   command.
+    func sendPostRequest(customPath: String? = nil,
+                         json: [JSONKey: Any]?,
+                         domain: Domain,
+                         action: Action,
+                         fireAndForget: Bool = false) async {
         let path: String = if let customPath {
             customPath
         } else {
             "/api/services/\(domain.rawValue)/\(action.rawValue)"
         }
-        let errorBannerTitle = "Misslyckades med att skicka request"
-        let errorBannerMessageEnd = "(\(domain.rawValue), \(action.rawValue))"
-        var jsonData: Data?
-        if let json {
-            jsonData = createJSONData(json: json)
-        }
+        let jsonData: Data? = json.flatMap { createJSONData(json: $0) }
 
         guard let request = createURLRequest(path: path,
                                              jsonData: jsonData,
@@ -21,30 +28,53 @@ extension RestAPIService {
             return
         }
 
-        var (statusCodeExternal, externalData): (Int, Data?) = (-1, nil)
         let (statusCode, data) = await sendRequest(request)
-        let url = request.url?.absoluteString ?? ""
-        if statusCode != statusCodeOK {
-            if !url.contains(GlobalConstants.baseExternalUrlString) {
-                guard let request = createURLRequest(shouldForceExternalURL: true, path: path, jsonData: jsonData, method: .post) else {
-                    logCreateRequestFailed(path: path, domain: domain, action: action, json: json, jsonData: jsonData)
-                    setErrorBannerText("Misslyckades med att skapa external http request", "POST: \(path). \(statusCode.errorDescription)")
-                    return
-                }
+        if statusCode == statusCodeOK {
+            if let data {
+                handleSuccessfulResponse(domain: domain, action: action, data: data)
+            }
+            return
+        }
 
-                (statusCodeExternal, externalData) = await sendRequest(request)
-                if statusCodeExternal != statusCodeOK {
-                    setErrorBannerText(errorBannerTitle, "\(statusCodeExternal.errorDescription) \(errorBannerMessageEnd)")
-                } else if let externalData {
-                    handleSuccessfulResponse(domain: domain, action: action, data: externalData)
-                }
+        if fireAndForget {
+            Log.error("Fire-and-forget POST failed (\(domain.rawValue), \(action.rawValue)): \(statusCode.errorDescription)")
+            return
+        }
+
+        let context = PostRetryContext(path: path,
+                                       jsonData: jsonData,
+                                       domain: domain,
+                                       action: action,
+                                       primaryURL: request.url?.absoluteString ?? "",
+                                       primaryStatusCode: statusCode)
+        await retryOnExternalURL(context: context)
+    }
+
+    /// Failover path when the primary POST failed: retry on the external URL, otherwise surface the error banner.
+    private func retryOnExternalURL(context: PostRetryContext) async {
+        let errorBannerTitle = "Misslyckades med att skicka request"
+        let errorBannerMessageEnd = "(\(context.domain.rawValue), \(context.action.rawValue))"
+
+        guard !context.primaryURL.contains(GlobalConstants.baseExternalUrlString) else {
+            setErrorBannerText(errorBannerTitle, "\(context.primaryStatusCode.errorDescription) \(errorBannerMessageEnd)")
+            return
+        }
+        guard let request = createURLRequest(shouldForceExternalURL: true, path: context.path,
+                                             jsonData: context.jsonData, method: .post) else {
+            logCreateRequestFailed(path: context.path, domain: context.domain, action: context.action,
+                                   json: nil, jsonData: context.jsonData)
+            setErrorBannerText("Misslyckades med att skapa external http request",
+                               "POST: \(context.path). \(context.primaryStatusCode.errorDescription)")
+            return
+        }
+
+        let (statusCodeExternal, externalData) = await sendRequest(request)
+        if statusCodeExternal == statusCodeOK {
+            if let externalData {
+                handleSuccessfulResponse(domain: context.domain, action: context.action, data: externalData)
             }
-            if statusCode != statusCodeOK, statusCodeExternal != statusCodeOK {
-                let errorCode = statusCode != statusCodeOK ? statusCode : statusCodeExternal
-                setErrorBannerText(errorBannerTitle, "\(errorCode.errorDescription) \(errorBannerMessageEnd)")
-            }
-        } else if let data {
-            handleSuccessfulResponse(domain: domain, action: action, data: data)
+        } else {
+            setErrorBannerText(errorBannerTitle, "\(statusCodeExternal.errorDescription) \(errorBannerMessageEnd)")
         }
     }
 
@@ -73,6 +103,15 @@ extension RestAPIService {
             }
         }
     }
+}
+
+private struct PostRetryContext {
+    let path: String
+    let jsonData: Data?
+    let domain: Domain
+    let action: Action
+    let primaryURL: String
+    let primaryStatusCode: Int
 }
 
 private extension Int {

--- a/IntelliNest/Services/RestAPIService.swift
+++ b/IntelliNest/Services/RestAPIService.swift
@@ -329,12 +329,13 @@ extension RestAPIService {
         }
     }
 
-    func update(entityID: EntityId, domain: Domain, action: Action, dataKey: JSONKey, dataValue: Double, reloadTimes: Int = 1) {
+    func update(entityID: EntityId, domain: Domain, action: Action, dataKey: JSONKey, dataValue: Double,
+                reloadTimes: Int = 1, fireAndForget: Bool = false) {
         Task {
             var json = [JSONKey: Any]()
             json[.entityID] = entityID.rawValue
             json[dataKey] = dataValue
-            await sendPostRequest(json: json, domain: domain, action: action)
+            await sendPostRequest(json: json, domain: domain, action: action, fireAndForget: fireAndForget)
             repeatReloadAction(reloadTimes)
         }
     }

--- a/IntelliNest/ViewModels/HeatersViewModel.swift
+++ b/IntelliNest/ViewModels/HeatersViewModel.swift
@@ -67,7 +67,8 @@ class HeatersViewModel: ObservableObject, Reloadable {
                               action: .setPercentage,
                               dataKey: .percentage,
                               dataValue: PurifierFanScale.pure.percentage(forLevel: speed),
-                              reloadTimes: 5)
+                              reloadTimes: 5,
+                              fireAndForget: true)
     }
 
     func setPurifier500FanSpeed(_ speed: Double) {
@@ -76,7 +77,8 @@ class HeatersViewModel: ObservableObject, Reloadable {
                               action: .setPercentage,
                               dataKey: .percentage,
                               dataValue: PurifierFanScale.pure500.percentage(forLevel: speed),
-                              reloadTimes: 5)
+                              reloadTimes: 5,
+                              fireAndForget: true)
     }
 
     func setHvacMode(heater: HeaterEntity, hvacMode: HvacMode) {

--- a/IntelliNest/Views/Components/NumberPickerScrollView.swift
+++ b/IntelliNest/Views/Components/NumberPickerScrollView.swift
@@ -16,6 +16,7 @@ struct NumberPickerScrollView: View {
     let strideFrom: CGFloat
     let strideTo: CGFloat
     let strideStep: CGFloat
+    var confirmedNumber: Double?
 
     static let numberFormat: NumberFormatter = {
         let numberFormatter = NumberFormatter()
@@ -37,7 +38,8 @@ struct NumberPickerScrollView: View {
                                            targetTemperature: $targetNumber,
                                            selectedNewTarget: $selectedNewNumber,
                                            index: index,
-                                           numberPickerFormat: NumberPickerScrollView.numberFormat)
+                                           numberPickerFormat: NumberPickerScrollView.numberFormat,
+                                           confirmedNumber: confirmedNumber)
                             Rectangle()
                                 .padding([.top, .bottom], 14)
                                 .frame(width: 2)
@@ -70,7 +72,8 @@ struct NumberPickerScrollView: View {
          selectedNewNumber: Bool = false,
          strideFrom: CGFloat = 16,
          strideTo: CGFloat = 29,
-         strideStep: CGFloat = 0.5) {
+         strideStep: CGFloat = 0.5,
+         confirmedNumber: Double? = nil) {
         self.entityId = entityId
         _targetNumber = targetNumber
         self.numberSelectedCallback = numberSelectedCallback
@@ -79,6 +82,7 @@ struct NumberPickerScrollView: View {
         self.strideFrom = strideFrom
         self.strideTo = strideTo
         self.strideStep = strideStep
+        self.confirmedNumber = confirmedNumber
     }
 }
 

--- a/IntelliNest/Views/Heater/NumberTextView.swift
+++ b/IntelliNest/Views/Heater/NumberTextView.swift
@@ -13,6 +13,10 @@ struct NumberTextView: View {
     @Binding var selectedNewTarget: Bool
     var index: Double
     let numberPickerFormat: NumberFormatter
+    /// The value the backend confirms is actually set. When it matches this tile, a dot marks it so the user
+    /// can see the real state catch up to their selection (used by the slow-to-apply purifier fans).
+    var confirmedNumber: Double?
+
     var body: some View {
         Text("\(index as NSNumber, formatter: numberPickerFormat)")
             .id(index)
@@ -23,6 +27,14 @@ struct NumberTextView: View {
                 targetTemperature = index
             })
             .foregroundColor(targetTemperature == index ? .white : .white.opacity(0.667))
+            .overlay(alignment: .bottom) {
+                if confirmedNumber == index {
+                    Circle()
+                        .fill(Color.lightBlue)
+                        .frame(width: 6, height: 6)
+                        .offset(y: 7)
+                }
+            }
     }
 }
 

--- a/IntelliNest/Views/Heater/PurifierView.swift
+++ b/IntelliNest/Views/Heater/PurifierView.swift
@@ -37,7 +37,8 @@ struct PurifierView: View {
                                                },
                                                strideFrom: 0,
                                                strideTo: CGFloat(maxLevel + 1),
-                                               strideStep: 1)
+                                               strideStep: 1,
+                                               confirmedNumber: currentLevel)
                             .padding(.vertical)
                     }
 

--- a/IntelliNestTests/RestAPIServiceTests.swift
+++ b/IntelliNestTests/RestAPIServiceTests.swift
@@ -161,6 +161,43 @@ class RestAPIServiceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(errorBannerCallCount, 1, "Error banner should be shown when both POST URLs fail")
     }
 
+    func testSendPostRequest_fireAndForget_doesNotSetErrorBannerOnFailure() async {
+        // No stubs — the POST fails; fire-and-forget must swallow it instead of alarming the user.
+        var errorBannerCallCount = 0
+        let localService = RestAPIService(
+            urlCreator: urlCreator,
+            session: URLProtocolStub.createStubbedURLSession(),
+            setErrorBannerText: { _, _ in errorBannerCallCount += 1 },
+            repeatReloadAction: { _ in }
+        )
+
+        await localService.sendPostRequest(json: [.entityID: EntityId.purifier500FanSpeed.rawValue],
+                                           domain: .fan, action: .setPercentage, fireAndForget: true)
+
+        XCTAssertEqual(errorBannerCallCount, 0, "fire-and-forget must not raise the error banner")
+    }
+
+    func testSendPostRequest_fireAndForget_doesNotRetryExternalURL() async {
+        // Internal returns 500; fire-and-forget must send exactly one POST (no external re-fire).
+        var components = URLComponents(string: GlobalConstants.baseInternalUrlString)!
+        components.path = "/api/services/fan/set_percentage"
+        let url = components.url!
+        let response = HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)!
+        URLProtocolStub.setStub(for: url, data: nil, response: response, error: nil)
+
+        let lock = NSLock()
+        var postCount = 0
+        URLProtocolStub.observerRequests { request in
+            guard request.httpMethod == "POST" else { return }
+            lock.lock(); postCount += 1; lock.unlock()
+        }
+
+        await restAPIService.sendPostRequest(json: [.entityID: EntityId.purifier500FanSpeed.rawValue],
+                                             domain: .fan, action: .setPercentage, fireAndForget: true)
+
+        XCTAssertEqual(postCount, 1, "fire-and-forget must send exactly one POST (no external retry)")
+    }
+
     // MARK: - sendRequest tests
 
     func testSendRequest_nonHTTPResponse_returnsBadResponse() async {


### PR DESCRIPTION
## Problem

Changing a purifier fan level surfaced **500** and **-1005** error banners. Cause: the `wellbeing`
integration holds the `fan.set_percentage` HTTP response for ~20 s (`sleep(10)` + a cloud re-poll)
even though the command lands in the first second. Waiting on that long-held connection intermittently
500s (Electrolux hiccup) or drops the socket (-1005, `NSURLErrorNetworkConnectionLost`), and the app
then re-fired the whole command on the external URL and raised an alarming, non-actionable banner.

## Changes

**1. Fire-and-forget for the purifier fans.** `sendPostRequest` gains a `fireAndForget` flag: one
attempt, no external-URL re-fire, failures logged instead of bannered. `setPurifierFanSpeed` /
`setPurifier500FanSpeed` use it. The command still lands; the 5-second reload loop is the source of
truth for the real state. (The external-retry/banner path was also extracted into a helper for the
complexity budget; behaviour is otherwise unchanged for every other call.)

**2. Confirmed-level indicator in the picker.** Because the appliance can take 1–2 minutes to actually
apply a speed, the picker now shows a small dot under the level the **backend** reports. Your selection
is the large centred number; when the dot slides under it, the fan has really reached it. Purely
additive — `NumberTextView` / `NumberPickerScrollView` take an optional `confirmedNumber` (nil for the
heater temperature pickers, so they are unaffected).

## Verification

- Reproduced the 21 s hold directly against Home Assistant and confirmed the appliance honours every
  speed (1/2/3) given the lag — it was never a logic bug, just the connection being held too long.
- New tests: `sendPostRequest` fire-and-forget swallows failures (no banner) and sends exactly one POST
  (no external retry).
- SwiftFormat + SwiftLint `--strict` clean; test target green. Confirmed-dot verified by rendering the
  real `NumberTextView` tiles (the scrolling picker itself can't be rasterised by ImageRenderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRsr6gtFF9zpuoThgWJHzY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “fire-and-forget” update mode for selected actions, letting some updates send without triggering retry/failover behavior.
  * Added visual confirmation in the number picker to show when the backend has accepted the selected value.

* **Bug Fixes**
  * Improved handling of failed POST requests so certain updates no longer surface unnecessary fallback behavior.
  * Purifier fan speed controls now use the new update mode for smoother interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->