### PR TITLE
Moved the speaker picker out of the now-playing card into a dismissable sheet

### DIFF
--- a/IntelliNest/ViewModels/MusicViewModel.swift
+++ b/IntelliNest/ViewModels/MusicViewModel.swift
@@ -46,6 +46,10 @@ class MusicViewModel: ObservableObject, Reloadable {
     /// MA queue entity has gone stale (playback started outside the app's queue).
     @Published var hardwareTwins: [EntityId: MediaPlayerEntity] = [:]
     @Published var activeSpeakerID: EntityId?
+    /// Drives the speaker-picker sheet, opened from the screen-level speaker
+    /// button. The picker only replaces the screen content inline while no
+    /// speaker is active yet.
+    @Published var isShowingSpeakerPicker = false
     @Published var searchText = ""
     @Published var searchSections: [MusicSearchSection] = []
     @Published var hasSearched = false

--- a/IntelliNest/Views/Music/MusicView.swift
+++ b/IntelliNest/Views/Music/MusicView.swift
@@ -19,6 +19,9 @@ struct MusicView: View {
                 if !viewModel.isSpotifyAuthorized {
                     spotifyLoginTriangle
                 }
+                if viewModel.displayedActiveSpeaker != nil {
+                    speakerPickerButton
+                }
             }
 
             ScrollView {
@@ -53,6 +56,9 @@ struct MusicView: View {
         .sheet(isPresented: $viewModel.isShowingSearchResults) {
             MusicSearchResultsView(viewModel: viewModel)
         }
+        .sheet(isPresented: $viewModel.isShowingSpeakerPicker) {
+            SpeakerPickerSheet(viewModel: viewModel)
+        }
         .sheet(isPresented: $viewModel.isShowingQueue) {
             QueueView(viewModel: viewModel)
         }
@@ -79,6 +85,22 @@ struct MusicView: View {
         .sheet(isPresented: $isShowingSpotifyLogin) {
             SpotifyLoginPromptView(viewModel: viewModel)
         }
+    }
+
+    /// Opens the speaker picker. It sits at screen level rather than inside the
+    /// now-playing card: picking a speaker (or a new group leader) is a choice
+    /// about the whole screen, not an action on the speaker currently playing.
+    private var speakerPickerButton: some View {
+        Button {
+            viewModel.isShowingSpeakerPicker = true
+        } label: {
+            Image(systemName: "hifispeaker.2.fill")
+                .font(.title3)
+                .foregroundStyle(.white)
+                .frame(width: 36, height: 36)
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel("Byt högtalare")
     }
 
     /// A discrete warning triangle shown next to the search bar while logged out

--- a/IntelliNest/Views/Music/NowPlayingView.swift
+++ b/IntelliNest/Views/Music/NowPlayingView.swift
@@ -21,7 +21,7 @@ struct NowPlayingView: View {
                     .foregroundStyle(.yellow)
                     .lineLimit(1)
                 Spacer(minLength: 4)
-                // Each action gets a full 44×44 hit target so the three controls are
+                // Each action gets a full 44×44 hit target so the controls are
                 // comfortably tappable and evenly spaced.
                 HStack(spacing: 4) {
                     headerButton("quote.bubble",
@@ -31,9 +31,6 @@ struct NowPlayingView: View {
                     }
                     headerButton("list.bullet", label: "Visa kö") {
                         Task { await viewModel.openQueue() }
-                    }
-                    headerButton("hifispeaker.2.fill", label: "Byt högtalare") {
-                        viewModel.activeSpeakerID = nil
                     }
                 }
                 // Pull the row of icons to the card's edge so the 44pt hit targets
@@ -79,7 +76,7 @@ struct NowPlayingView: View {
     }
 
     /// A header action rendered with a full 44×44 hit target (Apple's minimum), so
-    /// the three now-playing controls are easy to tap and evenly spaced. `isActive`
+    /// the now-playing controls are easy to tap and evenly spaced. `isActive`
     /// tints the icon yellow to show a toggled-on state (used by the lyrics toggle).
     private func headerButton(_ systemName: String,
                               label: String,

--- a/IntelliNest/Views/Music/SpeakerPickerView.swift
+++ b/IntelliNest/Views/Music/SpeakerPickerView.swift
@@ -7,19 +7,30 @@
 
 import SwiftUI
 
-/// Shown when no speaker is active. Lists the available speakers so the user can
-/// pick one to control.
+/// Lists the available speakers so the user can pick one to control. Shown
+/// inline while no speaker is active, and inside `SpeakerPickerSheet` when the
+/// user changes speaker from an already-playing screen.
 struct SpeakerPickerView: View {
     @ObservedObject var viewModel: MusicViewModel
+    /// Called after a speaker is picked, so the sheet presentation can dismiss
+    /// itself. Inline presentation leaves it empty — the picker is replaced by
+    /// the now-playing card on its own.
+    var onSelect: MainActorVoidClosure = {}
+    /// The sheet presentation draws its own header, so it hides the inline one.
+    var showsTitle = true
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Välj högtalare")
-                .font(.headline)
+            if showsTitle {
+                Text("Välj högtalare")
+                    .font(.headline)
+            }
             ForEach(viewModel.availableSpeakers, id: \.entityId) { speaker in
+                let isActive = speaker.entityId == viewModel.activeSpeakerID
                 VStack(spacing: 8) {
                     Button {
                         viewModel.selectSpeaker(speaker.entityId)
+                        onSelect()
                     } label: {
                         HStack {
                             Image(systemName: "hifispeaker.fill")
@@ -35,7 +46,12 @@ struct SpeakerPickerView: View {
                                 .foregroundStyle(.white.opacity(0.5))
                         }
                     }
+                    // The speaker in control right now is tinted yellow, matching the
+                    // now-playing card, so "byt högtalare" starts from a visible
+                    // current selection instead of an undifferentiated list.
+                    .foregroundStyle(isActive ? .yellow : .white)
                     .accessibilityLabel("Välj \(speaker.friendlyName)")
+                    .accessibilityAddTraits(isActive ? [.isSelected] : [])
 
                     VolumeSliderView(volume: speaker.volumeLevel,
                                      onCommit: { viewModel.setVolume($0, for: speaker.entityId) })
@@ -45,10 +61,46 @@ struct SpeakerPickerView: View {
                 .padding(.horizontal, 12)
                 .background(Color.white.opacity(0.08))
                 .cornerRadius(10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.yellow.opacity(isActive ? 0.7 : 0), lineWidth: 2)
+                )
             }
         }
         .padding()
         .background(Color.white.opacity(0.05))
         .cornerRadius(16)
+    }
+}
+
+/// The speaker picker presented as a dismissable sheet. Used when a speaker is
+/// already active: the picker is a screen-level action, not part of the
+/// now-playing card, and closing it must return to the music screen rather than
+/// popping the whole navigation stack back home.
+struct SpeakerPickerSheet: View {
+    @ObservedObject var viewModel: MusicViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Välj högtalare")
+                    .font(.title3.bold())
+                Spacer()
+                Button("Stäng") { dismiss() }
+            }
+            .padding(.horizontal)
+            .padding(.top, 24)
+            .padding(.bottom, 12)
+
+            ScrollView {
+                SpeakerPickerView(viewModel: viewModel, onSelect: { dismiss() }, showsTitle: false)
+                    .padding(.horizontal)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .backgroundModifier()
+        .foregroundStyle(.white)
+        .presentationDragIndicator(.visible)
     }
 }


### PR DESCRIPTION
Picking a speaker used to clear `activeSpeakerID`, which swapped the whole music screen for the
inline speaker list. The screen's back button then popped the navigation stack all the way home
instead of returning to the music screen — there was no way back to what was playing.

The switch button also lived in the now-playing card's header, next to lyrics and queue, even
though choosing a speaker (or a new group leader) is a screen-level choice, not an action on the
speaker currently playing.

- Moved the speaker button to the screen header, next to the search bar. It shows only when a
  speaker is active — with none selected the picker is still the screen's inline content.
- The button now opens `SpeakerPickerSheet`: the same picker in a sheet with a "Stäng" button and
  a drag indicator. Picking a speaker dismisses it and the now-playing card updates behind.
- The active speaker is tinted yellow with a yellow border in the picker, matching the
  now-playing card, so "byt högtalare" starts from a visible current selection.

Verified on the simulator against live Home Assistant: switching Kitchen → Gästrummet from the
sheet, and "Stäng" returning to the music screen rather than home. Full test suite green,
SwiftFormat and SwiftLint `--strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JGYmQEyfCgp85MuwhWirS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a speaker picker for selecting and switching active speakers during music playback.
  * Added a dedicated speaker-picker sheet with scrolling, dismissal, and automatic closing after selection.
  * The currently selected speaker is visibly highlighted and announced for accessibility.
  * Added an accessible button to open the speaker picker when an active speaker is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->